### PR TITLE
Several fixes for issues found while working with a large composed schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ graphql-dgs-codegen-core/out/
 
 graphql-dgs-codegen-core/compiled-sources/
 
+generated-examples

--- a/.run/CodeGenCliKt.run.xml
+++ b/.run/CodeGenCliKt.run.xml
@@ -1,0 +1,15 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="CodeGenCliKt" type="JetRunConfigurationType" nameIsGenerated="true">
+    <module name="graphql-dgs-codegen.graphql-dgs-codegen-core.main" />
+    <option name="VM_PARAMETERS" value="" />
+    <option name="PROGRAM_PARAMETERS" value="--package-name=tester.generated --include-query=acct_allCompanies --include-mutation=prdcl_importCrewContacts --output-dir=$PROJECT_DIR$/../generated-api-tester/src --generate-client --language=kotlin --skip-entities --type-mapping=BigDecimal=java.math.BigDecimal --type-mapping=Currency=java.util.Currency --type-mapping=BGTAccountNumber=java.lang.String --type-mapping=Url=java.lang.String --type-mapping=CountryCode=java.lang.String --type-mapping=BGTRevisionNumber=java.lang.String composed-schema.graphqls" />
+    <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="false" />
+    <option name="ALTERNATIVE_JRE_PATH" />
+    <option name="PASS_PARENT_ENVS" value="true" />
+    <option name="MAIN_CLASS_NAME" value="com.netflix.graphql.dgs.codegen.CodeGenCliKt" />
+    <option name="WORKING_DIRECTORY" value="" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@
 
 plugins {
     id 'nebula.netflixoss' version '8.9.0'
-    id 'org.jetbrains.kotlin.jvm' version '1.4.21' apply false
+    id 'org.jetbrains.kotlin.jvm' version '1.4.30' apply false
 }
 
 allprojects {

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@
 
 plugins {
     id 'nebula.netflixoss' version '8.9.0'
-    id 'org.jetbrains.kotlin.jvm' version '1.3.70' apply false
+    id 'org.jetbrains.kotlin.jvm' version '1.4.21' apply false
 }
 
 allprojects {

--- a/graphql-dgs-codegen-core/build.gradle
+++ b/graphql-dgs-codegen-core/build.gradle
@@ -43,12 +43,13 @@ dependencies {
         transitive = false
     }
     implementation "com.netflix.graphql.dgs:graphql-dgs-client:latest.release"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
     implementation "com.squareup:javapoet:1.13.+"
     implementation "com.squareup:kotlinpoet:1.7.+"
     implementation "com.graphql-java:graphql-java:14.0"
-    implementation("com.github.ajalt:clikt:2.3.0")
+    implementation("com.github.ajalt.clikt:clikt:3.1.0")
     implementation "com.fasterxml.jackson.core:jackson-annotations:2.11.+"
+    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:2.11.+"
+
 
     testImplementation "com.google.testing.compile:compile-testing:0.+"
     testImplementation "com.google.truth:truth:1.+"

--- a/graphql-dgs-codegen-core/build.gradle
+++ b/graphql-dgs-codegen-core/build.gradle
@@ -56,6 +56,7 @@ dependencies {
     testImplementation "org.assertj:assertj-core:3.11.+"
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.5.1")
+    testImplementation("org.junit.jupiter:junit-jupiter-params:5.5.1")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.5.1")
 }
 

--- a/graphql-dgs-codegen-core/dependencies.lock
+++ b/graphql-dgs-codegen-core/dependencies.lock
@@ -1,7 +1,7 @@
 {
     "apiDependenciesMetadata": {
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
-            "locked": "1.4.21"
+            "locked": "1.4.30"
         }
     },
     "compileClasspath": {
@@ -18,10 +18,10 @@
             "locked": "14.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
-            "locked": "3.1.2"
+            "locked": "3.3.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs-client": {
-            "locked": "3.1.2"
+            "locked": "3.3.0"
         },
         "com.squareup:javapoet": {
             "locked": "1.13.0"
@@ -30,7 +30,7 @@
             "locked": "1.7.2"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
-            "locked": "1.4.21"
+            "locked": "1.4.30"
         }
     },
     "implementationDependenciesMetadata": {
@@ -47,10 +47,10 @@
             "locked": "14.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
-            "locked": "3.1.2"
+            "locked": "3.3.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs-client": {
-            "locked": "3.1.2"
+            "locked": "3.3.0"
         },
         "com.squareup:javapoet": {
             "locked": "1.13.0"
@@ -59,22 +59,22 @@
             "locked": "1.7.2"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
-            "locked": "1.4.21"
+            "locked": "1.4.30"
         }
     },
     "kotlinCompilerClasspath": {
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
-            "locked": "1.4.21"
+            "locked": "1.4.30"
         }
     },
     "kotlinCompilerPluginClasspath": {
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
-            "locked": "1.4.21"
+            "locked": "1.4.30"
         }
     },
     "kotlinKlibCommonizerClasspath": {
         "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable": {
-            "locked": "1.4.21"
+            "locked": "1.4.30"
         }
     },
     "runtimeClasspath": {
@@ -91,10 +91,10 @@
             "locked": "14.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
-            "locked": "3.1.2"
+            "locked": "3.3.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs-client": {
-            "locked": "3.1.2"
+            "locked": "3.3.0"
         },
         "com.squareup:javapoet": {
             "locked": "1.13.0"
@@ -103,7 +103,7 @@
             "locked": "1.7.2"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
-            "locked": "1.4.21"
+            "locked": "1.4.30"
         }
     },
     "testCompileClasspath": {
@@ -126,10 +126,10 @@
             "locked": "14.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
-            "locked": "3.1.2"
+            "locked": "3.3.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs-client": {
-            "locked": "3.1.2"
+            "locked": "3.3.0"
         },
         "com.squareup:javapoet": {
             "locked": "1.13.0"
@@ -141,9 +141,12 @@
             "locked": "3.11.1"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
-            "locked": "1.4.21"
+            "locked": "1.4.30"
         },
         "org.junit.jupiter:junit-jupiter-api": {
+            "locked": "5.5.1"
+        },
+        "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.5.1"
         }
     },
@@ -167,10 +170,10 @@
             "locked": "14.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
-            "locked": "3.1.2"
+            "locked": "3.3.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs-client": {
-            "locked": "3.1.2"
+            "locked": "3.3.0"
         },
         "com.squareup:javapoet": {
             "locked": "1.13.0"
@@ -182,9 +185,12 @@
             "locked": "3.11.1"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
-            "locked": "1.4.21"
+            "locked": "1.4.30"
         },
         "org.junit.jupiter:junit-jupiter-api": {
+            "locked": "5.5.1"
+        },
+        "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.5.1"
         }
     },
@@ -208,10 +214,10 @@
             "locked": "14.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
-            "locked": "3.1.2"
+            "locked": "3.3.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs-client": {
-            "locked": "3.1.2"
+            "locked": "3.3.0"
         },
         "com.squareup:javapoet": {
             "locked": "1.13.0"
@@ -223,12 +229,15 @@
             "locked": "3.11.1"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
-            "locked": "1.4.21"
+            "locked": "1.4.30"
         },
         "org.junit.jupiter:junit-jupiter-api": {
             "locked": "5.5.1"
         },
         "org.junit.jupiter:junit-jupiter-engine": {
+            "locked": "5.5.1"
+        },
+        "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.5.1"
         }
     },

--- a/graphql-dgs-codegen-core/dependencies.lock
+++ b/graphql-dgs-codegen-core/dependencies.lock
@@ -1,275 +1,240 @@
 {
+    "apiDependenciesMetadata": {
+        "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
+            "locked": "1.4.21"
+        }
+    },
     "compileClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.11.3",
-            "requested": "2.11.+"
+            "locked": "2.11.4"
         },
-        "com.github.ajalt:clikt": {
-            "locked": "2.3.0",
-            "requested": "2.3.0"
+        "com.fasterxml.jackson.module:jackson-module-kotlin": {
+            "locked": "2.11.4"
+        },
+        "com.github.ajalt.clikt:clikt": {
+            "locked": "3.1.0"
         },
         "com.graphql-java:graphql-java": {
-            "locked": "14.0",
-            "requested": "14.0"
+            "locked": "14.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
-            "locked": "3.0.10",
-            "requested": "latest.release"
+            "locked": "3.1.2"
         },
         "com.netflix.graphql.dgs:graphql-dgs-client": {
-            "locked": "3.0.10",
-            "requested": "latest.release"
+            "locked": "3.1.2"
         },
         "com.squareup:javapoet": {
-            "locked": "1.13.0",
-            "requested": "1.13.+"
+            "locked": "1.13.0"
         },
         "com.squareup:kotlinpoet": {
-            "locked": "1.7.2",
-            "requested": "1.7.+"
+            "locked": "1.7.2"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
-            "locked": "1.4.10",
-            "requested": "1.3.70"
+            "locked": "1.4.21"
         }
     },
     "implementationDependenciesMetadata": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.11.3",
-            "requested": "2.11.+"
+            "locked": "2.11.4"
         },
-        "com.github.ajalt:clikt": {
-            "locked": "2.3.0",
-            "requested": "2.3.0"
+        "com.fasterxml.jackson.module:jackson-module-kotlin": {
+            "locked": "2.11.4"
+        },
+        "com.github.ajalt.clikt:clikt": {
+            "locked": "3.1.0"
         },
         "com.graphql-java:graphql-java": {
-            "locked": "14.0",
-            "requested": "14.0"
+            "locked": "14.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
-            "locked": "3.0.10",
-            "requested": "latest.release"
+            "locked": "3.1.2"
         },
         "com.netflix.graphql.dgs:graphql-dgs-client": {
-            "locked": "3.0.10",
-            "requested": "latest.release"
+            "locked": "3.1.2"
         },
         "com.squareup:javapoet": {
-            "locked": "1.13.0",
-            "requested": "1.13.+"
+            "locked": "1.13.0"
         },
         "com.squareup:kotlinpoet": {
-            "locked": "1.7.2",
-            "requested": "1.7.+"
+            "locked": "1.7.2"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
-            "locked": "1.4.10",
-            "requested": "1.3.70"
+            "locked": "1.4.21"
         }
     },
     "kotlinCompilerClasspath": {
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
-            "locked": "1.3.70"
+            "locked": "1.4.21"
         }
     },
     "kotlinCompilerPluginClasspath": {
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
-            "locked": "1.3.70",
-            "requested": "1.3.70"
+            "locked": "1.4.21"
+        }
+    },
+    "kotlinKlibCommonizerClasspath": {
+        "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable": {
+            "locked": "1.4.21"
         }
     },
     "runtimeClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.11.3",
-            "requested": "2.11.+"
+            "locked": "2.11.4"
         },
-        "com.github.ajalt:clikt": {
-            "locked": "2.3.0",
-            "requested": "2.3.0"
+        "com.fasterxml.jackson.module:jackson-module-kotlin": {
+            "locked": "2.11.4"
+        },
+        "com.github.ajalt.clikt:clikt": {
+            "locked": "3.1.0"
         },
         "com.graphql-java:graphql-java": {
-            "locked": "14.0",
-            "requested": "14.0"
+            "locked": "14.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
-            "locked": "3.0.10",
-            "requested": "latest.release"
+            "locked": "3.1.2"
         },
         "com.netflix.graphql.dgs:graphql-dgs-client": {
-            "locked": "3.0.10",
-            "requested": "latest.release"
+            "locked": "3.1.2"
         },
         "com.squareup:javapoet": {
-            "locked": "1.13.0",
-            "requested": "1.13.+"
+            "locked": "1.13.0"
         },
         "com.squareup:kotlinpoet": {
-            "locked": "1.7.2",
-            "requested": "1.7.+"
+            "locked": "1.7.2"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
-            "locked": "1.4.10",
-            "requested": "1.3.70"
+            "locked": "1.4.21"
         }
     },
     "testCompileClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.11.3",
-            "requested": "2.11.+"
+            "locked": "2.11.4"
         },
-        "com.github.ajalt:clikt": {
-            "locked": "2.3.0",
-            "requested": "2.3.0"
+        "com.fasterxml.jackson.module:jackson-module-kotlin": {
+            "locked": "2.11.4"
+        },
+        "com.github.ajalt.clikt:clikt": {
+            "locked": "3.1.0"
         },
         "com.google.testing.compile:compile-testing": {
-            "locked": "0.19",
-            "requested": "0.+"
+            "locked": "0.19"
         },
         "com.google.truth:truth": {
-            "locked": "1.1",
-            "requested": "1.+"
+            "locked": "1.1.2"
         },
         "com.graphql-java:graphql-java": {
-            "locked": "14.0",
-            "requested": "14.0"
+            "locked": "14.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
-            "locked": "3.0.10",
-            "requested": "latest.release"
+            "locked": "3.1.2"
         },
         "com.netflix.graphql.dgs:graphql-dgs-client": {
-            "locked": "3.0.10",
-            "requested": "latest.release"
+            "locked": "3.1.2"
         },
         "com.squareup:javapoet": {
-            "locked": "1.13.0",
-            "requested": "1.13.+"
+            "locked": "1.13.0"
         },
         "com.squareup:kotlinpoet": {
-            "locked": "1.7.2",
-            "requested": "1.7.+"
+            "locked": "1.7.2"
         },
         "org.assertj:assertj-core": {
-            "locked": "3.11.1",
-            "requested": "3.11.+"
+            "locked": "3.11.1"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
-            "locked": "1.4.10",
-            "requested": "1.3.70"
+            "locked": "1.4.21"
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.5.1",
-            "requested": "5.5.1"
+            "locked": "5.5.1"
         }
     },
     "testImplementationDependenciesMetadata": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.11.3",
-            "requested": "2.11.+"
+            "locked": "2.11.4"
         },
-        "com.github.ajalt:clikt": {
-            "locked": "2.3.0",
-            "requested": "2.3.0"
+        "com.fasterxml.jackson.module:jackson-module-kotlin": {
+            "locked": "2.11.4"
+        },
+        "com.github.ajalt.clikt:clikt": {
+            "locked": "3.1.0"
         },
         "com.google.testing.compile:compile-testing": {
-            "locked": "0.19",
-            "requested": "0.+"
+            "locked": "0.19"
         },
         "com.google.truth:truth": {
-            "locked": "1.1",
-            "requested": "1.+"
+            "locked": "1.1.2"
         },
         "com.graphql-java:graphql-java": {
-            "locked": "14.0",
-            "requested": "14.0"
+            "locked": "14.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
-            "locked": "3.0.10",
-            "requested": "latest.release"
+            "locked": "3.1.2"
         },
         "com.netflix.graphql.dgs:graphql-dgs-client": {
-            "locked": "3.0.10",
-            "requested": "latest.release"
+            "locked": "3.1.2"
         },
         "com.squareup:javapoet": {
-            "locked": "1.13.0",
-            "requested": "1.13.+"
+            "locked": "1.13.0"
         },
         "com.squareup:kotlinpoet": {
-            "locked": "1.7.2",
-            "requested": "1.7.+"
+            "locked": "1.7.2"
         },
         "org.assertj:assertj-core": {
-            "locked": "3.11.1",
-            "requested": "3.11.+"
+            "locked": "3.11.1"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
-            "locked": "1.4.10",
-            "requested": "1.3.70"
+            "locked": "1.4.21"
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.5.1",
-            "requested": "5.5.1"
+            "locked": "5.5.1"
         }
     },
     "testRuntimeClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.11.3",
-            "requested": "2.11.+"
+            "locked": "2.11.4"
         },
-        "com.github.ajalt:clikt": {
-            "locked": "2.3.0",
-            "requested": "2.3.0"
+        "com.fasterxml.jackson.module:jackson-module-kotlin": {
+            "locked": "2.11.4"
+        },
+        "com.github.ajalt.clikt:clikt": {
+            "locked": "3.1.0"
         },
         "com.google.testing.compile:compile-testing": {
-            "locked": "0.19",
-            "requested": "0.+"
+            "locked": "0.19"
         },
         "com.google.truth:truth": {
-            "locked": "1.1",
-            "requested": "1.+"
+            "locked": "1.1.2"
         },
         "com.graphql-java:graphql-java": {
-            "locked": "14.0",
-            "requested": "14.0"
+            "locked": "14.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
-            "locked": "3.0.10",
-            "requested": "latest.release"
+            "locked": "3.1.2"
         },
         "com.netflix.graphql.dgs:graphql-dgs-client": {
-            "locked": "3.0.10",
-            "requested": "latest.release"
+            "locked": "3.1.2"
         },
         "com.squareup:javapoet": {
-            "locked": "1.13.0",
-            "requested": "1.13.+"
+            "locked": "1.13.0"
         },
         "com.squareup:kotlinpoet": {
-            "locked": "1.7.2",
-            "requested": "1.7.+"
+            "locked": "1.7.2"
         },
         "org.assertj:assertj-core": {
-            "locked": "3.11.1",
-            "requested": "3.11.+"
+            "locked": "3.11.1"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
-            "locked": "1.4.10",
-            "requested": "1.3.70"
+            "locked": "1.4.21"
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.5.1",
-            "requested": "5.5.1"
+            "locked": "5.5.1"
         },
         "org.junit.jupiter:junit-jupiter-engine": {
-            "locked": "5.5.1",
-            "requested": "5.5.1"
+            "locked": "5.5.1"
         }
     },
     "testRuntimeOnlyDependenciesMetadata": {
         "org.junit.jupiter:junit-jupiter-engine": {
-            "locked": "5.5.1",
-            "requested": "5.5.1"
+            "locked": "5.5.1"
         }
     }
 }

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
@@ -245,7 +245,9 @@ data class CodeGenConfig(
         val typeMapping: Map<String, String> = emptyMap(),
         val includeQueries: Set<String> = emptySet(),
         val includeMutations: Set<String> = emptySet(),
-        val skipEntityQueries: Boolean = false
+        val skipEntityQueries: Boolean = false,
+        val shortProjectionNames: Boolean = false,
+
 )
 
 enum class Language {

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
@@ -287,6 +287,30 @@ fun List<FieldDefinition>.filterSkipped(): List<FieldDefinition> {
     return this.filter { it.directives.none { d -> d.name == "skipcodegen" } }
 }
 
+fun List<FieldDefinition>.filterIncludedInConfig(definitionName: String, config: CodeGenConfig): List<FieldDefinition> {
+    return when (definitionName) {
+        "Query" -> {
+            if(config.includeQueries.isNullOrEmpty()) {
+                this
+            } else {
+                this.filter {
+                    config.includeQueries.contains(it.name)
+                }
+            }
+        }
+        "Mutation" -> {
+            if(config.includeMutations.isNullOrEmpty()) {
+                this
+            } else {
+                this.filter {
+                    config.includeMutations.contains(it.name)
+                }
+            }
+        }
+        else -> this
+    }
+}
+
 fun ObjectTypeDefinition.shouldSkip(): Boolean {
     return this.directives.any { it.name == "skipcodegen" }
 }

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
@@ -50,7 +50,11 @@ class CodeGen(private val config: CodeGenConfig) {
                 codeGenResult.enumTypes.forEach { it.writeTo(config.outputDir) }
                 codeGenResult.dataFetchers.forEach { it.writeTo(config.examplesOutputDir) }
                 codeGenResult.queryTypes.forEach { it.writeTo(config.outputDir) }
-                codeGenResult.clientProjections.forEach { it.writeTo(config.outputDir) }
+                codeGenResult.clientProjections.forEach { try {
+                    it.writeTo(config.outputDir)
+                } catch (ex: Exception) {
+                    println(ex.message)
+                } }
                 codeGenResult.constants.forEach { it.writeTo(config.outputDir) }
             }
 
@@ -238,7 +242,11 @@ data class CodeGenConfig(
         val packageName: String = "com.netflix.${Paths.get("").toAbsolutePath().fileName}.generated",
         val language: Language = Language.JAVA,
         val generateClientApi: Boolean = false,
-        val typeMapping: Map<String, String> = emptyMap())
+        val typeMapping: Map<String, String> = emptyMap(),
+        val includeQueries: Set<String> = emptySet(),
+        val includeMutations: Set<String> = emptySet(),
+        val skipEntityQueries: Boolean = false
+)
 
 enum class Language {
     JAVA,

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGenCli.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGenCli.kt
@@ -40,7 +40,8 @@ class CodeGenCli : CliktCommand("Generate Java sources for SCHEMA file(s)") {
     private val includeQueries by option("--include-query").multiple().unique()
     private val includeMutations by option("--include-mutation").multiple().unique()
     private val skipEntityQueries by option("--skip-entities").flag()
-    val typeMapping: Map<String, String> by option("--type-mapping").associate()
+    private val typeMapping: Map<String, String> by option("--type-mapping").associate()
+    private val shortProjectionNames by option("--short-projection-names").flag()
 
 
     override fun run() {
@@ -58,9 +59,9 @@ class CodeGenCli : CliktCommand("Generate Java sources for SCHEMA file(s)") {
 
         val generate = CodeGen(
                 if(packageName != null) {
-                    CodeGenConfig(schemaFiles = inputSchemas, writeToFiles = writeFiles, outputDir = output.toPath(), packageName = packageName!!, language = Language.valueOf(language.toUpperCase()), generateClientApi = generateClient, includeQueries = includeQueries, includeMutations = includeMutations, skipEntityQueries = skipEntityQueries, typeMapping = typeMapping)
+                    CodeGenConfig(schemaFiles = inputSchemas, writeToFiles = writeFiles, outputDir = output.toPath(), packageName = packageName!!, language = Language.valueOf(language.toUpperCase()), generateClientApi = generateClient, includeQueries = includeQueries, includeMutations = includeMutations, skipEntityQueries = skipEntityQueries, typeMapping = typeMapping, shortProjectionNames = shortProjectionNames)
                 } else {
-                    CodeGenConfig(schemaFiles = inputSchemas, writeToFiles = writeFiles, outputDir = output.toPath(), language = Language.valueOf(language.toUpperCase()), generateClientApi = generateClient, includeQueries = includeQueries, includeMutations = includeMutations, skipEntityQueries = skipEntityQueries, typeMapping = typeMapping)
+                    CodeGenConfig(schemaFiles = inputSchemas, writeToFiles = writeFiles, outputDir = output.toPath(), language = Language.valueOf(language.toUpperCase()), generateClientApi = generateClient, includeQueries = includeQueries, includeMutations = includeMutations, skipEntityQueries = skipEntityQueries, typeMapping = typeMapping, shortProjectionNames = shortProjectionNames)
                 }
         ).generate()
 

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGenCli.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGenCli.kt
@@ -22,9 +22,7 @@ import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.UsageError
 import com.github.ajalt.clikt.parameters.arguments.argument
 import com.github.ajalt.clikt.parameters.arguments.multiple
-import com.github.ajalt.clikt.parameters.options.default
-import com.github.ajalt.clikt.parameters.options.flag
-import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.options.*
 import com.github.ajalt.clikt.parameters.types.choice
 import com.github.ajalt.clikt.parameters.types.file
 import java.io.File
@@ -33,12 +31,17 @@ import java.nio.file.Paths
 @ExperimentalStdlibApi
 class CodeGenCli : CliktCommand("Generate Java sources for SCHEMA file(s)") {
 
-    private val schemas by argument().file(exists = true).multiple()
-    private val output by option("--output-dir", "-o", help = "Output directory").file(fileOkay = false, folderOkay = true).default(File("generated"))
+    private val schemas by argument().file(mustExist = true).multiple()
+    private val output by option("--output-dir", "-o", help = "Output directory").file(canBeFile = false, canBeDir = true).default(File("generated"))
     private val packageName by option("--package-name", "-p", help = "Package name for generated types")
     private val writeFiles by option("--write-to-disk", "-w", help = "Write files to disk").flag("--console-output", default = true)
     private val language by option("--language", "-l", help = "Output language").choice("java", "kotlin").default("java")
     private val generateClient by option("--generate-client", "-c", help = "Genereate client api").flag(default = false)
+    private val includeQueries by option("--include-query").multiple().unique()
+    private val includeMutations by option("--include-mutation").multiple().unique()
+    private val skipEntityQueries by option("--skip-entities").flag()
+    val typeMapping: Map<String, String> by option("--type-mapping").associate()
+
 
     override fun run() {
         val inputSchemas = if(schemas.isEmpty()) {
@@ -55,9 +58,9 @@ class CodeGenCli : CliktCommand("Generate Java sources for SCHEMA file(s)") {
 
         val generate = CodeGen(
                 if(packageName != null) {
-                    CodeGenConfig(schemaFiles = inputSchemas, writeToFiles = writeFiles, outputDir = output.toPath(), packageName = packageName!!, language = Language.valueOf(language.toUpperCase()), generateClientApi = generateClient)
+                    CodeGenConfig(schemaFiles = inputSchemas, writeToFiles = writeFiles, outputDir = output.toPath(), packageName = packageName!!, language = Language.valueOf(language.toUpperCase()), generateClientApi = generateClient, includeQueries = includeQueries, includeMutations = includeMutations, skipEntityQueries = skipEntityQueries, typeMapping = typeMapping)
                 } else {
-                    CodeGenConfig(schemaFiles = inputSchemas, writeToFiles = writeFiles, outputDir = output.toPath(), language = Language.valueOf(language.toUpperCase()), generateClientApi = generateClient)
+                    CodeGenConfig(schemaFiles = inputSchemas, writeToFiles = writeFiles, outputDir = output.toPath(), language = Language.valueOf(language.toUpperCase()), generateClientApi = generateClient, includeQueries = includeQueries, includeMutations = includeMutations, skipEntityQueries = skipEntityQueries, typeMapping = typeMapping)
                 }
         ).generate()
 

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ClassnameShortener.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ClassnameShortener.kt
@@ -1,0 +1,38 @@
+/*
+ *
+ *  Copyright 2020 Netflix, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package com.netflix.graphql.dgs.codegen.generators.java
+
+class ClassnameShortener {
+    companion object {
+        /**
+         * Takes a class name, and shortens it by taking each upper case letter, and the first following lower case letter.
+         * Example: ThisIsATest becomes ThIsATe
+         * This is required to prevent extremely long class/file names for projections.
+         */
+        fun shorten(name: String): String {
+            val sb = StringBuilder()
+
+            val split = name.split(Regex("(?=[A-Z])"))
+            split.filter { it.isNotEmpty() }.forEach {
+                sb.append(it.substring(0, if(it.length > 1) 2 else 1))
+            }
+            return sb.toString()
+        }
+    }
+}

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ClientApiGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ClientApiGenerator.kt
@@ -351,9 +351,7 @@ class ClientApiGenerator(private val config: CodeGenConfig, private val document
     }
 
     private fun truncatePrefix(prefix: String): String {
-
-
-        return prefix.filter { it.isUpperCase() }
+        return if(config.shortProjectionNames) prefix.filter { it.isUpperCase() } else prefix
     }
 
     fun processSchemaTypes(key: Pair<String, String>): Boolean {

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ClientApiGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ClientApiGenerator.kt
@@ -32,7 +32,7 @@ class ClientApiGenerator(private val config: CodeGenConfig, private val document
     private val processedSchemaTypes = mutableMapOf<Pair<String, String>, Int>()
 
     fun generate(definition: ObjectTypeDefinition): CodeGenResult {
-        return definition.fieldDefinitions.filterSkipped().map {
+        return definition.fieldDefinitions.filterSkipped().filter(isIncludedInConfig(definition)).map {
             val javaFile = createQueryClass(it, definition.name)
 
             val rootProjection = it.type.findTypeDefinition(document, true)?.let { typeDefinition -> createRootProjection(typeDefinition, it.name.capitalize()) } ?: CodeGenResult()
@@ -40,7 +40,17 @@ class ClientApiGenerator(private val config: CodeGenConfig, private val document
         }.fold(CodeGenResult()) { total, current -> total.merge(current) }
     }
 
+    private fun isIncludedInConfig(definition: ObjectTypeDefinition): (FieldDefinition) -> Boolean =
+        {
+            ((definition.name == "Query" && (config.includeQueries.isEmpty() || config.includeQueries.contains(it.name))) ||
+            (definition.name == "Mutation" && (config.includeMutations.isEmpty() || config.includeMutations.contains(it.name))))
+        }
+
     fun generateEntities(definitions: List<ObjectTypeDefinition>): CodeGenResult {
+            if(config.skipEntityQueries) {
+                return CodeGenResult()
+            }
+
             var entitiesRootProjection = CodeGenResult()
             // generate for federation types, if present
             val federatedTypes = definitions.filter { it.getDirective("key") != null }
@@ -69,7 +79,7 @@ class ClientApiGenerator(private val config: CodeGenConfig, private val document
                         .addModifiers(Modifier.PUBLIC)
                         .returns(ClassName.get("", "${it.name.capitalize()}GraphQLQuery"))
                         .addCode("""
-                                     return new ${it.name.capitalize()}GraphQLQuery(${it.inputValueDefinitions.joinToString(", ") { it.name }});
+                                     return new ${it.name.capitalize()}GraphQLQuery(${it.inputValueDefinitions.joinToString(", ") { ReservedKeywordSanitizer.sanitize(it.name) }});
                                      
                                 """.trimIndent())
                         .build())
@@ -84,19 +94,19 @@ class ClientApiGenerator(private val config: CodeGenConfig, private val document
         it.inputValueDefinitions.forEach { inputValue ->
             val findReturnType = TypeUtils(getDatatypesPackageName(), config).findReturnType(inputValue.type)
             builderClass
-                    .addMethod(MethodSpec.methodBuilder(inputValue.name)
-                            .addParameter(findReturnType, inputValue.name)
+                    .addMethod(MethodSpec.methodBuilder(ReservedKeywordSanitizer.sanitize(inputValue.name))
+                            .addParameter(findReturnType, ReservedKeywordSanitizer.sanitize(inputValue.name))
                             .returns(ClassName.get("", "Builder"))
                             .addModifiers(Modifier.PUBLIC)
                             .addCode("""
-                                this.${inputValue.name} = ${inputValue.name};
+                                this.${ReservedKeywordSanitizer.sanitize(inputValue.name)} = ${ReservedKeywordSanitizer.sanitize(inputValue.name)};
                                 return this;
                             """.trimIndent()).build())
-                    .addField(findReturnType, inputValue.name, Modifier.PRIVATE)
+                    .addField(findReturnType, ReservedKeywordSanitizer.sanitize(inputValue.name), Modifier.PRIVATE)
 
-            constructorBuilder.addParameter(findReturnType, inputValue.name)
+            constructorBuilder.addParameter(findReturnType, ReservedKeywordSanitizer.sanitize(inputValue.name))
             constructorBuilder.addCode("""
-                getInput().put("${inputValue.name}", ${inputValue.name});
+                getInput().put("${inputValue.name}", ${ReservedKeywordSanitizer.sanitize(inputValue.name)});
                 
             """.trimIndent())
         }
@@ -305,7 +315,7 @@ class ClientApiGenerator(private val config: CodeGenConfig, private val document
                     ! processSchemaTypes(key)
                 }
                 .map {
-                    val projectionName = "${prefix}${it.first.name.capitalize()}Projection"
+                    val projectionName = "${truncatePrefix(prefix)}${it.first.name.capitalize()}Projection"
                     javaType.addMethod(MethodSpec.methodBuilder(it.first.name)
                             .returns(ClassName.get(getPackageName(), projectionName))
                             .addCode("""
@@ -315,7 +325,7 @@ class ClientApiGenerator(private val config: CodeGenConfig, private val document
                     """.trimIndent())
                             .addModifiers(Modifier.PUBLIC)
                             .build())
-                    createSubProjection(it.second!!, javaType.build(), root, "${prefix}${it.first.name.capitalize()}")
+                    createSubProjection(it.second!!, javaType.build(), root, "${truncatePrefix(prefix)}${it.first.name.capitalize()}")
                 }.fold(CodeGenResult()) { total, current -> total.merge(current) }
 
 
@@ -323,7 +333,7 @@ class ClientApiGenerator(private val config: CodeGenConfig, private val document
                 .forEach {
                     val objectTypeDefinition = it.type.findTypeDefinition(document)
                     if (objectTypeDefinition == null) {
-                        javaType.addMethod(MethodSpec.methodBuilder(it.name)
+                        javaType.addMethod(MethodSpec.methodBuilder(ReservedKeywordSanitizer.sanitize(it.name))
                                 .returns(ClassName.get(getPackageName(), javaType.build().name))
                                 .addCode("""
                         getFields().put("${it.name}", null);
@@ -338,6 +348,12 @@ class ClientApiGenerator(private val config: CodeGenConfig, private val document
         val unionTypesResult = createUnionTypes(type, javaType, root, prefix)
 
         return Pair(javaType, codeGenResult.merge(concreteTypesResult).merge(unionTypesResult))
+    }
+
+    private fun truncatePrefix(prefix: String): String {
+
+
+        return prefix.filter { it.isUpperCase() }
     }
 
     fun processSchemaTypes(key: Pair<String, String>): Boolean {

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ClientApiGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ClientApiGenerator.kt
@@ -351,7 +351,7 @@ class ClientApiGenerator(private val config: CodeGenConfig, private val document
     }
 
     private fun truncatePrefix(prefix: String): String {
-        return if(config.shortProjectionNames) prefix.filter { it.isUpperCase() } else prefix
+        return if(config.shortProjectionNames) ClassnameShortener.shorten(prefix) else prefix
     }
 
     fun processSchemaTypes(key: Pair<String, String>): Boolean {

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ClientApiGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ClientApiGenerator.kt
@@ -140,7 +140,7 @@ class ClientApiGenerator(private val config: CodeGenConfig, private val document
                 .filter { ! processSchemaTypes(Pair(it.second!!.name, type.name)) }
                 .map {
                     val projectionName = "${prefix}${it.first.name.capitalize()}Projection"
-                    javaType.addMethod(MethodSpec.methodBuilder(it.first.name)
+                    javaType.addMethod(MethodSpec.methodBuilder(ReservedKeywordSanitizer.sanitize(it.first.name))
                             .returns(ClassName.get(getPackageName(), projectionName))
                             .addCode("""
                         $projectionName projection = new $projectionName(this, this);    
@@ -157,7 +157,7 @@ class ClientApiGenerator(private val config: CodeGenConfig, private val document
 
             val objectTypeDefinition = it.type.findTypeDefinition(document)
             if (objectTypeDefinition == null) {
-                javaType.addMethod(MethodSpec.methodBuilder(it.name)
+                javaType.addMethod(MethodSpec.methodBuilder(ReservedKeywordSanitizer.sanitize(it.name))
                         .returns(ClassName.get(getPackageName(), javaType.build().name))
                         .addCode("""
                         getFields().put("${it.name}", null);

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ConstantsGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ConstantsGenerator.kt
@@ -98,7 +98,7 @@ class ConstantsGenerator(private val config: CodeGenConfig, private val document
     }
 
     private fun addFieldNameConstant(constantsType: TypeSpec.Builder, fieldName: String) {
-        constantsType.addField(FieldSpec.builder(TypeName.get(String::class.java), fieldName.capitalize()).addModifiers(Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL).initializer(""""$fieldName"""").build())
+        constantsType.addField(FieldSpec.builder(TypeName.get(String::class.java), ReservedKeywordSanitizer.sanitize(fieldName.capitalize())).addModifiers(Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL).initializer(""""$fieldName"""").build())
     }
 
     private fun findExtensions(name: String, definitions: List<Definition<Definition<*>>>) =

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/DataTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/DataTypeGenerator.kt
@@ -168,7 +168,7 @@ abstract class BaseDataTypeGenerator(internal val packageName: String, config: C
         val toStringBody = StringBuilder("return \"${javaType.build().name}{\" + ")
         fieldDefinitions.forEachIndexed { index, field ->
             toStringBody.append("""
-                "${field.name}='" + ${field.name} + "'${if (index < fieldDefinitions.size - 1) "," else ""}" +
+                "${field.name}='" + ${ReservedKeywordSanitizer.sanitize(field.name)} + "'${if (index < fieldDefinitions.size - 1) "," else ""}" +
             """.trimIndent())
         }
 
@@ -259,9 +259,9 @@ abstract class BaseDataTypeGenerator(internal val packageName: String, config: C
         val constructorBuilder = MethodSpec.constructorBuilder()
         fieldDefinitions.forEach {
             constructorBuilder
-                    .addParameter(it.type, it.name)
+                    .addParameter(it.type, ReservedKeywordSanitizer.sanitize(it.name))
                     .addModifiers(Modifier.PUBLIC)
-                    .addStatement("this.\$N = \$N", it.name, it.name)
+                    .addStatement("this.\$N = \$N", ReservedKeywordSanitizer.sanitize(it.name), ReservedKeywordSanitizer.sanitize(it.name))
         }
 
         javaType.addMethod(constructorBuilder.build())
@@ -291,15 +291,15 @@ abstract class BaseDataTypeGenerator(internal val packageName: String, config: C
                 .build()
             javaType.addField(field)
         } else {
-            val field = FieldSpec.builder(returnType, fieldDefinition.name).addModifiers(Modifier.PRIVATE).build()
+            val field = FieldSpec.builder(returnType, ReservedKeywordSanitizer.sanitize(fieldDefinition.name)).addModifiers(Modifier.PRIVATE).build()
             javaType.addField(field)
         }
 
         val getterName = "get${fieldDefinition.name[0].toUpperCase()}${fieldDefinition.name.substring(1)}"
-        javaType.addMethod(MethodSpec.methodBuilder(getterName).addModifiers(Modifier.PUBLIC).returns(returnType).addStatement("return \$N", fieldDefinition.name).build())
+        javaType.addMethod(MethodSpec.methodBuilder(getterName).addModifiers(Modifier.PUBLIC).returns(returnType).addStatement("return \$N", ReservedKeywordSanitizer.sanitize(fieldDefinition.name)).build())
 
         val setterName = "set${fieldDefinition.name[0].toUpperCase()}${fieldDefinition.name.substring(1)}"
-        javaType.addMethod(MethodSpec.methodBuilder(setterName).addModifiers(Modifier.PUBLIC).addParameter(returnType, fieldDefinition.name).addStatement("this.\$N = \$N", fieldDefinition.name, fieldDefinition.name).build())
+        javaType.addMethod(MethodSpec.methodBuilder(setterName).addModifiers(Modifier.PUBLIC).addParameter(returnType, ReservedKeywordSanitizer.sanitize(fieldDefinition.name)).addStatement("this.\$N = \$N", ReservedKeywordSanitizer.sanitize(fieldDefinition.name), ReservedKeywordSanitizer.sanitize(fieldDefinition.name)).build())
     }
 
     private fun addBuilder(javaType: TypeSpec.Builder) {

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/EntitiesRepresentationTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/EntitiesRepresentationTypeGenerator.kt
@@ -25,8 +25,12 @@ import graphql.language.*
 
 
 @Suppress("UNCHECKED_CAST")
-class EntitiesRepresentationTypeGenerator(config: CodeGenConfig): BaseDataTypeGenerator(config.packageName + ".client", config) {
+class EntitiesRepresentationTypeGenerator(val config: CodeGenConfig): BaseDataTypeGenerator(config.packageName + ".client", config) {
     fun generate(definition: ObjectTypeDefinition, document: Document, generatedRepresentations: MutableMap<String, Any>): CodeGenResult {
+        if(config.skipEntityQueries) {
+            return CodeGenResult()
+        }
+
         val name = "${definition.name}Representation"
         if (generatedRepresentations.containsKey(name)) {
             return CodeGenResult()

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ReservedKeywordSanitizer.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ReservedKeywordSanitizer.kt
@@ -1,0 +1,39 @@
+/*
+ *
+ *  Copyright 2020 Netflix, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package com.netflix.graphql.dgs.codegen.generators.java
+
+class ReservedKeywordSanitizer {
+
+    companion object {
+        private val reservedKeywords = setOf("import", "_")
+        private const val prefix = "_"
+
+        fun sanitize(originalName: String): String {
+            return if (reservedKeywords.contains(originalName)) {
+                "$prefix$originalName"
+            } else {
+                originalName
+            }
+        }
+
+        fun removePrefix(name: String): String {
+            return name.removePrefix(prefix)
+        }
+    }
+}

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ReservedKeywordSanitizer.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ReservedKeywordSanitizer.kt
@@ -21,7 +21,7 @@ package com.netflix.graphql.dgs.codegen.generators.java
 class ReservedKeywordSanitizer {
 
     companion object {
-        private val reservedKeywords = setOf("import", "_")
+        private val reservedKeywords = setOf("import", "_", "root", "parent")
         private const val prefix = "_"
 
         fun sanitize(originalName: String): String {

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/TypeUtils.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/TypeUtils.kt
@@ -29,6 +29,7 @@ import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
 import java.time.OffsetDateTime
+import java.util.*
 
 class TypeUtils(private val packageName: String, private val config: CodeGenConfig) {
     fun findReturnType(fieldType: Type<*>): com.squareup.javapoet.TypeName {
@@ -86,15 +87,21 @@ class TypeUtils(private val packageName: String, private val config: CodeGenConf
 
         return when (name) {
             "String" -> ClassName.get(String::class.java)
+            "StringValue" -> ClassName.get(String::class.java)
             "Int" -> com.squareup.javapoet.TypeName.INT
+            "IntValue" -> com.squareup.javapoet.TypeName.INT
             "Float" -> com.squareup.javapoet.TypeName.DOUBLE
+            "FloatValue" -> com.squareup.javapoet.TypeName.DOUBLE
             "Boolean" -> com.squareup.javapoet.TypeName.BOOLEAN
+            "BooleanValue" -> com.squareup.javapoet.TypeName.BOOLEAN
             "ID" -> ClassName.get(String::class.java)
+            "IDValue" -> ClassName.get(String::class.java)
             "LocalTime" -> ClassName.get(LocalTime::class.java)
             "LocalDate" -> ClassName.get(LocalDate::class.java)
             "LocalDateTime" -> ClassName.get(LocalDateTime::class.java)
             "TimeZone" -> ClassName.get(String::class.java)
             "DateTime" -> ClassName.get(OffsetDateTime::class.java)
+            "Currency" -> ClassName.get(Currency::class.java)
             "RelayPageInfo" -> ClassName.get(PageInfo::class.java)
             "PageInfo" -> ClassName.get(PageInfo::class.java)
             "PresignedUrlResponse" -> ClassName.get("com.netflix.graphql.types.core.resolvers", "PresignedUrlResponse")

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinConstantsGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinConstantsGenerator.kt
@@ -38,7 +38,7 @@ class KotlinConstantsGenerator(private val config: CodeGenConfig, private val do
 
             constantsType.addProperty(PropertySpec.builder("TYPE_NAME", String::class).addModifiers(KModifier.CONST).initializer(""""${it.name}"""").build())
 
-            fields.forEach { field ->
+            fields.filter(ReservedKeywordFilter.filterInvalidNames).forEach { field ->
                 addFieldName(constantsType, field.name)
             }
 
@@ -51,7 +51,7 @@ class KotlinConstantsGenerator(private val config: CodeGenConfig, private val do
             val extensions = findInputExtensions(it.name, document.definitions)
             val fields = it.inputValueDefinitions.plus(extensions.flatMap { it.inputValueDefinitions })
             constantsType.addProperty(PropertySpec.builder("TYPE_NAME", String::class).addModifiers(KModifier.CONST).initializer(""""${it.name}"""").build())
-            fields.forEach { field ->
+            fields.filter(ReservedKeywordFilter.filterInvalidNames).forEach { field ->
                 addFieldName(constantsType, field.name)
             }
 
@@ -62,7 +62,7 @@ class KotlinConstantsGenerator(private val config: CodeGenConfig, private val do
             val constantsType = TypeSpec.objectBuilder((it.name.toUpperCase()))
             constantsType.addProperty(PropertySpec.builder("TYPE_NAME", String::class).addModifiers(KModifier.CONST).initializer(""""${it.name}"""").build())
 
-            it.fieldDefinitions.forEach { field ->
+            it.fieldDefinitions.filter(ReservedKeywordFilter.filterInvalidNames).forEach { field ->
                 addFieldName(constantsType, field.name)
             }
 
@@ -99,5 +99,7 @@ class KotlinConstantsGenerator(private val config: CodeGenConfig, private val do
 
     private fun findInputExtensions(name: String, definitions: List<Definition<Definition<*>>>) =
             definitions.filterIsInstance<InputObjectTypeExtensionDefinition>().filter { name == it.name }
+
+
 
 }

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinEntitiesRepresentationTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinEntitiesRepresentationTypeGenerator.kt
@@ -60,7 +60,7 @@ class KotlinEntitiesRepresentationTypeGenerator(private val config: CodeGenConfi
                     val type = findType(it.type, document)
                     val fieldType = typeUtils.findReturnType(it.type)
                     if (type != null && type is ObjectTypeDefinition) {
-                        val representationType = fieldType.toString().replace(type.name, "${type.name}Representation")
+                        val representationType = fieldType.toString().replace(type.name, "${type.name}Representation").removeSuffix("?")
                         if (! generatedRepresentations.containsKey(name)) {
                             result = generateRepresentations(type, document, generatedRepresentations, keyFields[it.name] as Map<String, Any>)
                         }

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinTypeUtils.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinTypeUtils.kt
@@ -38,10 +38,8 @@ import graphql.language.TypeName
 import graphql.relay.PageInfo
 import graphql.util.TraversalControl
 import graphql.util.TraverserContext
-import java.time.LocalDate
-import java.time.LocalDateTime
-import java.time.LocalTime
-import java.time.OffsetDateTime
+import java.time.*
+import java.util.*
 
 class KotlinTypeUtils(private val packageName: String, val config: CodeGenConfig) {
     @ExperimentalStdlibApi
@@ -80,19 +78,27 @@ class KotlinTypeUtils(private val packageName: String, val config: CodeGenConfig
 
         return when (name) {
             "String" -> STRING
+            "StringValue" -> STRING
             "Int" -> INT
+            "IntValue" -> INT
             "Float" -> DOUBLE
+            "FloatValue" -> DOUBLE
             "Boolean" -> BOOLEAN
+            "BooleanValue" -> BOOLEAN
             "ID" -> STRING
+            "IDValue" -> STRING
             "LocalTime" -> typeNameOf<LocalTime>()
             "LocalDate" -> typeNameOf<LocalDate>()
             "LocalDateTime" -> typeNameOf<LocalDateTime>()
             "TimeZone" -> STRING
             "DateTime" -> typeNameOf<OffsetDateTime>()
+            "Instant" -> typeNameOf<Instant>()
+            "Currency" -> typeNameOf<Currency>()
             "RelayPageInfo" -> typeNameOf<PageInfo>()
             "PageInfo" -> typeNameOf<PageInfo>()
             "PresignedUrlResponse" -> ClassName.bestGuess("com.netflix.graphql.types.core.resolvers.PresignedUrlResponse")
             "Header" -> ClassName.bestGuess("com.netflix.graphql.types.core.resolvers.PresignedUrlResponse.Header")
+
             else ->  ClassName.bestGuess("${packageName}.${name}")
         }
     }

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/ReservedKeywordFilter.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/ReservedKeywordFilter.kt
@@ -16,20 +16,10 @@
  *
  */
 
-package com.netflix.graphql.dgs.codegen.generators.java
+package com.netflix.graphql.dgs.codegen.generators.kotlin
 
-class ReservedKeywordSanitizer {
+import graphql.language.NamedNode
 
-    companion object {
-        private val reservedKeywords = setOf("import", "_")
-        private const val prefix = "_"
-
-        fun sanitize(originalName: String): String {
-            return if (reservedKeywords.contains(originalName)) {
-                "$prefix$originalName"
-            } else {
-                originalName
-            }
-        }
-    }
+object ReservedKeywordFilter {
+    val filterInvalidNames : (NamedNode<*>) -> Boolean = { it.name != "_"}
 }

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/shared/ClassnameShortener.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/shared/ClassnameShortener.kt
@@ -16,7 +16,7 @@
  *
  */
 
-package com.netflix.graphql.dgs.codegen.generators.java
+package com.netflix.graphql.dgs.codegen.generators.shared
 
 class ClassnameShortener {
     companion object {

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/ClientApiGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/ClientApiGenTest.kt
@@ -819,7 +819,7 @@ class ClientApiGenTest {
         """.trimIndent()
 
 
-        val codeGenResult = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, generateClientApi = true, writeToFiles = true)).generate() as CodeGenResult
+        val codeGenResult = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, generateClientApi = true)).generate() as CodeGenResult
 
         assertThat(codeGenResult.clientProjections.size).isEqualTo(2)
         val weirdType = codeGenResult.clientProjections.find { it.typeSpec.name == "NormalTypeWeirdTypeProjection" }

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/ClientApiGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/ClientApiGenTest.kt
@@ -25,6 +25,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 
+@ExperimentalStdlibApi
 class ClientApiGenTest {
 
     val basePackageName = "com.netflix.graphql.dgs.codegen.tests.generated"
@@ -267,6 +268,38 @@ class ClientApiGenTest {
         assertThat(codeGenResult.clientProjections.size).isEqualTo(2)
         assertThat(codeGenResult.clientProjections[0].typeSpec.name).isEqualTo("MoviesProjectionRoot")
         assertThat(codeGenResult.clientProjections[1].typeSpec.name).isEqualTo("MoviesActorsProjection")
+
+        assertCompiles(codeGenResult.clientProjections.plus(codeGenResult.queryTypes))
+    }
+
+    @ExperimentalStdlibApi
+    @Test
+    fun generateSubProjectionTypesWithShortNames() {
+
+        val schema = """
+            type Query {
+                movies: [Movie]
+            }
+            
+            type Movie {
+                title: String
+                actors: [Actor]
+            }
+            
+            type Actor {
+                name: String
+                age: Integer
+                movies: [Movie]
+            }
+
+        """.trimIndent()
+
+        val codeGenResult = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, generateClientApi = true, shortProjectionNames = true)).generate() as CodeGenResult
+
+        assertThat(codeGenResult.clientProjections.size).isEqualTo(3)
+        assertThat(codeGenResult.clientProjections[0].typeSpec.name).isEqualTo("MoviesProjectionRoot")
+        assertThat(codeGenResult.clientProjections[1].typeSpec.name).isEqualTo("MoviesActorsProjection")
+        assertThat(codeGenResult.clientProjections[2].typeSpec.name).isEqualTo("MoAcMoviesProjection")
 
         assertCompiles(codeGenResult.clientProjections.plus(codeGenResult.queryTypes))
     }
@@ -695,5 +728,45 @@ class ClientApiGenTest {
         assertThat(projections[1].typeSpec.methodSpecs).extracting("name").contains("title", "director", "<init>")
 
         assertCompiles(codeGenResult.clientProjections.plus(codeGenResult.queryTypes).plus(codeGenResult.dataTypes).plus(codeGenResult.enumTypes))
+    }
+
+    @ExperimentalStdlibApi
+    @Test
+    fun includeQueryConfig() {
+
+        val schema = """
+            type Query {
+                movieTitles: [String]
+                actorNames: [String]
+            }           
+        """.trimIndent()
+
+
+        val codeGenResult = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, generateClientApi = true, includeQueries = setOf("movieTitles"))).generate() as CodeGenResult
+
+        assertThat(codeGenResult.queryTypes.size).isEqualTo(1)
+        assertThat(codeGenResult.queryTypes[0].typeSpec.name).isEqualTo("MovieTitlesGraphQLQuery")
+
+        assertCompiles(codeGenResult.clientProjections.plus(codeGenResult.queryTypes))
+    }
+
+    @ExperimentalStdlibApi
+    @Test
+    fun includeMutationConfig() {
+
+        val schema = """
+            type Mutation {
+                updateMovieTitle: String
+                addActorName: Boolean
+            }           
+        """.trimIndent()
+
+
+        val codeGenResult = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, generateClientApi = true, includeMutations = setOf("updateMovieTitle"))).generate() as CodeGenResult
+
+        assertThat(codeGenResult.queryTypes.size).isEqualTo(1)
+        assertThat(codeGenResult.queryTypes[0].typeSpec.name).isEqualTo("UpdateMovieTitleGraphQLQuery")
+
+        assertCompiles(codeGenResult.clientProjections.plus(codeGenResult.queryTypes))
     }
 }

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/EntitiesClientApiGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/EntitiesClientApiGenTest.kt
@@ -250,4 +250,30 @@ class EntitiesClientApiGenTest {
         assertThat(projections.size).isEqualTo(3)
         assertCompiles(codeGenResult.clientProjections.plus(codeGenResult.queryTypes).plus(codeGenResult.dataTypes))
     }
+
+    @ExperimentalStdlibApi
+    @Test
+    fun skipEntities() {
+        val schema = """
+            type Query {
+                search: Movie
+            }
+
+            type Movie @key(fields: "movieId") {
+                movieId: ID! @external
+                title: String
+                actor: Actor
+            }
+
+            type Actor {
+                name: String
+                friends: Actor
+            }
+        """.trimIndent()
+
+        val codeGenResult = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, generateClientApi = true, skipEntityQueries = true)).generate() as CodeGenResult
+
+        val projections = codeGenResult.clientProjections.filter {it.typeSpec.name.contains("Entities")}
+        assertThat(projections).isEmpty()
+    }
 }

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
@@ -673,7 +673,7 @@ internal class KotlinCodeGenTest {
                 return  builder.toString()
         """.trimIndent()
         generatedInputString = type.funSpecs.single { it.name == "serializeListOfStrings" }.body.toString().trimIndent()
-        assertThat(expectedInputString).isEqualTo(generatedInputString)
+        assertThat(generatedInputString).isEqualTo(expectedInputString)
     }
 
     @Test
@@ -693,10 +693,10 @@ internal class KotlinCodeGenTest {
 
         val type = dataTypes[0].members[0] as TypeSpec
         assertThat(type.funSpecs).extracting("name").contains("toString")
-        var expectedInputString = """
+        val expectedInputString = """
             return "{" + "genre:" + genre + "" +"}"
         """.trimIndent()
-        var generatedInputString = type.funSpecs.single { it.name == "toString" }.body.toString().trimIndent()
+        val generatedInputString = type.funSpecs.single { it.name == "toString" }.body.toString().trimIndent()
         assertThat(expectedInputString).isEqualTo(generatedInputString)
     }
 

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ClassnameShortenerTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ClassnameShortenerTest.kt
@@ -1,0 +1,46 @@
+/*
+ *
+ *  Copyright 2020 Netflix, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package com.netflix.graphql.dgs.codegen.generators.java
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import java.util.stream.Stream
+
+internal class ClassnameShortenerTest {
+    @ParameterizedTest
+    @MethodSource("inputAndExpectedProvider")
+    fun shorten(input: String, expected: String) {
+        val shortened = ClassnameShortener.shorten(input)
+        assertThat(shortened).isEqualTo(expected)
+    }
+
+    companion object {
+        @JvmStatic
+        fun inputAndExpectedProvider(): Stream<Arguments> {
+            return Stream.of(
+                Arguments.arguments("ThisIsATest", "ThIsATe"),
+                Arguments.arguments("T", "T"),
+                Arguments.arguments("lowercase", "lo"),
+                Arguments.arguments("lowercaseAndUppercase", "loAnUp"),
+            )
+        }
+    }
+}

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ClassnameShortenerTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ClassnameShortenerTest.kt
@@ -18,6 +18,7 @@
 
 package com.netflix.graphql.dgs.codegen.generators.java
 
+import com.netflix.graphql.dgs.codegen.generators.shared.ClassnameShortener
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments

--- a/graphql-dgs-codegen-gradle/build.gradle
+++ b/graphql-dgs-codegen-gradle/build.gradle
@@ -37,7 +37,7 @@ apply plugin: 'license'
 
 dependencies {
     api project(":graphql-dgs-codegen-core")
-    compileOnly "org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.70"
+    compileOnly "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.21"
     testImplementation gradleTestKit()
     testImplementation("org.assertj:assertj-core:3.11.1")
     // Use JUnit test framework for unit tests

--- a/graphql-dgs-codegen-gradle/dependencies.lock
+++ b/graphql-dgs-codegen-gradle/dependencies.lock
@@ -1,265 +1,345 @@
 {
     "apiDependenciesMetadata": {
-        "graphql-dgs-codegen:graphql-dgs-codegen-core": {
+        "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core": {
             "project": true
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.4.21"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
+            ],
+            "locked": "1.4.21"
         }
     },
     "compileClasspath": {
-        "graphql-dgs-codegen:graphql-dgs-codegen-core": {
+        "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core": {
             "project": true
         },
         "org.jetbrains.kotlin:kotlin-gradle-plugin": {
-            "locked": "1.3.70",
-            "requested": "1.3.70"
+            "locked": "1.4.21"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.4.21"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
+            ],
+            "locked": "1.4.21"
         }
     },
     "compileOnlyDependenciesMetadata": {
         "org.jetbrains.kotlin:kotlin-gradle-plugin": {
-            "locked": "1.3.70",
-            "requested": "1.3.70"
+            "locked": "1.4.21"
         }
     },
     "functionalTestCompileClasspath": {
-        "graphql-dgs-codegen:graphql-dgs-codegen-core": {
+        "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core": {
             "project": true
         },
         "junit:junit": {
-            "locked": "4.12",
-            "requested": "4.12"
+            "locked": "4.12"
         },
         "org.assertj:assertj-core": {
-            "locked": "3.11.1",
-            "requested": "3.11.1"
+            "locked": "3.11.1"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.4.21"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
+            ],
+            "locked": "1.4.21"
         }
     },
     "functionalTestImplementationDependenciesMetadata": {
-        "graphql-dgs-codegen:graphql-dgs-codegen-core": {
+        "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core": {
             "project": true
         },
         "junit:junit": {
-            "locked": "4.12",
-            "requested": "4.12"
+            "locked": "4.12"
         },
         "org.assertj:assertj-core": {
-            "locked": "3.11.1",
-            "requested": "3.11.1"
+            "locked": "3.11.1"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.4.21"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
+            ],
+            "locked": "1.4.21"
         }
     },
     "functionalTestRuntimeClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
             "firstLevelTransitive": [
-                "graphql-dgs-codegen:graphql-dgs-codegen-core"
+                "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
-            "locked": "2.11.3"
+            "locked": "2.11.4"
         },
-        "com.github.ajalt:clikt": {
+        "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
-                "graphql-dgs-codegen:graphql-dgs-codegen-core"
+                "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
-            "locked": "2.3.0"
+            "locked": "2.11.4"
+        },
+        "com.github.ajalt.clikt:clikt": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
+            ],
+            "locked": "3.1.0"
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
-                "graphql-dgs-codegen:graphql-dgs-codegen-core"
+                "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
             "locked": "14.0"
         },
+        "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core": {
+            "project": true
+        },
         "com.netflix.graphql.dgs:graphql-dgs": {
             "firstLevelTransitive": [
-                "graphql-dgs-codegen:graphql-dgs-codegen-core"
+                "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
-            "locked": "3.0.10"
+            "locked": "3.1.2"
         },
         "com.netflix.graphql.dgs:graphql-dgs-client": {
             "firstLevelTransitive": [
-                "graphql-dgs-codegen:graphql-dgs-codegen-core"
+                "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
-            "locked": "3.0.10"
+            "locked": "3.1.2"
         },
         "com.squareup:javapoet": {
             "firstLevelTransitive": [
-                "graphql-dgs-codegen:graphql-dgs-codegen-core"
+                "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
             "locked": "1.13.0"
         },
         "com.squareup:kotlinpoet": {
             "firstLevelTransitive": [
-                "graphql-dgs-codegen:graphql-dgs-codegen-core"
+                "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
             "locked": "1.7.2"
         },
-        "graphql-dgs-codegen:graphql-dgs-codegen-core": {
-            "project": true
-        },
         "junit:junit": {
-            "locked": "4.12",
-            "requested": "4.12"
+            "locked": "4.12"
         },
         "org.assertj:assertj-core": {
-            "locked": "3.11.1",
-            "requested": "3.11.1"
+            "locked": "3.11.1"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.4.21"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
-                "graphql-dgs-codegen:graphql-dgs-codegen-core"
+                "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
-            "locked": "1.4.10"
+            "locked": "1.4.21"
         }
     },
     "implementationDependenciesMetadata": {
-        "graphql-dgs-codegen:graphql-dgs-codegen-core": {
+        "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core": {
             "project": true
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.4.21"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
+            ],
+            "locked": "1.4.21"
         }
     },
     "kotlinCompilerClasspath": {
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
-            "locked": "1.3.70"
+            "locked": "1.4.21"
         }
     },
     "kotlinCompilerPluginClasspath": {
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
-            "locked": "1.3.70",
-            "requested": "1.3.70"
+            "locked": "1.4.21"
+        }
+    },
+    "kotlinKlibCommonizerClasspath": {
+        "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable": {
+            "locked": "1.4.21"
         }
     },
     "runtimeClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
             "firstLevelTransitive": [
-                "graphql-dgs-codegen:graphql-dgs-codegen-core"
+                "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
-            "locked": "2.11.3"
+            "locked": "2.11.4"
         },
-        "com.github.ajalt:clikt": {
+        "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
-                "graphql-dgs-codegen:graphql-dgs-codegen-core"
+                "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
-            "locked": "2.3.0"
+            "locked": "2.11.4"
+        },
+        "com.github.ajalt.clikt:clikt": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
+            ],
+            "locked": "3.1.0"
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
-                "graphql-dgs-codegen:graphql-dgs-codegen-core"
+                "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
             "locked": "14.0"
         },
+        "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core": {
+            "project": true
+        },
         "com.netflix.graphql.dgs:graphql-dgs": {
             "firstLevelTransitive": [
-                "graphql-dgs-codegen:graphql-dgs-codegen-core"
+                "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
-            "locked": "3.0.10"
+            "locked": "3.1.2"
         },
         "com.netflix.graphql.dgs:graphql-dgs-client": {
             "firstLevelTransitive": [
-                "graphql-dgs-codegen:graphql-dgs-codegen-core"
+                "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
-            "locked": "3.0.10"
+            "locked": "3.1.2"
         },
         "com.squareup:javapoet": {
             "firstLevelTransitive": [
-                "graphql-dgs-codegen:graphql-dgs-codegen-core"
+                "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
             "locked": "1.13.0"
         },
         "com.squareup:kotlinpoet": {
             "firstLevelTransitive": [
-                "graphql-dgs-codegen:graphql-dgs-codegen-core"
+                "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
             "locked": "1.7.2"
         },
-        "graphql-dgs-codegen:graphql-dgs-codegen-core": {
-            "project": true
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.4.21"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
-                "graphql-dgs-codegen:graphql-dgs-codegen-core"
+                "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
-            "locked": "1.4.10"
+            "locked": "1.4.21"
         }
     },
     "testCompileClasspath": {
-        "graphql-dgs-codegen:graphql-dgs-codegen-core": {
+        "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core": {
             "project": true
         },
         "junit:junit": {
-            "locked": "4.12",
-            "requested": "4.12"
+            "locked": "4.12"
         },
         "org.assertj:assertj-core": {
-            "locked": "3.11.1",
-            "requested": "3.11.1"
+            "locked": "3.11.1"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.4.21"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
+            ],
+            "locked": "1.4.21"
         }
     },
     "testImplementationDependenciesMetadata": {
-        "graphql-dgs-codegen:graphql-dgs-codegen-core": {
+        "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core": {
             "project": true
         },
         "junit:junit": {
-            "locked": "4.12",
-            "requested": "4.12"
+            "locked": "4.12"
         },
         "org.assertj:assertj-core": {
-            "locked": "3.11.1",
-            "requested": "3.11.1"
+            "locked": "3.11.1"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.4.21"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
+            ],
+            "locked": "1.4.21"
         }
     },
     "testRuntimeClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
             "firstLevelTransitive": [
-                "graphql-dgs-codegen:graphql-dgs-codegen-core"
+                "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
-            "locked": "2.11.3"
+            "locked": "2.11.4"
         },
-        "com.github.ajalt:clikt": {
+        "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
-                "graphql-dgs-codegen:graphql-dgs-codegen-core"
+                "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
-            "locked": "2.3.0"
+            "locked": "2.11.4"
+        },
+        "com.github.ajalt.clikt:clikt": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
+            ],
+            "locked": "3.1.0"
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
-                "graphql-dgs-codegen:graphql-dgs-codegen-core"
+                "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
             "locked": "14.0"
         },
+        "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core": {
+            "project": true
+        },
         "com.netflix.graphql.dgs:graphql-dgs": {
             "firstLevelTransitive": [
-                "graphql-dgs-codegen:graphql-dgs-codegen-core"
+                "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
-            "locked": "3.0.10"
+            "locked": "3.1.2"
         },
         "com.netflix.graphql.dgs:graphql-dgs-client": {
             "firstLevelTransitive": [
-                "graphql-dgs-codegen:graphql-dgs-codegen-core"
+                "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
-            "locked": "3.0.10"
+            "locked": "3.1.2"
         },
         "com.squareup:javapoet": {
             "firstLevelTransitive": [
-                "graphql-dgs-codegen:graphql-dgs-codegen-core"
+                "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
             "locked": "1.13.0"
         },
         "com.squareup:kotlinpoet": {
             "firstLevelTransitive": [
-                "graphql-dgs-codegen:graphql-dgs-codegen-core"
+                "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
             "locked": "1.7.2"
         },
-        "graphql-dgs-codegen:graphql-dgs-codegen-core": {
-            "project": true
-        },
         "junit:junit": {
-            "locked": "4.12",
-            "requested": "4.12"
+            "locked": "4.12"
         },
         "org.assertj:assertj-core": {
-            "locked": "3.11.1",
-            "requested": "3.11.1"
+            "locked": "3.11.1"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.4.21"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
-                "graphql-dgs-codegen:graphql-dgs-codegen-core"
+                "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
-            "locked": "1.4.10"
+            "locked": "1.4.21"
         }
     }
 }

--- a/graphql-dgs-codegen-gradle/dependencies.lock
+++ b/graphql-dgs-codegen-gradle/dependencies.lock
@@ -4,13 +4,13 @@
             "project": true
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
-            "locked": "1.4.21"
+            "locked": "1.4.30"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
-            "locked": "1.4.21"
+            "locked": "1.4.30"
         }
     },
     "compileClasspath": {
@@ -21,13 +21,13 @@
             "locked": "1.4.21"
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
-            "locked": "1.4.21"
+            "locked": "1.4.30"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
-            "locked": "1.4.21"
+            "locked": "1.4.30"
         }
     },
     "compileOnlyDependenciesMetadata": {
@@ -46,13 +46,13 @@
             "locked": "3.11.1"
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
-            "locked": "1.4.21"
+            "locked": "1.4.30"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
-            "locked": "1.4.21"
+            "locked": "1.4.30"
         }
     },
     "functionalTestImplementationDependenciesMetadata": {
@@ -66,13 +66,13 @@
             "locked": "3.11.1"
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
-            "locked": "1.4.21"
+            "locked": "1.4.30"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
-            "locked": "1.4.21"
+            "locked": "1.4.30"
         }
     },
     "functionalTestRuntimeClasspath": {
@@ -107,13 +107,13 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
-            "locked": "3.1.2"
+            "locked": "3.3.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs-client": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
-            "locked": "3.1.2"
+            "locked": "3.3.0"
         },
         "com.squareup:javapoet": {
             "firstLevelTransitive": [
@@ -134,13 +134,13 @@
             "locked": "3.11.1"
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
-            "locked": "1.4.21"
+            "locked": "1.4.30"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
-            "locked": "1.4.21"
+            "locked": "1.4.30"
         }
     },
     "implementationDependenciesMetadata": {
@@ -148,28 +148,28 @@
             "project": true
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
-            "locked": "1.4.21"
+            "locked": "1.4.30"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
-            "locked": "1.4.21"
+            "locked": "1.4.30"
         }
     },
     "kotlinCompilerClasspath": {
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
-            "locked": "1.4.21"
+            "locked": "1.4.30"
         }
     },
     "kotlinCompilerPluginClasspath": {
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
-            "locked": "1.4.21"
+            "locked": "1.4.30"
         }
     },
     "kotlinKlibCommonizerClasspath": {
         "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable": {
-            "locked": "1.4.21"
+            "locked": "1.4.30"
         }
     },
     "runtimeClasspath": {
@@ -204,13 +204,13 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
-            "locked": "3.1.2"
+            "locked": "3.3.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs-client": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
-            "locked": "3.1.2"
+            "locked": "3.3.0"
         },
         "com.squareup:javapoet": {
             "firstLevelTransitive": [
@@ -225,13 +225,13 @@
             "locked": "1.7.2"
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
-            "locked": "1.4.21"
+            "locked": "1.4.30"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
-            "locked": "1.4.21"
+            "locked": "1.4.30"
         }
     },
     "testCompileClasspath": {
@@ -245,13 +245,13 @@
             "locked": "3.11.1"
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
-            "locked": "1.4.21"
+            "locked": "1.4.30"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
-            "locked": "1.4.21"
+            "locked": "1.4.30"
         }
     },
     "testImplementationDependenciesMetadata": {
@@ -265,13 +265,13 @@
             "locked": "3.11.1"
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
-            "locked": "1.4.21"
+            "locked": "1.4.30"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
-            "locked": "1.4.21"
+            "locked": "1.4.30"
         }
     },
     "testRuntimeClasspath": {
@@ -306,13 +306,13 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
-            "locked": "3.1.2"
+            "locked": "3.3.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs-client": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
-            "locked": "3.1.2"
+            "locked": "3.3.0"
         },
         "com.squareup:javapoet": {
             "firstLevelTransitive": [
@@ -333,13 +333,13 @@
             "locked": "3.11.1"
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
-            "locked": "1.4.21"
+            "locked": "1.4.30"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
-            "locked": "1.4.21"
+            "locked": "1.4.30"
         }
     }
 }

--- a/graphql-dgs-codegen-gradle/src/main/kotlin/com/netflix/graphql/dgs/codegen/gradle/GenerateJavaTask.kt
+++ b/graphql-dgs-codegen-gradle/src/main/kotlin/com/netflix/graphql/dgs/codegen/gradle/GenerateJavaTask.kt
@@ -71,6 +71,18 @@ open class GenerateJavaTask : DefaultTask() {
         return Paths.get("${generatedSourcesDir}/generated-examples").toFile()
     }
 
+    @Input
+    var includeQueries = mutableListOf<String>()
+
+    @Input
+    var includeMutations = mutableListOf<String>()
+
+    @Input
+    var skipEntityQueries = false
+
+    @Input
+    var shortProjectionNames = false
+
     @TaskAction
     fun generate() {
         val schemaPaths = schemaPaths.map { Paths.get(it.toString()).toFile() }.toSet()
@@ -87,7 +99,12 @@ open class GenerateJavaTask : DefaultTask() {
                 packageName = packageName,
                 language = Language.valueOf(language.toUpperCase()),
                 generateClientApi = generateClient,
-                typeMapping = typeMapping)
+                typeMapping = typeMapping,
+                includeQueries = includeQueries.toSet(),
+                includeMutations = includeMutations.toSet(),
+                skipEntityQueries = skipEntityQueries,
+                shortProjectionNames = shortProjectionNames
+        )
 
         LOGGER.info("Codegen config: {}", config)
 


### PR DESCRIPTION
* Options to generate only for specific queries/mutations
* Several fixes to work around issues with reserved names in Java/Kotlin
* Option to shorten generated projection type names. These types are only used internally by the Projection builder API and are not visible to users directly. The shorter names are required for deeply nested graphs that would otherwise result in file names that are too long.