### PR TITLE
Remove usage of ExperimentalStdlibApi annotation

### DIFF
--- a/graphql-dgs-codegen-gradle/src/main/kotlin/com/netflix/graphql/dgs/codegen/gradle/CodegenPlugin.kt
+++ b/graphql-dgs-codegen-gradle/src/main/kotlin/com/netflix/graphql/dgs/codegen/gradle/CodegenPlugin.kt
@@ -24,8 +24,6 @@ import org.gradle.api.plugins.JavaPlugin
 import org.gradle.api.plugins.JavaPluginConvention
 import org.gradle.api.tasks.SourceSet
 
-
-@ExperimentalStdlibApi
 class CodegenPlugin : Plugin<Project> {
     override fun apply(project: Project) {
         project.plugins.apply(JavaPlugin::class.java)

--- a/graphql-dgs-codegen-gradle/src/main/kotlin/com/netflix/graphql/dgs/codegen/gradle/GenerateJavaTask.kt
+++ b/graphql-dgs-codegen-gradle/src/main/kotlin/com/netflix/graphql/dgs/codegen/gradle/GenerateJavaTask.kt
@@ -31,7 +31,6 @@ import org.slf4j.LoggerFactory
 import java.io.File
 import java.nio.file.Paths
 
-@ExperimentalStdlibApi
 open class GenerateJavaTask : DefaultTask() {
 
     private val LOGGER = LoggerFactory.getLogger("DgsCodegenPlugin")


### PR DESCRIPTION
As of e4262e5, the annotation is no longer necessary.