### PR TITLE
Added Date to LocalDate default mapping

### DIFF
--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/TypeUtils.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/TypeUtils.kt
@@ -42,6 +42,7 @@ class TypeUtils(private val packageName: String, private val config: CodeGenConf
         "LocalDate" to ClassName.get(LocalDate::class.java),
         "LocalDateTime" to ClassName.get(LocalDateTime::class.java),
         "TimeZone" to ClassName.get(String::class.java),
+        "Date" to ClassName.get(LocalDate::class.java),
         "DateTime" to ClassName.get(OffsetDateTime::class.java),
         "Currency" to ClassName.get(Currency::class.java),
         "Instant" to ClassName.get(Instant::class.java),

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinTypeUtils.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinTypeUtils.kt
@@ -54,6 +54,7 @@ class KotlinTypeUtils(private val packageName: String, val config: CodeGenConfig
         "TimeZone" to STRING,
         "Currency" to Currency::class.asTypeName(),
         "Instant" to Instant::class.asTypeName(),
+        "Date" to LocalDate::class.asTypeName(),
         "DateTime" to OffsetDateTime::class.asTypeName(),
         "RelayPageInfo" to PageInfo::class.asTypeName(),
         "PageInfo" to PageInfo::class.asTypeName(),


### PR DESCRIPTION
I noticed #43 and I in my local project I have a mapping for `Date` to `LocalDate` as well.

Probably more people will face this and expect `Date` mapped to `LocalDate` automatically.
This PR adds that default mapping.


PS: A little bit of inconsistency is that `DateTime` is already mapped to `OffsetDateTime` and not `LocalDateTime. 
So for that reason I can image this PR not to be accepted. In that case just close it; no hard feelings ;-) 