### PR TITLE
Fix input type code generation for enum fields with default values

### DIFF
--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/DataTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/DataTypeGenerator.kt
@@ -25,10 +25,6 @@ import com.netflix.graphql.dgs.codegen.shouldSkip
 import com.squareup.javapoet.*
 import graphql.language.*
 import graphql.language.TypeName
-import java.time.LocalDate
-import java.time.LocalDateTime
-import java.time.LocalTime
-import java.time.OffsetDateTime
 import javax.lang.model.element.Modifier
 
 class DataTypeGenerator(config: CodeGenConfig) : BaseDataTypeGenerator(config.packageNameTypes, config) {
@@ -58,26 +54,23 @@ class InputTypeGenerator(config: CodeGenConfig) : BaseDataTypeGenerator(config.p
         val name = definition.name
 
         val fieldDefinitions = definition.inputValueDefinitions.map {
-            var defaultValue: Any
-            if (it.defaultValue != null) {
-                    defaultValue = when (it.defaultValue) {
-                        is BooleanValue -> (it.defaultValue as BooleanValue).isValue
-                        is IntValue -> (it.defaultValue as graphql.language.IntValue).value
-                        is StringValue -> (it.defaultValue as graphql.language.StringValue).value
-                        is FloatValue -> (it.defaultValue as graphql.language.FloatValue).value
-                        else -> it.defaultValue
-                    }
-                Field(it.name, typeUtils.findReturnType(it.type), defaultValue)
-            } else {
-                Field(it.name, typeUtils.findReturnType(it.type))
+            val defaultValue = it.defaultValue?.let { defVal ->
+                when (defVal) {
+                    is BooleanValue -> CodeBlock.of("\$L", defVal.isValue)
+                    is IntValue -> CodeBlock.of("\$L", defVal.value)
+                    is StringValue -> CodeBlock.of("\$S", defVal.value)
+                    is FloatValue -> CodeBlock.of("\$L", defVal.value)
+                    is EnumValue -> CodeBlock.of("\$T.\$N", typeUtils.findReturnType(it.type), defVal.name)
+                    else -> CodeBlock.of("\$L", defVal)
+                }
             }
-
+            Field(it.name, typeUtils.findReturnType(it.type), defaultValue)
         }.plus(extensions.flatMap { it.inputValueDefinitions }.map { Field(it.name, typeUtils.findReturnType(it.type)) })
         return generate(name, emptyList(), fieldDefinitions, true)
     }
 }
 
-internal data class Field(val name: String, val type: com.squareup.javapoet.TypeName, val initialValue: Any? = null)
+internal data class Field(val name: String, val type: com.squareup.javapoet.TypeName, val initialValue: CodeBlock? = null)
 
 abstract class BaseDataTypeGenerator(internal val packageName: String, config: CodeGenConfig) {
     internal val typeUtils = TypeUtils(packageName, config)
@@ -290,20 +283,12 @@ abstract class BaseDataTypeGenerator(internal val packageName: String, config: C
     }
 
     private fun addFieldWithGetterAndSetter(returnType: com.squareup.javapoet.TypeName?, fieldDefinition: Field, javaType: TypeSpec.Builder) {
-        if (fieldDefinition.initialValue != null) {
-            var initializerBlock = if (fieldDefinition.type.toString().contains("String")) {
-                "\"${fieldDefinition.initialValue}\""
-            } else {
-                "${fieldDefinition.initialValue}"
-            }
-            val field = FieldSpec.builder(fieldDefinition.type, fieldDefinition.name).addModifiers(Modifier.PRIVATE)
-                .initializer(initializerBlock)
-                .build()
-            javaType.addField(field)
+        val field = if (fieldDefinition.initialValue != null) {
+            FieldSpec.builder(fieldDefinition.type, fieldDefinition.name).addModifiers(Modifier.PRIVATE).initializer(fieldDefinition.initialValue).build()
         } else {
-            val field = FieldSpec.builder(returnType, ReservedKeywordSanitizer.sanitize(fieldDefinition.name)).addModifiers(Modifier.PRIVATE).build()
-            javaType.addField(field)
+            FieldSpec.builder(returnType, ReservedKeywordSanitizer.sanitize(fieldDefinition.name)).addModifiers(Modifier.PRIVATE).build()
         }
+        javaType.addField(field)
 
         val getterName = "get${fieldDefinition.name[0].toUpperCase()}${fieldDefinition.name.substring(1)}"
         javaType.addMethod(MethodSpec.methodBuilder(getterName).addModifiers(Modifier.PUBLIC).returns(returnType).addStatement("return \$N", ReservedKeywordSanitizer.sanitize(fieldDefinition.name)).build())

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/EntitiesRepresentationTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/EntitiesRepresentationTypeGenerator.kt
@@ -21,6 +21,7 @@ package com.netflix.graphql.dgs.codegen.generators.java
 import com.netflix.graphql.dgs.codegen.CodeGenConfig
 import com.netflix.graphql.dgs.codegen.CodeGenResult
 import com.squareup.javapoet.ClassName
+import com.squareup.javapoet.CodeBlock
 import graphql.language.*
 
 
@@ -48,7 +49,7 @@ class EntitiesRepresentationTypeGenerator(val config: CodeGenConfig): BaseDataTy
         }
         var result = CodeGenResult()
         // generate representations of entity types that have @key, including the __typename field, and the  key fields
-        val typeName = Field("__typename", ClassName.get(String::class.java), definition.name)
+        val typeName = Field("__typename", ClassName.get(String::class.java), CodeBlock.of("\$S", definition.name))
         val fieldDefinitions = definition.fieldDefinitions
                 .filter {
                     keyFields.containsKey(it.name)

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinEntitiesRepresentationTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinEntitiesRepresentationTypeGenerator.kt
@@ -20,6 +20,7 @@ package com.netflix.graphql.dgs.codegen.generators.kotlin
 
 import com.netflix.graphql.dgs.codegen.CodeGenConfig
 import com.netflix.graphql.dgs.codegen.KotlinCodeGenResult
+import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.LIST
 import com.squareup.kotlinpoet.ParameterizedTypeName
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
@@ -47,7 +48,7 @@ class KotlinEntitiesRepresentationTypeGenerator(private val config: CodeGenConfi
 
         var result = KotlinCodeGenResult()
         // generate representations of entity types that have @key, including the __typename field, and the  key fields
-        val typeName = Field("__typename", STRING, false, definition.name)
+        val typeName = Field("__typename", STRING, false, CodeBlock.of("%S", definition.name))
         val fieldDefinitions= definition.fieldDefinitions
                 .filter {
                     keyFields.containsKey(it.name)

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
@@ -568,6 +568,38 @@ class CodeGenTest {
     }
 
     @Test
+    fun generateInputWithDefaultValueForEnum() {
+        val schema = """
+            enum Color {
+                red
+            }
+            
+            input ColorFilter {
+                color: Color = red
+            }
+        """.trimIndent()
+
+        val (dataTypes, _, enumTypes) = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName)).generate() as CodeGenResult
+        assertThat(dataTypes).hasSize(1)
+
+        val data = dataTypes[0]
+        assertThat(data.packageName).isEqualTo(typesPackageName)
+
+        val type = data.typeSpec
+        assertThat(type.name).isEqualTo("ColorFilter")
+
+        val fields = type.fieldSpecs
+        assertThat(fields).hasSize(1)
+
+        val colorField = fields[0]
+        assertThat(colorField.name).isEqualTo("color")
+        assertThat(colorField.type.toString()).isEqualTo("$typesPackageName.Color")
+        assertThat(colorField.initializer.toString()).isEqualTo("$typesPackageName.Color.red")
+
+         assertCompiles(enumTypes + dataTypes)
+    }
+
+    @Test
     fun generateToInputStringMethodForInputTypes() {
 
         val schema = """


### PR DESCRIPTION
This fixes #19.

Initializers were set verbatim as strings which discards type information. This isn't a problem for literals and strings (special treatment for them was already done), but `enum`s need more information about the actual type. By using `CodeBlock`s the custom special handling of strings can be avoided and type information for `enum`s is preserved (AFAICT up to the point that imports for types are created automatically).