### PR TITLE
Nebula netflix oss update

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@
  */
 
 plugins {
-    id 'nebula.netflixoss' version '8.8.1'
+    id 'nebula.netflixoss' version '8.9.0'
     id 'org.jetbrains.kotlin.jvm' version '1.3.70' apply false
 }
 


### PR DESCRIPTION
Update to nebula.netflixoss 8.9.0. Allows building the project on Apple silicon.