### PR TITLE
Support for interfaces multi-inheritance via graphql-java 16

### DIFF
--- a/graphql-dgs-codegen-core/build.gradle
+++ b/graphql-dgs-codegen-core/build.gradle
@@ -45,8 +45,8 @@ dependencies {
     implementation "com.netflix.graphql.dgs:graphql-dgs-client:latest.release"
     implementation "com.squareup:javapoet:1.13.+"
     implementation "com.squareup:kotlinpoet:1.7.+"
-    implementation "com.graphql-java:graphql-java:14.0"
-    implementation("com.github.ajalt.clikt:clikt:3.1.+")
+    implementation "com.graphql-java:graphql-java:16.+"
+    implementation "com.github.ajalt.clikt:clikt:3.1.+"
     implementation "com.fasterxml.jackson.core:jackson-annotations:2.12.+"
 
     testImplementation "com.google.testing.compile:compile-testing:0.+"

--- a/graphql-dgs-codegen-core/dependencies.lock
+++ b/graphql-dgs-codegen-core/dependencies.lock
@@ -1,6 +1,6 @@
 {
     "apiDependenciesMetadata": {
-        "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
+        "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.4.30"
         }
     },
@@ -12,13 +12,13 @@
             "locked": "3.1.0"
         },
         "com.graphql-java:graphql-java": {
-            "locked": "14.0"
+            "locked": "16.2"
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
-            "locked": "3.3.0"
+            "locked": "3.5.1"
         },
         "com.netflix.graphql.dgs:graphql-dgs-client": {
-            "locked": "3.3.0"
+            "locked": "3.5.1"
         },
         "com.squareup:javapoet": {
             "locked": "1.13.0"
@@ -26,7 +26,7 @@
         "com.squareup:kotlinpoet": {
             "locked": "1.7.2"
         },
-        "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
+        "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.4.30"
         }
     },
@@ -38,13 +38,13 @@
             "locked": "3.1.0"
         },
         "com.graphql-java:graphql-java": {
-            "locked": "14.0"
+            "locked": "16.2"
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
-            "locked": "3.3.0"
+            "locked": "3.5.1"
         },
         "com.netflix.graphql.dgs:graphql-dgs-client": {
-            "locked": "3.3.0"
+            "locked": "3.5.1"
         },
         "com.squareup:javapoet": {
             "locked": "1.13.0"
@@ -52,7 +52,7 @@
         "com.squareup:kotlinpoet": {
             "locked": "1.7.2"
         },
-        "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
+        "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.4.30"
         }
     },
@@ -79,13 +79,13 @@
             "locked": "3.1.0"
         },
         "com.graphql-java:graphql-java": {
-            "locked": "14.0"
+            "locked": "16.2"
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
-            "locked": "3.3.0"
+            "locked": "3.5.1"
         },
         "com.netflix.graphql.dgs:graphql-dgs-client": {
-            "locked": "3.3.0"
+            "locked": "3.5.1"
         },
         "com.squareup:javapoet": {
             "locked": "1.13.0"
@@ -93,7 +93,7 @@
         "com.squareup:kotlinpoet": {
             "locked": "1.7.2"
         },
-        "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
+        "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.4.30"
         }
     },
@@ -111,13 +111,13 @@
             "locked": "1.1.2"
         },
         "com.graphql-java:graphql-java": {
-            "locked": "14.0"
+            "locked": "16.2"
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
-            "locked": "3.3.0"
+            "locked": "3.5.1"
         },
         "com.netflix.graphql.dgs:graphql-dgs-client": {
-            "locked": "3.3.0"
+            "locked": "3.5.1"
         },
         "com.squareup:javapoet": {
             "locked": "1.13.0"
@@ -128,7 +128,7 @@
         "org.assertj:assertj-core": {
             "locked": "3.11.1"
         },
-        "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
+        "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.4.30"
         },
         "org.junit.jupiter:junit-jupiter": {
@@ -155,13 +155,13 @@
             "locked": "1.1.2"
         },
         "com.graphql-java:graphql-java": {
-            "locked": "14.0"
+            "locked": "16.2"
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
-            "locked": "3.3.0"
+            "locked": "3.5.1"
         },
         "com.netflix.graphql.dgs:graphql-dgs-client": {
-            "locked": "3.3.0"
+            "locked": "3.5.1"
         },
         "com.squareup:javapoet": {
             "locked": "1.13.0"
@@ -172,7 +172,7 @@
         "org.assertj:assertj-core": {
             "locked": "3.11.1"
         },
-        "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
+        "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.4.30"
         },
         "org.junit.jupiter:junit-jupiter": {
@@ -199,13 +199,13 @@
             "locked": "1.1.2"
         },
         "com.graphql-java:graphql-java": {
-            "locked": "14.0"
+            "locked": "16.2"
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
-            "locked": "3.3.0"
+            "locked": "3.5.1"
         },
         "com.netflix.graphql.dgs:graphql-dgs-client": {
-            "locked": "3.3.0"
+            "locked": "3.5.1"
         },
         "com.squareup:javapoet": {
             "locked": "1.13.0"
@@ -216,7 +216,7 @@
         "org.assertj:assertj-core": {
             "locked": "3.11.1"
         },
-        "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
+        "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.4.30"
         },
         "org.junit.jupiter:junit-jupiter": {

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
@@ -112,7 +112,7 @@ class CodeGen(private val config: CodeGenConfig) {
 
     private fun generateJavaClientEntitiesApi(definitions: MutableList<Definition<Definition<*>>>, document: Document): CodeGenResult {
         return if (config.generateClientApi) {
-            val federatedDefinitions = definitions.filterIsInstance<ObjectTypeDefinition>().filter { it.getDirective("key") != null }
+            val federatedDefinitions = definitions.filterIsInstance<ObjectTypeDefinition>().filter { it.hasDirective("key") }
             ClientApiGenerator(config, document).generateEntities(federatedDefinitions)
         } else CodeGenResult()
     }
@@ -121,7 +121,7 @@ class CodeGen(private val config: CodeGenConfig) {
         return if (config.generateClientApi) {
             val generatedRepresentations = mutableMapOf<String, Any>()
             return definitions.filterIsInstance<ObjectTypeDefinition>()
-                    .filter { it.getDirective("key") != null }
+                    .filter { it.hasDirective("key") }
                     .map { d ->
                         EntitiesRepresentationTypeGenerator(config).generate(d, document, generatedRepresentations)
                     }.fold(CodeGenResult()) { t: CodeGenResult, u: CodeGenResult -> t.merge(u) }
@@ -195,7 +195,7 @@ class CodeGen(private val config: CodeGenConfig) {
 
     private fun generateKotlinClientEntitiesApi(definitions: MutableList<Definition<Definition<*>>>, document: Document): KotlinCodeGenResult {
         return if (config.generateClientApi) {
-            val federatedDefinitions = definitions.filterIsInstance<ObjectTypeDefinition>().filter { it.getDirective("key") != null }
+            val federatedDefinitions = definitions.filterIsInstance<ObjectTypeDefinition>().filter { it.hasDirective("key") }
             KotlinClientApiGenerator(config, document).generateEntities(federatedDefinitions)
         } else KotlinCodeGenResult()
     }
@@ -204,7 +204,7 @@ class CodeGen(private val config: CodeGenConfig) {
         return if (config.generateClientApi) {
             val generatedRepresentations = mutableMapOf<String, Any>()
             return definitions.filterIsInstance<ObjectTypeDefinition>()
-                    .filter { it.getDirective("key") != null }
+                    .filter { it.hasDirective("key") }
                     .map { d ->
                         KotlinEntitiesRepresentationTypeGenerator(config).generate(d, document, generatedRepresentations)
                     }.fold(KotlinCodeGenResult()) { t: KotlinCodeGenResult, u: KotlinCodeGenResult -> t.merge(u) }

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ClientApiGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ClientApiGenerator.kt
@@ -47,7 +47,7 @@ class ClientApiGenerator(private val config: CodeGenConfig, private val document
 
             var entitiesRootProjection = CodeGenResult()
             // generate for federation types, if present
-            val federatedTypes = definitions.filter { it.getDirective("key") != null }
+            val federatedTypes = definitions.filter { it.hasDirective("key") }
             if (federatedTypes.isNotEmpty()) {
                 // create entities root projection
                 entitiesRootProjection = createEntitiesRootProjection(federatedTypes)

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/EntitiesRepresentationTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/EntitiesRepresentationTypeGenerator.kt
@@ -26,9 +26,9 @@ import graphql.language.*
 
 
 @Suppress("UNCHECKED_CAST")
-class EntitiesRepresentationTypeGenerator(val config: CodeGenConfig): BaseDataTypeGenerator(config.packageNameClient, config) {
+class EntitiesRepresentationTypeGenerator(val config: CodeGenConfig) : BaseDataTypeGenerator(config.packageNameClient, config) {
     fun generate(definition: ObjectTypeDefinition, document: Document, generatedRepresentations: MutableMap<String, Any>): CodeGenResult {
-        if(config.skipEntityQueries) {
+        if (config.skipEntityQueries) {
             return CodeGenResult()
         }
 
@@ -36,7 +36,7 @@ class EntitiesRepresentationTypeGenerator(val config: CodeGenConfig): BaseDataTy
         if (generatedRepresentations.containsKey(name)) {
             return CodeGenResult()
         }
-        val directiveArg = (definition.getDirective("key").argumentsByName["fields"]?.value as StringValue).value
+        val directiveArg = definition.getDirectives("key").map { it.argumentsByName["fields"]?.value as StringValue }.map { it.value }
         val keyFields = parseKeyDirectiveValue(directiveArg)
         return generateRepresentations(definition, document, generatedRepresentations, keyFields)
     }
@@ -58,7 +58,7 @@ class EntitiesRepresentationTypeGenerator(val config: CodeGenConfig): BaseDataTy
                     val type = findType(it.type, document)
                     if (type != null && type is ObjectTypeDefinition) {
                         val representationType = typeUtils.findReturnType(it.type).toString().replace(type.name, "${type.name}Representation")
-                        if (! generatedRepresentations.containsKey(name)) {
+                        if (!generatedRepresentations.containsKey(name)) {
                             result = generateRepresentations(type, document, generatedRepresentations, keyFields[it.name] as Map<String, Any>)
                         }
                         generatedRepresentations["${type.name}Representation"] = representationType
@@ -82,10 +82,14 @@ class EntitiesRepresentationTypeGenerator(val config: CodeGenConfig): BaseDataTy
         }
     }
 
-    private fun parseKeyDirectiveValue(keyDirective: String): Map<String, Any> {
-        data class Node (val key: String, val map: MutableMap<String, Any>, val parent: Node?)
-        val sanitizedKeys =  keyDirective.map { if (it == '{' || it == '}') " $it "  else "$it" }
-        val keys = sanitizedKeys.joinToString("", "", "").split(" ")
+    private fun parseKeyDirectiveValue(keyDirective: List<String>): Map<String, Any> {
+        data class Node(val key: String, val map: MutableMap<String, Any>, val parent: Node?)
+
+        val keys = keyDirective.map { ds ->
+            ds.map { if (it == '{' || it == '}') " $it " else "$it" }
+                    .joinToString("", "", "")
+                    .split(" ")
+        }.flatten()
 
         // handle simple keys and nested keys by constructing the path to each  key
         // e.g. type Movie @key(fields: "movieId") or type MovieCast @key(fields: movie { movieId } actors { name } }

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/ClientApiGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/ClientApiGenerator.kt
@@ -48,7 +48,7 @@ class KotlinClientApiGenerator(private val config: CodeGenConfig, private val do
 
         var entitiesRootProjection = KotlinCodeGenResult()
         // generate for federation types, if present
-        val federatedTypes = definitions.filter { it.getDirective("key") != null }
+        val federatedTypes = definitions.filter { it.hasDirective("key") }
         if (federatedTypes.isNotEmpty()) {
             // create entities root projection
             entitiesRootProjection = createEntitiesRootProjection(federatedTypes)

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
@@ -22,6 +22,7 @@ import com.google.common.truth.Truth
 import com.netflix.graphql.dgs.codegen.generators.java.disableJsonTypeInfoAnnotation
 import com.squareup.javapoet.ClassName
 import com.squareup.javapoet.ParameterizedTypeName
+import com.squareup.javapoet.JavaFile
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -596,7 +597,7 @@ class CodeGenTest {
         assertThat(colorField.type.toString()).isEqualTo("$typesPackageName.Color")
         assertThat(colorField.initializer.toString()).isEqualTo("$typesPackageName.Color.red")
 
-         assertCompiles(enumTypes + dataTypes)
+        assertCompiles(enumTypes + dataTypes)
     }
 
     @Test
@@ -623,7 +624,7 @@ class CodeGenTest {
         assertThat(colorField.name).isEqualTo("names")
         assertThat(colorField.initializer.toString()).isEqualTo("java.util.Collections.emptyList()")
 
-         assertCompiles(dataTypes)
+        assertCompiles(dataTypes)
     }
 
     @Test
@@ -650,7 +651,7 @@ class CodeGenTest {
         assertThat(colorField.name).isEqualTo("names")
         assertThat(colorField.initializer.toString()).isEqualTo("""java.util.Arrays.asList("A", "B")""")
 
-         assertCompiles(dataTypes)
+        assertCompiles(dataTypes)
     }
 
     @Test
@@ -677,7 +678,7 @@ class CodeGenTest {
         assertThat(colorField.name).isEqualTo("numbers")
         assertThat(colorField.initializer.toString()).isEqualTo("""java.util.Arrays.asList(1, 2, 3)""")
 
-         assertCompiles(dataTypes)
+        assertCompiles(dataTypes)
     }
 
     @Test
@@ -693,7 +694,7 @@ class CodeGenTest {
             }
         """.trimIndent()
 
-        val (dataTypes,_, enumTypes) = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, writeToFiles = true)).generate() as CodeGenResult
+        val (dataTypes, _, enumTypes) = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, writeToFiles = true)).generate() as CodeGenResult
         assertThat(dataTypes).hasSize(1)
 
         val data = dataTypes[0]
@@ -709,7 +710,7 @@ class CodeGenTest {
         assertThat(colorField.name).isEqualTo("colors")
         assertThat(colorField.initializer.toString()).isEqualTo("""java.util.Arrays.asList(Color.red)""")
 
-         assertCompiles(dataTypes + enumTypes)
+        assertCompiles(dataTypes + enumTypes)
     }
 
     @Test
@@ -1029,7 +1030,7 @@ class CodeGenTest {
             type Query {
                 people: [Person]
             }
-            
+
             type Person {
                 firstname: String
                 lastname: String
@@ -1222,4 +1223,237 @@ class CodeGenTest {
         assertThat(dataTypes[0].packageName).isEqualTo("$basePackageName.mytypes")
         assertCompiles(dataTypes)
     }
+
+    @Test
+    fun generateDataClassWithInterfaceInheritance() {
+
+        val schema = """
+            type Query {
+                people: [Person]
+            }
+
+            interface Person {
+                firstname: String
+                lastname: String
+            }
+
+            interface Employee implements Person {
+                firstname: String
+                lastname: String
+                company: String
+            }
+
+            type Talent implements Employee {
+                firstname: String
+                lastname: String
+                company: String
+                imdbProfile: String
+            }
+
+        """.trimIndent()
+
+        val (dataTypes, interfaces) =
+                CodeGen(CodeGenConfig(
+                        schemas = setOf(schema),
+                        packageName = basePackageName)
+                ).generate() as CodeGenResult
+
+        assertThat(dataTypes.size).isEqualTo(1)
+        val talent = dataTypes.single().typeSpec
+        //Check data class
+        assertThat(talent.name).isEqualTo("Talent")
+        assertThat(talent.fieldSpecs.size).isEqualTo(4)
+        assertThat(talent.fieldSpecs)
+                .extracting("name")
+                .contains("firstname", "lastname", "company", "imdbProfile")
+
+        val annotation = talent.annotations.single()
+        Truth.assertThat(annotation).isEqualTo(disableJsonTypeInfoAnnotation())
+
+        assertThat(interfaces).hasSize(2)
+
+        val person = interfaces[0]
+        Truth.assertThat(person.toString()).isEqualTo(
+                """
+               |package com.netflix.graphql.dgs.codegen.tests.generated.types;
+               |
+               |import java.lang.String;
+               |
+               |public interface Person {
+               |  String getFirstname();
+               |
+               |  void setFirstname(String firstname);
+               |
+               |  String getLastname();
+               |
+               |  void setLastname(String lastname);
+               |}
+               |""".trimMargin())
+
+        val employee = interfaces[1]
+        Truth.assertThat(employee.toString()).isEqualTo(
+                """
+               |package com.netflix.graphql.dgs.codegen.tests.generated.types;
+               |
+               |import com.fasterxml.jackson.annotation.JsonSubTypes;
+               |import com.fasterxml.jackson.annotation.JsonTypeInfo;
+               |import java.lang.String;
+               |
+               |@JsonTypeInfo(
+               |    use = JsonTypeInfo.Id.NAME,
+               |    include = JsonTypeInfo.As.PROPERTY,
+               |    property = "__typename"
+               |)
+               |@JsonSubTypes(@JsonSubTypes.Type(value = Talent.class, name = "Talent"))
+               |public interface Employee {
+               |  String getFirstname();
+               |
+               |  void setFirstname(String firstname);
+               |
+               |  String getLastname();
+               |
+               |  void setLastname(String lastname);
+               |
+               |  String getCompany();
+               |
+               |  void setCompany(String company);
+               |}
+               |""".trimMargin())
+
+        Truth.assertThat(JavaFile.builder("$basePackageName.types", talent).build().toString()).isEqualTo(
+                """
+                |package com.netflix.graphql.dgs.codegen.tests.generated.types;
+                |
+                |import com.fasterxml.jackson.annotation.JsonTypeInfo;
+                |import java.lang.Object;
+                |import java.lang.Override;
+                |import java.lang.String;
+                |
+                |@JsonTypeInfo(
+                |    use = JsonTypeInfo.Id.NONE
+                |)
+                |public class Talent implements com.netflix.graphql.dgs.codegen.tests.generated.types.Employee {
+                |  private String firstname;
+                |
+                |  private String lastname;
+                |
+                |  private String company;
+                |
+                |  private String imdbProfile;
+                |
+                |  public Talent() {
+                |  }
+                |
+                |  public Talent(String firstname, String lastname, String company, String imdbProfile) {
+                |    this.firstname = firstname;
+                |    this.lastname = lastname;
+                |    this.company = company;
+                |    this.imdbProfile = imdbProfile;
+                |  }
+                |
+                |  public String getFirstname() {
+                |    return firstname;
+                |  }
+                |
+                |  public void setFirstname(String firstname) {
+                |    this.firstname = firstname;
+                |  }
+                |
+                |  public String getLastname() {
+                |    return lastname;
+                |  }
+                |
+                |  public void setLastname(String lastname) {
+                |    this.lastname = lastname;
+                |  }
+                |
+                |  public String getCompany() {
+                |    return company;
+                |  }
+                |
+                |  public void setCompany(String company) {
+                |    this.company = company;
+                |  }
+                |
+                |  public String getImdbProfile() {
+                |    return imdbProfile;
+                |  }
+                |
+                |  public void setImdbProfile(String imdbProfile) {
+                |    this.imdbProfile = imdbProfile;
+                |  }
+                |
+                |  @Override
+                |  public String toString() {
+                |    return "Talent{" + "firstname='" + firstname + "'," +"lastname='" + lastname + "'," +"company='" + company + "'," +"imdbProfile='" + imdbProfile + "'" +"}";
+                |  }
+                |
+                |  @Override
+                |  public boolean equals(Object o) {
+                |    if (this == o) return true;
+                |        if (o == null || getClass() != o.getClass()) return false;
+                |        Talent that = (Talent) o;
+                |        return java.util.Objects.equals(firstname, that.firstname) &&
+                |                            java.util.Objects.equals(lastname, that.lastname) &&
+                |                            java.util.Objects.equals(company, that.company) &&
+                |                            java.util.Objects.equals(imdbProfile, that.imdbProfile);
+                |  }
+                |
+                |  @Override
+                |  public int hashCode() {
+                |    return java.util.Objects.hash(firstname, lastname, company, imdbProfile);
+                |  }
+                |
+                |  public static com.netflix.graphql.dgs.codegen.tests.generated.types.Talent.Builder newBuilder() {
+                |    return new Builder();
+                |  }
+                |
+                |  public static class Builder {
+                |    private String firstname;
+                |
+                |    private String lastname;
+                |
+                |    private String company;
+                |
+                |    private String imdbProfile;
+                |
+                |    public Talent build() {
+                |                  com.netflix.graphql.dgs.codegen.tests.generated.types.Talent result = new com.netflix.graphql.dgs.codegen.tests.generated.types.Talent();
+                |                      result.firstname = this.firstname;
+                |          result.lastname = this.lastname;
+                |          result.company = this.company;
+                |          result.imdbProfile = this.imdbProfile;
+                |                      return result;
+                |    }
+                |
+                |    public com.netflix.graphql.dgs.codegen.tests.generated.types.Talent.Builder firstname(
+                |        String firstname) {
+                |      this.firstname = firstname;
+                |      return this;
+                |    }
+                |
+                |    public com.netflix.graphql.dgs.codegen.tests.generated.types.Talent.Builder lastname(
+                |        String lastname) {
+                |      this.lastname = lastname;
+                |      return this;
+                |    }
+                |
+                |    public com.netflix.graphql.dgs.codegen.tests.generated.types.Talent.Builder company(
+                |        String company) {
+                |      this.company = company;
+                |      return this;
+                |    }
+                |
+                |    public com.netflix.graphql.dgs.codegen.tests.generated.types.Talent.Builder imdbProfile(
+                |        String imdbProfile) {
+                |      this.imdbProfile = imdbProfile;
+                |      return this;
+                |    }
+                |  }
+                |}
+                |""".trimMargin())
+
+        assertCompiles(dataTypes + interfaces)
+    }
+
 }

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
@@ -142,7 +142,7 @@ class KotlinCodeGenTest {
             }
         """.trimIndent()
 
-        val (dataTypes) = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName,  language = Language.KOTLIN)).generate() as KotlinCodeGenResult
+        val (dataTypes) = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, language = Language.KOTLIN)).generate() as KotlinCodeGenResult
         assertThat(dataTypes.size).isEqualTo(1)
         val type = dataTypes[0].members[0] as TypeSpec
         assertThat(type.name).isEqualTo("Person")
@@ -162,7 +162,7 @@ class KotlinCodeGenTest {
             }
         """.trimIndent()
 
-        val (dataTypes) = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = "com.mypackage",  language = Language.KOTLIN)).generate() as KotlinCodeGenResult
+        val (dataTypes) = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = "com.mypackage", language = Language.KOTLIN)).generate() as KotlinCodeGenResult
 
         assertThat(dataTypes.size).isEqualTo(1)
         assertThat(dataTypes[0].name).isEqualTo("Person")
@@ -1009,7 +1009,7 @@ class KotlinCodeGenTest {
         """.trimIndent()
 
         val (dataTypes) = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, language = Language.KOTLIN,
-            typeMapping = mapOf(Pair("LocalTime", "java.time.LocalDateTime"), Pair("LocalDate", "java.lang.Integer")))).generate() as KotlinCodeGenResult
+                typeMapping = mapOf(Pair("LocalTime", "java.time.LocalDateTime"), Pair("LocalDate", "java.lang.Integer")))).generate() as KotlinCodeGenResult
         val type = dataTypes[0].members[0] as TypeSpec
         assertThat(type.funSpecs).extracting("name").contains("toString")
 
@@ -1244,4 +1244,118 @@ class KotlinCodeGenTest {
         assertThat(dataTypes[0].name).isEqualTo("Person")
         assertThat(dataTypes[0].packageName).isEqualTo("$basePackageName.mytypes")
     }
+
+    @Test
+    fun generateDataClassWithInterfaceInheritance() {
+
+        val schema = """
+            type Query {
+                people: [Person]
+            }
+
+            interface Person {
+                firstname: String
+                lastname: String
+            }
+
+            interface Employee implements Person {
+                firstname: String
+                lastname: String
+                company: String
+            }
+
+            type Talent implements Employee {
+                firstname: String
+                lastname: String
+                company: String
+                imdbProfile: String
+            }
+
+        """.trimIndent()
+
+        val (dataTypes, interfaces) =
+                CodeGen(CodeGenConfig(
+                        schemas = setOf(schema),
+                        packageName = basePackageName,
+                        language = Language.KOTLIN)
+                ).generate() as KotlinCodeGenResult
+
+        val type = dataTypes[0].members[0] as TypeSpec
+
+        //Check data class
+        assertThat(dataTypes.size).isEqualTo(1)
+        assertThat(type.name).isEqualTo("Talent")
+        assertThat(type.propertySpecs.size).isEqualTo(4)
+        assertThat(type.propertySpecs).extracting("name").contains("firstname", "lastname", "company", "imdbProfile")
+        assertThat(type.primaryConstructor?.parameters?.get(0)?.modifiers).contains(KModifier.OVERRIDE)
+        assertThat(type.superinterfaces.keys)
+                .contains(ClassName
+                        .bestGuess("com.netflix.graphql.dgs.codegen.tests.generated.types.Employee"))
+
+
+        //Check interface
+        assertThat(interfaces.size).isEqualTo(2)
+
+        val personInterfaceType = interfaces[0].members[0] as TypeSpec
+        Truth.assertThat(FileSpec.get("$basePackageName.types", personInterfaceType).toString()).isEqualTo(
+                """
+                |package com.netflix.graphql.dgs.codegen.tests.generated.types
+                |
+                |import kotlin.String
+                |
+                |public interface Person {
+                |  public val firstname: String?
+                |
+                |  public val lastname: String?
+                |}
+                |""".trimMargin())
+
+        val employeeInterfaceType = interfaces[1].members[0] as TypeSpec
+        Truth.assertThat(FileSpec.get("$basePackageName.types", employeeInterfaceType).toString()).isEqualTo(
+                """
+                |package com.netflix.graphql.dgs.codegen.tests.generated.types
+                |
+                |import com.fasterxml.jackson.`annotation`.JsonSubTypes
+                |import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+                |import kotlin.String
+                |
+                |@JsonTypeInfo(
+                |  use = JsonTypeInfo.Id.NAME,
+                |  include = JsonTypeInfo.As.PROPERTY,
+                |  property = "__typename"
+                |)
+                |@JsonSubTypes(value = [
+                |  JsonSubTypes.Type(value = Talent::class, name = "Talent")
+                |])
+                |public interface Employee {
+                |  public val firstname: String?
+                |
+                |  public val lastname: String?
+                |
+                |  public val company: String?
+                |}
+                |""".trimMargin())
+
+        Truth.assertThat(FileSpec.get("$basePackageName.types", type).toString()).isEqualTo(
+                """
+                |package com.netflix.graphql.dgs.codegen.tests.generated.types
+                |
+                |import com.fasterxml.jackson.`annotation`.JsonProperty
+                |import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+                |import kotlin.String
+                |
+                |@JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
+                |public data class Talent(
+                |  @JsonProperty("firstname")
+                |  public override val firstname: String? = null,
+                |  @JsonProperty("lastname")
+                |  public override val lastname: String? = null,
+                |  @JsonProperty("company")
+                |  public override val company: String? = null,
+                |  @JsonProperty("imdbProfile")
+                |  public val imdbProfile: String? = null
+                |) : Employee
+                |""".trimMargin())
+    }
+
 }

--- a/graphql-dgs-codegen-gradle/dependencies.lock
+++ b/graphql-dgs-codegen-gradle/dependencies.lock
@@ -4,9 +4,6 @@
             "project": true
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
-            "locked": "1.4.30"
-        },
-        "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
@@ -21,9 +18,6 @@
             "locked": "1.4.30"
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
-            "locked": "1.4.30"
-        },
-        "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
@@ -46,9 +40,6 @@
             "locked": "3.11.1"
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
-            "locked": "1.4.30"
-        },
-        "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
@@ -72,9 +63,6 @@
             "locked": "3.11.1"
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
-            "locked": "1.4.30"
-        },
-        "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
@@ -107,7 +95,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
-            "locked": "14.0"
+            "locked": "16.2"
         },
         "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core": {
             "project": true
@@ -116,13 +104,13 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
-            "locked": "3.3.0"
+            "locked": "3.5.1"
         },
         "com.netflix.graphql.dgs:graphql-dgs-client": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
-            "locked": "3.3.0"
+            "locked": "3.5.1"
         },
         "com.squareup:javapoet": {
             "firstLevelTransitive": [
@@ -140,9 +128,6 @@
             "locked": "3.11.1"
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
-            "locked": "1.4.30"
-        },
-        "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
@@ -160,9 +145,6 @@
             "project": true
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
-            "locked": "1.4.30"
-        },
-        "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
@@ -201,7 +183,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
-            "locked": "14.0"
+            "locked": "16.2"
         },
         "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core": {
             "project": true
@@ -210,13 +192,13 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
-            "locked": "3.3.0"
+            "locked": "3.5.1"
         },
         "com.netflix.graphql.dgs:graphql-dgs-client": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
-            "locked": "3.3.0"
+            "locked": "3.5.1"
         },
         "com.squareup:javapoet": {
             "firstLevelTransitive": [
@@ -231,9 +213,6 @@
             "locked": "1.7.2"
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
-            "locked": "1.4.30"
-        },
-        "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
@@ -251,9 +230,6 @@
             "locked": "3.11.1"
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
-            "locked": "1.4.30"
-        },
-        "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
@@ -277,9 +253,6 @@
             "locked": "3.11.1"
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
-            "locked": "1.4.30"
-        },
-        "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
@@ -312,7 +285,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
-            "locked": "14.0"
+            "locked": "16.2"
         },
         "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core": {
             "project": true
@@ -321,13 +294,13 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
-            "locked": "3.3.0"
+            "locked": "3.5.1"
         },
         "com.netflix.graphql.dgs:graphql-dgs-client": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
-            "locked": "3.3.0"
+            "locked": "3.5.1"
         },
         "com.squareup:javapoet": {
             "firstLevelTransitive": [
@@ -345,9 +318,6 @@
             "locked": "3.11.1"
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
-            "locked": "1.4.30"
-        },
-        "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],


### PR DESCRIPTION
This commit fixes #41 by adding support to multi interface inheritance
via graphql-java 16.0. For example.

```
interface Person {
    firstname: String
    lastname: String
}

interface Employee implements Person {
    firstname: String
    lastname: String
    company: String
}

type Talent implements Employee {
    firstname: String
    lastname: String
    company: String
    imdbProfile: String
}
```