### PR TITLE
Fix for missing case of escaping method names for fields named parent…

### DIFF
--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ClientApiGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ClientApiGenerator.kt
@@ -311,7 +311,7 @@ class ClientApiGenerator(private val config: CodeGenConfig, private val document
                 }
                 .map {
                     val projectionName = "${truncatePrefix(prefix)}${it.first.name.capitalize()}Projection"
-                    javaType.addMethod(MethodSpec.methodBuilder(it.first.name)
+                    javaType.addMethod(MethodSpec.methodBuilder(ReservedKeywordSanitizer.sanitize(it.first.name))
                             .returns(ClassName.get(getPackageName(), projectionName))
                             .addCode("""
                         $projectionName projection = new $projectionName(this, getRoot());    


### PR DESCRIPTION
…/root in projection classes.