### PR TITLE
Removed println about type mapping found

### DIFF
--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/TypeUtils.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/TypeUtils.kt
@@ -100,7 +100,6 @@ class TypeUtils(private val packageName: String, private val config: CodeGenConf
 
     private fun TypeName.toJavaTypeName(): JavaTypeName {
         if (name in config.typeMapping) {
-            println("Found mapping for type: $name")
             val mappedType = config.typeMapping.getValue(name)
             return ClassName.bestGuess(mappedType)
         }


### PR DESCRIPTION
When running my application / build I was getting:

```
> Task :generateJava
Found mapping for type: PageInfo
Found mapping for type: PageInfo
Found mapping for type: PageInfo
Found mapping for type: PageInfo
Found mapping for type: PageInfo
Found mapping for type: PageInfo
Found mapping for type: PageInfo
Found mapping for type: PageInfo
Found mapping for type: PageInfo
Found mapping for type: PageInfo
Found mapping for type: PageInfo
Found mapping for type: PageInfo
Found mapping for type: PageInfo
Found mapping for type: PageInfo
Found mapping for type: PageInfo
Found mapping for type: PageInfo
Found mapping for type: PageInfo
Found mapping for type: PageInfo
Found mapping for type: PageInfo
Found mapping for type: PageInfo
Found mapping for type: Date
Found mapping for type: Date
Found mapping for type: Date
Found mapping for type: Date
Found mapping for type: PageInfo
Found mapping for type: PageInfo
Found mapping for type: PageInfo
Found mapping for type: PageInfo
Found mapping for type: PageInfo
Found mapping for type: PageInfo
Found mapping for type: PageInfo
Found mapping for type: PageInfo
Found mapping for type: PageInfo
Found mapping for type: PageInfo
Found mapping for type: PageInfo
Found mapping for type: PageInfo
Found mapping for type: PageInfo
Found mapping for type: PageInfo
Found mapping for type: Date
Found mapping for type: Date
```

which is quite verbose in my opinion ;-)