### PR TITLE
Remove usage of experimental typeNameOf function

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,8 +27,15 @@ allprojects {
         jcenter()
     }
     group = 'com.netflix.graphql.dgs.codegen'
+
+    tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
+      kotlinOptions {
+        jvmTarget = "1.8"
+      }
+    }
 }
 description = 'Netflix GraphQL DGS Code Generation'
+
 bintray {
     pkgName = 'dgs-codegen'
 }

--- a/graphql-dgs-codegen-core/build.gradle
+++ b/graphql-dgs-codegen-core/build.gradle
@@ -69,13 +69,6 @@ test {
     useJUnitPlatform()
 }
 
-compileKotlin {
-    kotlinOptions.jvmTarget = "1.8"
-}
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "1.8"
-}
-
 application {
     mainClassName = 'com.netflix.graphql.dgs.codegen.CodeGenCliKt'
 }

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
@@ -28,7 +28,6 @@ import java.io.File
 import java.nio.file.Path
 import java.nio.file.Paths
 
-@ExperimentalStdlibApi
 class CodeGen(private val config: CodeGenConfig) {
     fun generate(): Any {
         if (config.writeToFiles) {

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGenCli.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGenCli.kt
@@ -28,7 +28,6 @@ import com.github.ajalt.clikt.parameters.types.file
 import java.io.File
 import java.nio.file.Paths
 
-@ExperimentalStdlibApi
 class CodeGenCli : CliktCommand("Generate Java sources for SCHEMA file(s)") {
 
     private val schemas by argument().file(mustExist = true).multiple()
@@ -76,8 +75,6 @@ class CodeGenCli : CliktCommand("Generate Java sources for SCHEMA file(s)") {
     }
 }
 
-
-@ExperimentalStdlibApi
 fun main(args: Array<String>) {
     CodeGenCli().main(args)
 }

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinDataTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinDataTypeGenerator.kt
@@ -25,7 +25,6 @@ import com.netflix.graphql.dgs.codegen.shouldSkip
 import com.squareup.kotlinpoet.*
 import graphql.language.*
 
-@ExperimentalStdlibApi
 class KotlinDataTypeGenerator(private val config: CodeGenConfig, private val document: Document): AbstractKotlinDataTypeGenerator(config) {
     private val typeUtils = KotlinTypeUtils(getPackageName(), config)
 
@@ -50,7 +49,6 @@ class KotlinDataTypeGenerator(private val config: CodeGenConfig, private val doc
     }
 }
 
-@ExperimentalStdlibApi
 class KotlinInputTypeGenerator(private val config: CodeGenConfig, private val document: Document): AbstractKotlinDataTypeGenerator(config) {
     private val typeUtils = KotlinTypeUtils(getPackageName(), config)
 

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinEntitiesRepresentationTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinEntitiesRepresentationTypeGenerator.kt
@@ -26,11 +26,9 @@ import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.STRING
 import graphql.language.*
 
-
 class KotlinEntitiesRepresentationTypeGenerator(private val config: CodeGenConfig): AbstractKotlinDataTypeGenerator(config) {
     private val typeUtils = KotlinTypeUtils(getPackageName(), config)
 
-    @ExperimentalStdlibApi
     fun generate(definition: ObjectTypeDefinition, document: Document, generatedRepresentations: MutableMap<String, Any>): KotlinCodeGenResult {
         val name = "${definition.name}Representation"
         if (generatedRepresentations.containsKey(name)) {
@@ -41,7 +39,6 @@ class KotlinEntitiesRepresentationTypeGenerator(private val config: CodeGenConfi
         return generateRepresentations(definition, document, generatedRepresentations, keyFields)
     }
 
-    @ExperimentalStdlibApi
     fun generateRepresentations(definition: ObjectTypeDefinition, document: Document, generatedRepresentations: MutableMap<String, Any>,
                                 keyFields: Map<String, Any> ): KotlinCodeGenResult {
         val name = "${definition.name}Representation"

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinInterfaceTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinInterfaceTypeGenerator.kt
@@ -33,7 +33,6 @@ class KotlinInterfaceTypeGenerator(config: CodeGenConfig) {
     private val packageName = config.packageName + ".types"
     private val typeUtils = KotlinTypeUtils(packageName, config)
 
-    @ExperimentalStdlibApi
     fun generate(definition: InterfaceTypeDefinition, document: Document): KotlinCodeGenResult {
         val interfaceBuilder = TypeSpec.interfaceBuilder(definition.name)
 

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinTypeUtils.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinTypeUtils.kt
@@ -25,9 +25,9 @@ import com.squareup.kotlinpoet.DOUBLE
 import com.squareup.kotlinpoet.INT
 import com.squareup.kotlinpoet.LIST
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
-import com.squareup.kotlinpoet.TypeName as KtTypeName
 import com.squareup.kotlinpoet.STRING
-import com.squareup.kotlinpoet.typeNameOf
+import com.squareup.kotlinpoet.asTypeName
+import com.squareup.kotlinpoet.TypeName as KtTypeName
 import graphql.language.ListType
 import graphql.language.Node
 import graphql.language.NodeTraverser
@@ -38,11 +38,14 @@ import graphql.language.TypeName
 import graphql.relay.PageInfo
 import graphql.util.TraversalControl
 import graphql.util.TraverserContext
-import java.time.*
-import java.util.*
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.OffsetDateTime
+import java.util.Currency
 
 class KotlinTypeUtils(private val packageName: String, val config: CodeGenConfig) {
-    @ExperimentalStdlibApi
     fun findReturnType(fieldType: Type<*>): KtTypeName {
         val visitor = object : NodeVisitorStub() {
             override fun visitTypeName(node: TypeName, context: TraverserContext<Node<Node<*>>>): TraversalControl {
@@ -70,7 +73,6 @@ class KotlinTypeUtils(private val packageName: String, val config: CodeGenConfig
         return fieldType !is NonNullType
     }
 
-    @ExperimentalStdlibApi
     private fun TypeName.toKtTypeName(): KtTypeName {
         if (name in config.typeMapping) {
             return ClassName.bestGuess(config.typeMapping.getValue(name))
@@ -87,15 +89,15 @@ class KotlinTypeUtils(private val packageName: String, val config: CodeGenConfig
             "BooleanValue" -> BOOLEAN
             "ID" -> STRING
             "IDValue" -> STRING
-            "LocalTime" -> typeNameOf<LocalTime>()
-            "LocalDate" -> typeNameOf<LocalDate>()
-            "LocalDateTime" -> typeNameOf<LocalDateTime>()
+            "LocalTime" -> LocalTime::class.asTypeName()
+            "LocalDate" -> LocalDate::class.asTypeName()
+            "LocalDateTime" -> LocalDateTime::class.asTypeName()
             "TimeZone" -> STRING
-            "DateTime" -> typeNameOf<OffsetDateTime>()
-            "Instant" -> typeNameOf<Instant>()
-            "Currency" -> typeNameOf<Currency>()
-            "RelayPageInfo" -> typeNameOf<PageInfo>()
-            "PageInfo" -> typeNameOf<PageInfo>()
+            "DateTime" -> OffsetDateTime::class.asTypeName()
+            "Instant" -> Instant::class.asTypeName()
+            "Currency" -> Currency::class.asTypeName()
+            "RelayPageInfo" -> PageInfo::class.asTypeName()
+            "PageInfo" -> PageInfo::class.asTypeName()
             "PresignedUrlResponse" -> ClassName.bestGuess("com.netflix.graphql.types.core.resolvers.PresignedUrlResponse")
             "Header" -> ClassName.bestGuess("com.netflix.graphql.types.core.resolvers.PresignedUrlResponse.Header")
 

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/ClientApiGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/ClientApiGenTest.kt
@@ -24,13 +24,10 @@ import com.squareup.javapoet.ParameterizedTypeName
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
-
-@ExperimentalStdlibApi
 class ClientApiGenTest {
 
     val basePackageName = "com.netflix.graphql.dgs.codegen.tests.generated"
 
-    @ExperimentalStdlibApi
     @Test
     fun generateQueryType() {
 
@@ -54,7 +51,6 @@ class ClientApiGenTest {
         assertCompiles(codeGenResult.clientProjections.plus(codeGenResult.queryTypes))
     }
 
-    @ExperimentalStdlibApi
     @Test
     fun generateMutationType() {
 
@@ -78,7 +74,6 @@ class ClientApiGenTest {
         assertCompiles(codeGenResult.clientProjections.plus(codeGenResult.queryTypes))
     }
 
-    @ExperimentalStdlibApi
     @Test
     fun generateMutationWithInputType() {
 
@@ -108,7 +103,6 @@ class ClientApiGenTest {
         assertCompiles(codeGenResult.clientProjections.plus(codeGenResult.queryTypes).plus(codeGenResult.dataTypes))
     }
 
-    @ExperimentalStdlibApi
     @Test
     fun generateProjectionRoot() {
 
@@ -132,7 +126,6 @@ class ClientApiGenTest {
         assertCompiles(codeGenResult.clientProjections)
     }
 
-    @ExperimentalStdlibApi
     @Test
     fun generateProjectionRootTestWithCycles() {
 
@@ -155,7 +148,6 @@ class ClientApiGenTest {
         assertCompiles(codeGenResult.clientProjections.plus(codeGenResult.queryTypes))
     }
 
-    @ExperimentalStdlibApi
     @Test
     fun generateInterfaceProjectionsWithCycles() {
         val schema = """
@@ -191,8 +183,6 @@ class ClientApiGenTest {
         assertCompiles(codeGenResult.clientProjections.plus(codeGenResult.queryTypes).plus(codeGenResult.enumTypes).plus(codeGenResult.dataTypes).plus(codeGenResult.interfaces))
     }
 
-
-    @ExperimentalStdlibApi
     @Test
     fun generateSubProjectionsWithDifferentRootTypes() {
 
@@ -214,7 +204,6 @@ class ClientApiGenTest {
         assertCompiles(codeGenResult.clientProjections.plus(codeGenResult.queryTypes))
     }
 
-    @ExperimentalStdlibApi
     @Test
     fun generateSubProjectionsWithDifferentParentTypes() {
 
@@ -242,7 +231,6 @@ class ClientApiGenTest {
         assertCompiles(codeGenResult.clientProjections.plus(codeGenResult.queryTypes))
     }
 
-    @ExperimentalStdlibApi
     @Test
     fun generateSubProjectionTypes() {
 
@@ -272,7 +260,6 @@ class ClientApiGenTest {
         assertCompiles(codeGenResult.clientProjections.plus(codeGenResult.queryTypes))
     }
 
-    @ExperimentalStdlibApi
     @Test
     fun generateSubProjectionTypesWithShortNames() {
 
@@ -304,8 +291,6 @@ class ClientApiGenTest {
         assertCompiles(codeGenResult.clientProjections.plus(codeGenResult.queryTypes))
     }
 
-
-    @ExperimentalStdlibApi
     @Test
     fun generateArgumentsForSimpleTypes() {
 
@@ -328,7 +313,6 @@ class ClientApiGenTest {
         assertCompiles(codeGenResult.clientProjections.plus(codeGenResult.queryTypes))
     }
 
-    @ExperimentalStdlibApi
     @Test
     fun generateArgumentsForEnum() {
 
@@ -356,7 +340,6 @@ class ClientApiGenTest {
         assertCompiles(codeGenResult.clientProjections.plus(codeGenResult.queryTypes).plus(codeGenResult.enumTypes))
     }
 
-    @ExperimentalStdlibApi
     @Test
     fun generateArgumentsForObjectType() {
 
@@ -384,7 +367,6 @@ class ClientApiGenTest {
         assertCompiles(codeGenResult.clientProjections.plus(codeGenResult.queryTypes).plus(codeGenResult.enumTypes).plus(codeGenResult.dataTypes))
     }
 
-    @ExperimentalStdlibApi
     @Test
     fun skipCodegen() {
 
@@ -413,7 +395,6 @@ class ClientApiGenTest {
         assertCompiles(codeGenResult.clientProjections.plus(codeGenResult.queryTypes).plus(codeGenResult.enumTypes).plus(codeGenResult.dataTypes))
     }
 
-    @ExperimentalStdlibApi
     @Test
     fun interfaceReturnTypes() {
         val schema = """
@@ -452,7 +433,6 @@ class ClientApiGenTest {
         assertCompiles(codeGenResult.clientProjections.plus(codeGenResult.queryTypes).plus(codeGenResult.enumTypes).plus(codeGenResult.dataTypes).plus(codeGenResult.interfaces))
     }
 
-    @ExperimentalStdlibApi
     @Test
     fun interfaceFragment() {
         val schema = """
@@ -493,7 +473,6 @@ class ClientApiGenTest {
         assertCompiles(codeGenResult.clientProjections.plus(codeGenResult.queryTypes).plus(codeGenResult.enumTypes).plus(codeGenResult.dataTypes).plus(codeGenResult.interfaces))
     }
 
-    @ExperimentalStdlibApi
     @Test
     fun interfaceFragmentOnSubType() {
         val schema = """
@@ -542,7 +521,6 @@ class ClientApiGenTest {
         assertCompiles(codeGenResult.clientProjections.plus(codeGenResult.queryTypes).plus(codeGenResult.enumTypes).plus(codeGenResult.dataTypes).plus(codeGenResult.interfaces))
     }
 
-    @ExperimentalStdlibApi
     @Test
     fun unionFragment() {
         val schema = """
@@ -577,7 +555,6 @@ class ClientApiGenTest {
         assertCompiles(codeGenResult.clientProjections.plus(codeGenResult.queryTypes).plus(codeGenResult.enumTypes).plus(codeGenResult.dataTypes).plus(codeGenResult.interfaces))
     }
 
-    @ExperimentalStdlibApi
     @Test
     fun unionFragmentOnSubType() {
         val schema = """
@@ -648,8 +625,6 @@ class ClientApiGenTest {
         assertCompiles(codeGenResult.clientProjections.plus(codeGenResult.queryTypes).plus(codeGenResult.enumTypes).plus(codeGenResult.dataTypes).plus(codeGenResult.interfaces))
     }
 
-
-    @ExperimentalStdlibApi
     @Test
     fun testScalarsDontGenerateProjections() {
         val schema = """
@@ -671,7 +646,6 @@ class ClientApiGenTest {
         assertCompiles(codeGenResult.clientProjections.plus(codeGenResult.queryTypes).plus(codeGenResult.dataTypes).plus(codeGenResult.enumTypes))
     }
 
-    @ExperimentalStdlibApi
     @Test
     fun testExtendRootProjection() {
         val schema = """
@@ -699,7 +673,6 @@ class ClientApiGenTest {
         assertCompiles(codeGenResult.clientProjections.plus(codeGenResult.queryTypes).plus(codeGenResult.dataTypes).plus(codeGenResult.enumTypes))
     }
 
-    @ExperimentalStdlibApi
     @Test
     fun testExtendSubProjection() {
         val schema = """
@@ -730,7 +703,6 @@ class ClientApiGenTest {
         assertCompiles(codeGenResult.clientProjections.plus(codeGenResult.queryTypes).plus(codeGenResult.dataTypes).plus(codeGenResult.enumTypes))
     }
 
-    @ExperimentalStdlibApi
     @Test
     fun includeQueryConfig() {
 
@@ -750,7 +722,6 @@ class ClientApiGenTest {
         assertCompiles(codeGenResult.clientProjections.plus(codeGenResult.queryTypes))
     }
 
-    @ExperimentalStdlibApi
     @Test
     fun includeMutationConfig() {
 
@@ -770,7 +741,6 @@ class ClientApiGenTest {
         assertCompiles(codeGenResult.clientProjections.plus(codeGenResult.queryTypes))
     }
 
-    @ExperimentalStdlibApi
     @Test
     fun generateProjectionRootWithReservedNames() {
 
@@ -797,7 +767,6 @@ class ClientApiGenTest {
         assertCompiles(codeGenResult.clientProjections)
     }
 
-    @ExperimentalStdlibApi
     @Test
     fun generateSubProjectionWithReservedNames() {
 

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
@@ -25,9 +25,7 @@ import com.squareup.javapoet.ParameterizedTypeName
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
-
-@ExperimentalStdlibApi
-internal class CodeGenTest {
+class CodeGenTest {
 
     val basePackageName = "com.netflix.graphql.dgs.codegen.tests.generated"
     val typesPackageName = "$basePackageName.types"

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/EntitiesClientApiGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/EntitiesClientApiGenTest.kt
@@ -25,7 +25,6 @@ class EntitiesClientApiGenTest {
 
     val basePackageName = "com.netflix.graphql.dgs.codegen.tests.generated"
 
-    @ExperimentalStdlibApi
     @Test
     fun generateForEntities() {
         val schema = """
@@ -62,8 +61,6 @@ class EntitiesClientApiGenTest {
         assertCompiles(codeGenResult.clientProjections.plus(codeGenResult.queryTypes).plus(codeGenResult.dataTypes))
     }
 
-
-    @ExperimentalStdlibApi
     @Test
     fun generateForEntitiesWithArraysAndNestedKeys() {
         val schema = """
@@ -100,7 +97,6 @@ class EntitiesClientApiGenTest {
         assertCompiles(codeGenResult.clientProjections.plus(codeGenResult.queryTypes).plus(codeGenResult.dataTypes))
     }
 
-    @ExperimentalStdlibApi
     @Test
     fun generateForEntitiesWithNestedKeys() {
         val schema = """
@@ -149,7 +145,6 @@ class EntitiesClientApiGenTest {
         assertCompiles(codeGenResult.clientProjections.plus(codeGenResult.queryTypes).plus(codeGenResult.dataTypes))
     }
 
-    @ExperimentalStdlibApi
     @Test
     fun generateForEntitiesWithMultipleKeyEntities() {
         val schema = """
@@ -189,7 +184,6 @@ class EntitiesClientApiGenTest {
         assertCompiles(codeGenResult.clientProjections.plus(codeGenResult.queryTypes).plus(codeGenResult.dataTypes))
     }
 
-    @ExperimentalStdlibApi
     @Test
     fun generateForEntitiesWithNestedComplexKeys() {
         val schema = """
@@ -227,7 +221,6 @@ class EntitiesClientApiGenTest {
         assertCompiles(codeGenResult.clientProjections.plus(codeGenResult.queryTypes).plus(codeGenResult.dataTypes))
     }
 
-    @ExperimentalStdlibApi
     @Test
     fun testScalarsInEntities() {
         val schema = """
@@ -251,7 +244,6 @@ class EntitiesClientApiGenTest {
         assertCompiles(codeGenResult.clientProjections.plus(codeGenResult.queryTypes).plus(codeGenResult.dataTypes))
     }
 
-    @ExperimentalStdlibApi
     @Test
     fun skipEntities() {
         val schema = """

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinClientApiGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinClientApiGenTest.kt
@@ -25,8 +25,6 @@ import com.squareup.kotlinpoet.TypeSpec
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
-
-@ExperimentalStdlibApi
 class KotlinClientApiGenTest {
 
     val basePackageName = "com.netflix.graphql.dgs.codegen.tests.generated"
@@ -442,7 +440,6 @@ class KotlinClientApiGenTest {
         assertThat(projectionTypeSpec.name).isEqualTo("PersonsFriendsProjection")
     }
 
-    @ExperimentalStdlibApi
     @Test
     fun generateSubProjectionsWithDifferentRootTypes() {
 
@@ -464,7 +461,6 @@ class KotlinClientApiGenTest {
         assertThat(projectionTypeSpec.name).isEqualTo("FriendsProjectionRoot")
     }
 
-    @ExperimentalStdlibApi
     @Test
     fun generateSubProjectionsWithDifferentParentTypes() {
 
@@ -568,7 +564,6 @@ class KotlinClientApiGenTest {
         assertThat(codeGenResult.queryTypes[0].toString()).contains("import com.netflix.graphql.dgs.codegen.tests.generated.types.SearchIndex\n")
     }
 
-    @ExperimentalStdlibApi
     @Test
     fun testScalarsDontGenerateProjections() {
         val schema = """
@@ -590,7 +585,6 @@ class KotlinClientApiGenTest {
         assertThat(projections.size).isEqualTo(1)
     }
 
-    @ExperimentalStdlibApi
     @Test
     fun testExtendRootProjection() {
         val schema = """
@@ -615,7 +609,6 @@ class KotlinClientApiGenTest {
         assertThat((projections[0].members[0] as TypeSpec).funSpecs).extracting("name").contains("name", "email")
     }
 
-    @ExperimentalStdlibApi
     @Test
     fun testExtendSubProjection() {
         val schema = """
@@ -642,6 +635,4 @@ class KotlinClientApiGenTest {
         assertThat(projections.size).isEqualTo(2)
         assertThat((projections[1].members[0] as TypeSpec).funSpecs).extracting("name").contains("title", "director")
     }
-
-
 }

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
@@ -24,9 +24,7 @@ import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
-
-@ExperimentalStdlibApi
-internal class KotlinCodeGenTest {
+class KotlinCodeGenTest {
 
     val basePackageName = "com.netflix.graphql.dgs.codegen.tests.generated"
     val typesPackageName = "$basePackageName.types"
@@ -73,9 +71,9 @@ internal class KotlinCodeGenTest {
         val type = dataTypes[0].members[0] as TypeSpec
 
         val (countProperty, truthProperty, floatyProperty) = type.propertySpecs
-        assertThat(countProperty.type).isEqualTo(typeNameOf<Int?>())
-        assertThat(truthProperty.type).isEqualTo(typeNameOf<Boolean?>())
-        assertThat(floatyProperty.type).isEqualTo(typeNameOf<Double?>())
+        assertThat(countProperty.type).isEqualTo(Int::class.asTypeName().copy(nullable = true))
+        assertThat(truthProperty.type).isEqualTo(Boolean::class.asTypeName().copy(nullable = true))
+        assertThat(floatyProperty.type).isEqualTo(Double::class.asTypeName().copy(nullable = true))
 
         val constructor = type.primaryConstructor
                 ?: throw AssertionError("No primary constructor found")
@@ -196,8 +194,8 @@ internal class KotlinCodeGenTest {
         assertThat(nameProperty.name).isEqualTo("name")
         assertThat(emailProperty.name).isEqualTo("email")
 
-        assertThat(nameProperty.type).isEqualTo(typeNameOf<String?>())
-        assertThat(emailProperty.type).isEqualTo(typeNameOf<List<String?>?>())
+        assertThat(nameProperty.type).isEqualTo(STRING.copy(nullable = true))
+        assertThat(emailProperty.type).isEqualTo(LIST.parameterizedBy(STRING.copy(nullable = true)).copy(nullable = true))
     }
 
     @Test
@@ -221,8 +219,8 @@ internal class KotlinCodeGenTest {
         assertThat(type.propertySpecs.size).isEqualTo(2)
 
         val (nameProperty, emailProperty) = type.propertySpecs
-        assertThat(nameProperty.type).isEqualTo(typeNameOf<String>())
-        assertThat(emailProperty.type).isEqualTo(typeNameOf<List<String>>())
+        assertThat(nameProperty.type).isEqualTo(STRING)
+        assertThat(emailProperty.type).isEqualTo(LIST.parameterizedBy(STRING))
     }
 
     @Test
@@ -247,8 +245,8 @@ internal class KotlinCodeGenTest {
 
         val (nameProperty, emailProperty) = type.propertySpecs
 
-        assertThat(nameProperty.type).isEqualTo(typeNameOf<String>())
-        assertThat(emailProperty.type).isEqualTo(typeNameOf<List<String?>>())
+        assertThat(nameProperty.type).isEqualTo(STRING)
+        assertThat(emailProperty.type).isEqualTo(LIST.parameterizedBy(STRING.copy(nullable = true)))
     }
 
     @Test
@@ -400,8 +398,8 @@ internal class KotlinCodeGenTest {
 
         val (firstName, lastName, friends) = type.propertySpecs
 
-        assertThat(firstName.type).isEqualTo(typeNameOf<String?>())
-        assertThat(lastName.type).isEqualTo(typeNameOf<String?>())
+        assertThat(firstName.type).isEqualTo(STRING.copy(nullable = true))
+        assertThat(lastName.type).isEqualTo(STRING.copy(nullable = true))
         val personClass = ClassName.bestGuess("com.netflix.graphql.dgs.codegen.tests.generated.types.Person")
         val friendsType = LIST.parameterizedBy(personClass.copy(nullable = true)).copy(nullable = true)
         assertThat(friends.type).isEqualTo(friendsType)
@@ -439,7 +437,6 @@ internal class KotlinCodeGenTest {
         val nestedType = dataTypes[1].members[0] as TypeSpec
         assertThat(nestedType.name).isEqualTo("Engine")
         assertThat(nestedType.propertySpecs).filteredOn("name", "performance").extracting("type.simpleName").containsExactly("Performance")
-
     }
 
     @Test
@@ -518,10 +515,8 @@ internal class KotlinCodeGenTest {
         assertThat(type.propertySpecs).extracting("name").contains("genre")
     }
 
-
     @Test
     fun generateToStringMethodForInputTypes() {
-
         val schema = """
             type Query {
                 movies(filter: MovieFilter)

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinEntitiesClientApiGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinEntitiesClientApiGenTest.kt
@@ -26,7 +26,6 @@ class KotlinEntitiesClientApiGenTest {
 
     val basePackageName = "com.netflix.graphql.dgs.codegen.tests.generated"
 
-    @ExperimentalStdlibApi
     @Test
     fun generateForEntities() {
         val schema = """
@@ -61,8 +60,6 @@ class KotlinEntitiesClientApiGenTest {
         assertThat((representations[0].members[0] as TypeSpec).propertySpecs).extracting("name").containsExactlyInAnyOrder("__typename", "movieId")
     }
 
-
-    @ExperimentalStdlibApi
     @Test
     fun generateForEntitiesWithArraysAndNestedKeys() {
         val schema = """
@@ -97,7 +94,6 @@ class KotlinEntitiesClientApiGenTest {
                 .toString().contains("List<com.netflix.graphql.dgs.codegen.tests.generated.client.ActorRepresentation>")
     }
 
-    @ExperimentalStdlibApi
     @Test
     fun generateForEntitiesWithNestedKeys() {
         val schema = """
@@ -145,7 +141,6 @@ class KotlinEntitiesClientApiGenTest {
         assertThat((representations[2].members[0] as TypeSpec).propertySpecs).extracting("name").containsExactlyInAnyOrder("__typename", "movie", "actor")
     }
 
-    @ExperimentalStdlibApi
     @Test
     fun generateForEntitiesWithMultipleKeyEntities() {
         val schema = """
@@ -183,7 +178,6 @@ class KotlinEntitiesClientApiGenTest {
         assertThat((representations[1].members[0] as TypeSpec).propertySpecs).extracting("name").containsExactlyInAnyOrder("__typename", "name")
     }
 
-        @ExperimentalStdlibApi
     @Test
     fun generateForEntitiesWithNestedComplexKeys() {
         val schema = """
@@ -219,7 +213,6 @@ class KotlinEntitiesClientApiGenTest {
         assertThat((representations[1].members[0] as TypeSpec).propertySpecs).extracting("name").containsExactlyInAnyOrder("__typename", "name", "age")
     }
 
-    @ExperimentalStdlibApi
     @Test
     fun testScalarsInEntities() {
         val schema = """

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/SchemaMergingTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/SchemaMergingTest.kt
@@ -23,7 +23,6 @@ import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Test
 import java.nio.file.Paths
 
-@ExperimentalStdlibApi
 class SchemaMergingTest {
     @Test
     fun mergeSchemasJava() {

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ClassnameShortenerTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ClassnameShortenerTest.kt
@@ -25,7 +25,7 @@ import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import java.util.stream.Stream
 
-internal class ClassnameShortenerTest {
+class ClassnameShortenerTest {
     @ParameterizedTest
     @MethodSource("inputAndExpectedProvider")
     fun shorten(input: String, expected: String) {


### PR DESCRIPTION
typeNameOf from KotlinPoet is annotated with ExperimentalStdlibApi, so
requires all callers also opt-in or also be annotated with
ExperimentalStdlibApi. Usage of this one helper was causing a
proliferation of classes and methods to be annotated, when most of the
actual usage of typeNameOf was not really much more concise; other than
the tests, there were no instances of nullable or parameterized types,
so switching to the asTypeName extension method on KClass is not too
verbose.