### PR TITLE
Limit types to generated client api

### DIFF
--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
@@ -29,6 +29,9 @@ import java.nio.file.Path
 import java.nio.file.Paths
 
 class CodeGen(private val config: CodeGenConfig) {
+    lateinit var document: Document
+    lateinit var requiredTypeCollector: RequiredTypeCollector
+
     fun generate(): Any {
         if (config.writeToFiles) {
             config.outputDir.toFile().deleteRecursively()
@@ -75,23 +78,14 @@ class CodeGen(private val config: CodeGenConfig) {
     }
 
     private fun generateForSchema(schema: String): CodeGenResult {
-        val document: Document = Parser().parseDocument(schema)
+        document = Parser().parseDocument(schema)
+        requiredTypeCollector = RequiredTypeCollector(document, queries = config.includeQueries)
         val definitions = document.definitions
-        val dataTypesResult = generateJavaDataType(definitions, document)
+        val dataTypesResult = generateJavaDataType(definitions)
         val inputTypesResult = generateJavaInputType(definitions)
-
-        val interfacesResult = definitions.filterIsInstance<InterfaceTypeDefinition>()
-                .map { InterfaceGenerator(config).generate(it, document) }
-                .fold(CodeGenResult()) { t: CodeGenResult, u: CodeGenResult -> t.merge(u) }
-
-        val unionsResult = definitions.filterIsInstance<UnionTypeDefinition>()
-                .map { UnionTypeGenerator(config).generate(it) }
-                .fold(CodeGenResult()) { t: CodeGenResult, u: CodeGenResult -> t.merge(u) }
-
-        val enumsResult = definitions.filterIsInstance<EnumTypeDefinition>()
-                .map { EnumTypeGenerator(config).generate(it) }
-                .fold(CodeGenResult()) { t: CodeGenResult, u: CodeGenResult -> t.merge(u) }
-
+        val interfacesResult = generateJavaInterfaces(definitions)
+        val unionsResult = generateJavaUnions(definitions)
+        val enumsResult = generateJavaEnums(definitions)
         val dataFetchersResult = generateJavaDataFetchers(definitions)
         val client = generateJavaClientApi(definitions, document)
         val entitiesClient = generateJavaClientEntitiesApi(definitions, document)
@@ -99,6 +93,35 @@ class CodeGen(private val config: CodeGenConfig) {
         val constantsClass = ConstantsGenerator(config, document).generate()
 
         return dataTypesResult.merge(dataFetchersResult).merge(inputTypesResult).merge(unionsResult).merge(enumsResult).merge(interfacesResult).merge(client).merge(entitiesClient).merge(entitiesRepresentationsTypes).merge(constantsClass)
+    }
+
+    private fun generateJavaEnums(definitions: MutableList<Definition<Definition<*>>>): CodeGenResult {
+        if(!config.generateDataTypes) {
+            return CodeGenResult()
+        }
+        return definitions.filterIsInstance<EnumTypeDefinition>()
+            .map { EnumTypeGenerator(config).generate(it) }
+            .fold(CodeGenResult()) { t: CodeGenResult, u: CodeGenResult -> t.merge(u) }
+    }
+
+    private fun generateJavaUnions(definitions: MutableList<Definition<Definition<*>>>): CodeGenResult {
+        if(!config.generateDataTypes) {
+            return CodeGenResult()
+        }
+
+        return definitions.filterIsInstance<UnionTypeDefinition>()
+            .map { UnionTypeGenerator(config).generate(it) }
+            .fold(CodeGenResult()) { t: CodeGenResult, u: CodeGenResult -> t.merge(u) }
+    }
+
+    private fun generateJavaInterfaces(definitions: MutableList<Definition<Definition<*>>>): CodeGenResult {
+        if(!config.generateDataTypes) {
+            return CodeGenResult()
+        }
+
+        return definitions.filterIsInstance<InterfaceTypeDefinition>()
+            .map { InterfaceGenerator(config).generate(it, document) }
+            .fold(CodeGenResult()) { t: CodeGenResult, u: CodeGenResult -> t.merge(u) }
     }
 
     private fun generateJavaClientApi(definitions: MutableList<Definition<Definition<*>>>, document: Document): CodeGenResult {
@@ -135,7 +158,11 @@ class CodeGen(private val config: CodeGenConfig) {
                 .fold(CodeGenResult()) { t: CodeGenResult, u: CodeGenResult -> t.merge(u) }
     }
 
-    private fun generateJavaDataType(definitions: List<Definition<Definition<*>>>, document: Document): CodeGenResult {
+    private fun generateJavaDataType(definitions: List<Definition<Definition<*>>>): CodeGenResult {
+        if(!config.generateDataTypes) {
+            return CodeGenResult()
+        }
+
         return definitions.filterIsInstance<ObjectTypeDefinition>()
                 .filter { it !is ObjectTypeExtensionDefinition && it.name != "Query" && it.name != "Mutation" && it.name != "RelayPageInfo" }
                 .map {
@@ -144,8 +171,13 @@ class CodeGen(private val config: CodeGenConfig) {
     }
 
     private fun generateJavaInputType(definitions: List<Definition<Definition<*>>>): CodeGenResult {
-        return definitions.filterIsInstance<InputObjectTypeDefinition>()
-                .filter { it !is InputObjectTypeExtensionDefinition }
+
+
+        val inputTypes = definitions.filterIsInstance<InputObjectTypeDefinition>()
+            .filter { it !is InputObjectTypeExtensionDefinition }
+            .filter { config.generateDataTypes || requiredTypeCollector.requiredTypes.contains(it.name) }
+
+        return inputTypes
                 .map { d ->
                     InputTypeGenerator(config).generate(d, findInputExtensions(d.name, definitions))
                 }.fold(CodeGenResult()) { t: CodeGenResult, u: CodeGenResult -> t.merge(u) }
@@ -158,11 +190,11 @@ class CodeGen(private val config: CodeGenConfig) {
             definitions.filterIsInstance<InputObjectTypeExtensionDefinition>().filter { name == it.name }
 
     private fun generateKotlinForSchema(schema: String): KotlinCodeGenResult {
-        val document: Document = Parser().parseDocument(schema)
+        document = Parser().parseDocument(schema)
         val definitions = document.definitions
 
-        val datatypesResult = generateKotlinDataTypes(definitions, document)
-        val inputTypes = generateKotlinInputTypes(definitions, document)
+        val datatypesResult = generateKotlinDataTypes(definitions)
+        val inputTypes = generateKotlinInputTypes(definitions)
 
         val interfacesResult = definitions.filterIsInstance<InterfaceTypeDefinition>()
                 .map { KotlinInterfaceTypeGenerator(config).generate(it, document) }
@@ -178,14 +210,14 @@ class CodeGen(private val config: CodeGenConfig) {
 
         val constantsClass = KotlinConstantsGenerator(config, document).generate()
 
-        val client = generateKotlinClientApi(definitions, document)
-        val entitiesClient = generateKotlinClientEntitiesApi(definitions, document)
-        val entitiesRepresentationsTypes = generateKotlinClientEntitiesRepresentations(definitions, document)
+        val client = generateKotlinClientApi(definitions)
+        val entitiesClient = generateKotlinClientEntitiesApi(definitions)
+        val entitiesRepresentationsTypes = generateKotlinClientEntitiesRepresentations(definitions)
 
         return datatypesResult.merge(inputTypes).merge(interfacesResult).merge(unionResult).merge(enumsResult).merge(client).merge(entitiesClient).merge(entitiesRepresentationsTypes).merge(constantsClass)
     }
 
-    private fun generateKotlinClientApi(definitions: List<Definition<Definition<*>>>, document: Document): KotlinCodeGenResult {
+    private fun generateKotlinClientApi(definitions: List<Definition<Definition<*>>>): KotlinCodeGenResult {
         return if (config.generateClientApi) {
             definitions.filterIsInstance<ObjectTypeDefinition>().filter { it.name == "Query" || it.name == "Mutation" }
                     .map { KotlinClientApiGenerator(config, document).generate(it) }
@@ -193,14 +225,14 @@ class CodeGen(private val config: CodeGenConfig) {
         } else KotlinCodeGenResult()
     }
 
-    private fun generateKotlinClientEntitiesApi(definitions: MutableList<Definition<Definition<*>>>, document: Document): KotlinCodeGenResult {
+    private fun generateKotlinClientEntitiesApi(definitions: MutableList<Definition<Definition<*>>>): KotlinCodeGenResult {
         return if (config.generateClientApi) {
             val federatedDefinitions = definitions.filterIsInstance<ObjectTypeDefinition>().filter { it.hasDirective("key") }
             KotlinClientApiGenerator(config, document).generateEntities(federatedDefinitions)
         } else KotlinCodeGenResult()
     }
 
-    private fun generateKotlinClientEntitiesRepresentations(definitions: MutableList<Definition<Definition<*>>>, document: Document): KotlinCodeGenResult {
+    private fun generateKotlinClientEntitiesRepresentations(definitions: MutableList<Definition<Definition<*>>>): KotlinCodeGenResult {
         return if (config.generateClientApi) {
             val generatedRepresentations = mutableMapOf<String, Any>()
             return definitions.filterIsInstance<ObjectTypeDefinition>()
@@ -211,7 +243,7 @@ class CodeGen(private val config: CodeGenConfig) {
         } else KotlinCodeGenResult()
     }
 
-    private fun generateKotlinInputTypes(definitions: List<Definition<Definition<*>>>, document: Document): KotlinCodeGenResult {
+    private fun generateKotlinInputTypes(definitions: List<Definition<Definition<*>>>): KotlinCodeGenResult {
         return definitions.filterIsInstance<InputObjectTypeDefinition>()
                 .map {
                     KotlinInputTypeGenerator(config, document).generate(it, findInputExtensions(it.name, definitions))
@@ -219,7 +251,7 @@ class CodeGen(private val config: CodeGenConfig) {
                 .fold(KotlinCodeGenResult()) { t: KotlinCodeGenResult, u: KotlinCodeGenResult -> t.merge(u) }
     }
 
-    private fun generateKotlinDataTypes(definitions: List<Definition<Definition<*>>>, document: Document): KotlinCodeGenResult {
+    private fun generateKotlinDataTypes(definitions: List<Definition<Definition<*>>>): KotlinCodeGenResult {
         return definitions.filterIsInstance<ObjectTypeDefinition>()
                 .filter { it !is ObjectTypeExtensionDefinition && it.name != "Query" && it.name != "Mutation" && it.name != "RelayPageInfo" }
                 .map {
@@ -250,8 +282,7 @@ data class CodeGenConfig(
         val includeMutations: Set<String> = emptySet(),
         val skipEntityQueries: Boolean = false,
         val shortProjectionNames: Boolean = false,
-
-
+        val generateDataTypes: Boolean = true,
 ) {
     val packageNameClient: String
         get() = "${packageName}.${subPackageNameClient}"
@@ -261,6 +292,27 @@ data class CodeGenConfig(
 
     val packageNameTypes: String
         get() = "${packageName}.${subPackageNameTypes}"
+
+    override fun toString(): String {
+        return """
+            --output-dir=${outputDir}
+            --package-name=${packageName}
+            --sub-package-name-client=${subPackageNameClient}
+            --sub-package-name-datafetchers=${subPackageNameDatafetchers}
+            --sub-package-name-types=${subPackageNameTypes}
+            ${if(generateBoxedTypes)"--generate-boxed-types" else ""}
+            ${if(writeToFiles) "--write-to-disk" else ""}
+            --language=${language}
+            ${if(generateClientApi) "--generate-client" else ""}
+            ${if(generateDataTypes) "--generate-data-types" else "--skip-generate-data-types" }
+            ${includeQueries.joinToString("\n") { "--include-query=${it}" }}
+            ${includeMutations.joinToString("\n") { "--include-mutation=${it}" }}
+            ${if(skipEntityQueries) "--skip-entities" else ""}
+            ${typeMapping.map { "--type-mapping ${it.key}=${it.value}"}.joinToString("\n")}           
+            ${if(shortProjectionNames) "--short-projection-names" else ""}
+            ${schemas.joinToString(" ")}
+        """.trimIndent()
+    }
 }
 
 enum class Language {

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
@@ -79,7 +79,7 @@ class CodeGen(private val config: CodeGenConfig) {
 
     private fun generateForSchema(schema: String): CodeGenResult {
         document = Parser().parseDocument(schema)
-        requiredTypeCollector = RequiredTypeCollector(document, queries = config.includeQueries)
+        requiredTypeCollector = RequiredTypeCollector(document, queries = config.includeQueries, mutations = config.includeMutations)
         val definitions = document.definitions
         val dataTypesResult = generateJavaDataType(definitions)
         val inputTypesResult = generateJavaInputType(definitions)
@@ -190,7 +190,7 @@ class CodeGen(private val config: CodeGenConfig) {
 
     private fun generateKotlinForSchema(schema: String): KotlinCodeGenResult {
         document = Parser().parseDocument(schema)
-        requiredTypeCollector = RequiredTypeCollector(document, queries = config.includeQueries)
+        requiredTypeCollector = RequiredTypeCollector(document, queries = config.includeQueries, mutations = config.includeMutations)
         val definitions = document.definitions
 
         val datatypesResult = generateKotlinDataTypes(definitions)

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGenCli.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGenCli.kt
@@ -31,15 +31,26 @@ import java.nio.file.Paths
 class CodeGenCli : CliktCommand("Generate Java sources for SCHEMA file(s)") {
 
     private val schemas by argument().file(mustExist = true).multiple()
-    private val output by option("--output-dir", "-o", help = "Output directory").file(canBeFile = false, canBeDir = true).default(File("generated"))
+    private val output by option("--output-dir", "-o", help = "Output directory").file(
+        canBeFile = false,
+        canBeDir = true
+    ).default(File("generated"))
     private val packageName by option("--package-name", "-p", help = "Package name for generated types")
     private val subPackageNameClient by option("--sub-package-name-client", help = "Sub package name for generated client").default("client")
     private val subPackageNameDatafetchers by option("--sub-package-name-datafetchers", help = "Sub package name for generated datafetchers").default("datafetchers")
     private val subPackageNameTypes by option("--sub-package-name-types", help = "Sub package name for generated types").default("types")
-    private val writeFiles by option("--write-to-disk", "-w", help = "Write files to disk").flag("--console-output", default = true)
-    private val language by option("--language", "-l", help = "Output language").choice("java", "kotlin").default("java")
     private val generateBoxedTypes by option("--generate-boxed-types", "-b", help = "Genereate boxed types").flag(default = false)
+    private val writeFiles by option("--write-to-disk", "-w", help = "Write files to disk").flag(
+        "--console-output",
+        default = true
+    )
+    private val language by option("--language", "-l", help = "Output language").choice("java", "kotlin", ignoreCase = true)
+        .default("java")
     private val generateClient by option("--generate-client", "-c", help = "Genereate client api").flag(default = false)
+    private val generateDataTypes by option(
+        "--generate-data-types",
+        help = "Generate data types. Not needed when only generating an API"
+    ).flag("--skip-generate-data-types", default = true)
     private val includeQueries by option("--include-query").multiple().unique()
     private val includeMutations by option("--include-mutation").multiple().unique()
     private val skipEntityQueries by option("--skip-entities").flag()
@@ -48,9 +59,9 @@ class CodeGenCli : CliktCommand("Generate Java sources for SCHEMA file(s)") {
 
 
     override fun run() {
-        val inputSchemas = if(schemas.isEmpty()) {
+        val inputSchemas = if (schemas.isEmpty()) {
             val defaultSchemaPath = Paths.get("src", "main", "resources", "schema")
-            if(defaultSchemaPath.toFile().exists()) {
+            if (defaultSchemaPath.toFile().exists()) {
                 echo("No schema files or directories specified, defaulting to src/main/resources/schema")
                 setOf(defaultSchemaPath.toFile())
             } else {
@@ -62,9 +73,9 @@ class CodeGenCli : CliktCommand("Generate Java sources for SCHEMA file(s)") {
 
         val generate = CodeGen(
                 if(packageName != null) {
-                    CodeGenConfig(schemaFiles = inputSchemas, writeToFiles = writeFiles, outputDir = output.toPath(), packageName = packageName!!, subPackageNameClient = subPackageNameClient, subPackageNameDatafetchers = subPackageNameDatafetchers, subPackageNameTypes = subPackageNameTypes, language = Language.valueOf(language.toUpperCase()), generateBoxedTypes = generateBoxedTypes, generateClientApi = generateClient, includeQueries = includeQueries, includeMutations = includeMutations, skipEntityQueries = skipEntityQueries, typeMapping = typeMapping, shortProjectionNames = shortProjectionNames)
+                    CodeGenConfig(schemaFiles = inputSchemas, writeToFiles = writeFiles, outputDir = output.toPath(), packageName = packageName!!, subPackageNameClient = subPackageNameClient, subPackageNameDatafetchers = subPackageNameDatafetchers, subPackageNameTypes = subPackageNameTypes, language = Language.valueOf(language.toUpperCase()), generateBoxedTypes = generateBoxedTypes, generateClientApi = generateClient, includeQueries = includeQueries, includeMutations = includeMutations, skipEntityQueries = skipEntityQueries, typeMapping = typeMapping, shortProjectionNames = shortProjectionNames, generateDataTypes = generateDataTypes)
                 } else {
-                    CodeGenConfig(schemaFiles = inputSchemas, writeToFiles = writeFiles, outputDir = output.toPath(), subPackageNameClient = subPackageNameClient, subPackageNameDatafetchers = subPackageNameDatafetchers, subPackageNameTypes = subPackageNameTypes, language = Language.valueOf(language.toUpperCase()), generateBoxedTypes = generateBoxedTypes, generateClientApi = generateClient, includeQueries = includeQueries, includeMutations = includeMutations, skipEntityQueries = skipEntityQueries, typeMapping = typeMapping, shortProjectionNames = shortProjectionNames)
+                    CodeGenConfig(schemaFiles = inputSchemas, writeToFiles = writeFiles, outputDir = output.toPath(), subPackageNameClient = subPackageNameClient, subPackageNameDatafetchers = subPackageNameDatafetchers, subPackageNameTypes = subPackageNameTypes, language = Language.valueOf(language.toUpperCase()), generateBoxedTypes = generateBoxedTypes, generateClientApi = generateClient, includeQueries = includeQueries, includeMutations = includeMutations, skipEntityQueries = skipEntityQueries, typeMapping = typeMapping, shortProjectionNames = shortProjectionNames, generateDataTypes = generateDataTypes)
                 }
         ).generate()
 

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/RequiredTypeCollector.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/RequiredTypeCollector.kt
@@ -1,0 +1,94 @@
+/*
+ *
+ *  Copyright 2020 Netflix, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package com.netflix.graphql.dgs.codegen
+
+import graphql.language.*
+import graphql.util.TraversalControl
+import graphql.util.TraverserContext
+
+class RequiredTypeCollector(private val document: Document, queries: Set<String> = emptySet(), mutations: Set<String> = emptySet()) {
+    val requiredTypes: Set<String>
+
+    init {
+        val query = document.definitions.filterIsInstance<ObjectTypeDefinition>()
+            .find { it.name == "Query" }?.fieldDefinitions?.filter { queries.contains(it.name) }
+
+        if(query != null) {
+
+
+            val nodeTraverserResult = NodeTraverser().postOrder(object : NodeVisitorStub() {
+                override fun visitInputObjectTypeDefinition(
+                    node: InputObjectTypeDefinition,
+                    context: TraverserContext<Node<Node<*>>>
+                ): TraversalControl {
+                    println(node)
+
+                    val currentAccumulate = context.getNewAccumulate<Set<String>>()
+                    if (currentAccumulate == null) {
+                        context.setAccumulate(setOf(node.name))
+                    } else {
+                        context.setAccumulate(currentAccumulate.plus(node.name))
+                    }
+
+                    node.inputValueDefinitions.map { it.type.findTypeDefinition(document)?.accept(context, this) }
+
+                    return TraversalControl.CONTINUE
+                }
+
+                override fun visitEnumTypeDefinition(
+                    node: EnumTypeDefinition,
+                    context: TraverserContext<Node<Node<*>>>
+                ): TraversalControl {
+                    println(node)
+
+
+                    val currentAccumulate = context.getNewAccumulate<Set<String>>()
+                    if (currentAccumulate == null) {
+                        context.setAccumulate(setOf(node.name))
+                    } else {
+                        context.setAccumulate(currentAccumulate.plus(node.name))
+                    }
+
+                    return TraversalControl.CONTINUE
+                }
+
+                override fun visitInputValueDefinition(
+                    node: InputValueDefinition,
+                    context: TraverserContext<Node<Node<*>>>
+                ): TraversalControl {
+                    println(node)
+
+                    node.type.findTypeDefinition(document)?.accept(context, this)
+
+
+                    return super.visitInputValueDefinition(node, context)
+                }
+            }, query)
+
+            requiredTypes = if(nodeTraverserResult != null && nodeTraverserResult is Set<*>) {
+                nodeTraverserResult as Set<String>
+            } else {
+                emptySet()
+            }
+        } else {
+            requiredTypes = emptySet()
+        }
+
+    }
+}

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ClientApiGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ClientApiGenerator.kt
@@ -58,6 +58,7 @@ class ClientApiGenerator(private val config: CodeGenConfig, private val document
     private fun createQueryClass(it: FieldDefinition, operation: String): JavaFile {
         val javaType = TypeSpec.classBuilder("${it.name.capitalize()}GraphQLQuery")
                 .addModifiers(Modifier.PUBLIC).superclass(ClassName.get(GraphQLQuery::class.java))
+        println("Generating ${it.name.capitalize()}GraphQLQuery")
         javaType.addMethod(
                 MethodSpec.methodBuilder("getOperationName")
                         .addModifiers(Modifier.PUBLIC)
@@ -124,10 +125,10 @@ class ClientApiGenerator(private val config: CodeGenConfig, private val document
     }
 
     private fun createRootProjection(type: TypeDefinition<*>, prefix: String): CodeGenResult {
-
         val clazzName = "${prefix}ProjectionRoot"
         val javaType = TypeSpec.classBuilder(clazzName)
                 .addModifiers(Modifier.PUBLIC).superclass(ClassName.get(BaseProjectionNode::class.java))
+        println("Generating ${prefix}ProjectionRoot")
 
         if(generatedClasses.contains(clazzName)) return CodeGenResult() else generatedClasses.add(clazzName)
 
@@ -284,6 +285,7 @@ class ClientApiGenerator(private val config: CodeGenConfig, private val document
     private fun createSubProjectionType(type: TypeDefinition<*>, parent: TypeSpec, root: TypeSpec, prefix: String, processedEdges: Set<Pair<String, String>>): Pair<TypeSpec.Builder, CodeGenResult>? {
         val className = ClassName.get(BaseSubProjectionNode::class.java)
         val clazzName = "${prefix}Projection"
+        println("generating: ${clazzName}")
         if(generatedClasses.contains(clazzName)) return null else generatedClasses.add(clazzName)
         val javaType = TypeSpec.classBuilder(clazzName)
                 .addModifiers(Modifier.PUBLIC).superclass(ParameterizedTypeName.get(className, ClassName.get(getPackageName(), parent.name), ClassName.get(getPackageName(), root.name)))

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/ClientApiGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/ClientApiGenTest.kt
@@ -43,7 +43,11 @@ class ClientApiGenTest {
         """.trimIndent()
 
 
-        val codeGenResult = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, generateClientApi = true)).generate() as CodeGenResult
+        val codeGenResult = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+            generateClientApi = true,
+        )).generate() as CodeGenResult
 
         assertThat(codeGenResult.queryTypes.size).isEqualTo(1)
         assertThat(codeGenResult.queryTypes[0].typeSpec.name).isEqualTo("PeopleGraphQLQuery")
@@ -66,7 +70,11 @@ class ClientApiGenTest {
         """.trimIndent()
 
 
-        val codeGenResult = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, generateClientApi = true)).generate() as CodeGenResult
+        val codeGenResult = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+            generateClientApi = true,
+        )).generate() as CodeGenResult
 
         assertThat(codeGenResult.queryTypes.size).isEqualTo(1)
         assertThat(codeGenResult.queryTypes[0].typeSpec.name).isEqualTo("UpdateMovieGraphQLQuery")
@@ -95,7 +103,11 @@ class ClientApiGenTest {
         """.trimIndent()
 
 
-        val codeGenResult = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, generateClientApi = true)).generate() as CodeGenResult
+        val codeGenResult = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+            generateClientApi = true,
+        )).generate() as CodeGenResult
 
         assertThat(codeGenResult.queryTypes.size).isEqualTo(1)
         assertThat(codeGenResult.queryTypes[0].typeSpec.name).isEqualTo("UpdateMovieGraphQLQuery")
@@ -118,7 +130,11 @@ class ClientApiGenTest {
         """.trimIndent()
 
 
-        val codeGenResult = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, generateClientApi = true)).generate() as CodeGenResult
+        val codeGenResult = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+            generateClientApi = true,
+        )).generate() as CodeGenResult
 
         assertThat(codeGenResult.clientProjections.size).isEqualTo(1)
         assertThat(codeGenResult.clientProjections[0].typeSpec.name).isEqualTo("PeopleProjectionRoot")
@@ -140,7 +156,11 @@ class ClientApiGenTest {
             }
         """.trimIndent()
 
-        val codeGenResult = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, generateClientApi = true)).generate() as CodeGenResult
+        val codeGenResult = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+            generateClientApi = true,
+        )).generate() as CodeGenResult
         assertThat(codeGenResult.clientProjections.size).isEqualTo(2)
         assertThat(codeGenResult.clientProjections[0].typeSpec.name).isEqualTo("PersonsProjectionRoot")
         assertThat(codeGenResult.clientProjections[1].typeSpec.name).isEqualTo("PersonsFriendsProjection")
@@ -174,7 +194,11 @@ class ClientApiGenTest {
             
         """.trimIndent()
 
-        val codeGenResult = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, generateClientApi = true)).generate() as CodeGenResult
+        val codeGenResult = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+            generateClientApi = true,
+        )).generate() as CodeGenResult
 
         assertThat(codeGenResult.clientProjections.size).isEqualTo(5)
         assertThat(codeGenResult.clientProjections[0].typeSpec.name).isEqualTo("SearchProjectionRoot")
@@ -239,7 +263,11 @@ class ClientApiGenTest {
             }
         """.trimIndent()
 
-        val codeGenResult = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, generateClientApi = true)).generate() as CodeGenResult
+        val codeGenResult = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+            generateClientApi = true,
+        )).generate() as CodeGenResult
         assertThat(codeGenResult.clientProjections[0].typeSpec.name).isEqualTo("PersonsProjectionRoot")
         assertThat(codeGenResult.clientProjections[1].typeSpec.name).isEqualTo("FriendsProjectionRoot")
 
@@ -265,7 +293,11 @@ class ClientApiGenTest {
             }
         """.trimIndent()
 
-        val codeGenResult = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, generateClientApi = true)).generate() as CodeGenResult
+        val codeGenResult = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+            generateClientApi = true,
+        )).generate() as CodeGenResult
         assertThat(codeGenResult.clientProjections[0].typeSpec.name).isEqualTo("PersonsProjectionRoot")
         assertThat(codeGenResult.clientProjections[1].typeSpec.name).isEqualTo("PersonsDetailsProjection")
         assertThat(codeGenResult.clientProjections[2].typeSpec.name).isEqualTo("DetailsProjectionRoot")
@@ -293,7 +325,11 @@ class ClientApiGenTest {
 
         """.trimIndent()
 
-        val codeGenResult = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, generateClientApi = true)).generate() as CodeGenResult
+        val codeGenResult = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+            generateClientApi = true,
+        )).generate() as CodeGenResult
 
         assertThat(codeGenResult.clientProjections.size).isEqualTo(2)
         assertThat(codeGenResult.clientProjections[0].typeSpec.name).isEqualTo("MoviesProjectionRoot")
@@ -323,7 +359,12 @@ class ClientApiGenTest {
 
         """.trimIndent()
 
-        val codeGenResult = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, generateClientApi = true, shortProjectionNames = true)).generate() as CodeGenResult
+        val codeGenResult = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+            generateClientApi = true,
+            shortProjectionNames = true,
+        )).generate() as CodeGenResult
 
         assertThat(codeGenResult.clientProjections.size).isEqualTo(3)
         assertThat(codeGenResult.clientProjections[0].typeSpec.name).isEqualTo("MoviesProjectionRoot")
@@ -349,7 +390,11 @@ class ClientApiGenTest {
         """.trimIndent()
 
 
-        val codeGenResult = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, generateClientApi = true)).generate() as CodeGenResult
+        val codeGenResult = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+            generateClientApi = true,
+        )).generate() as CodeGenResult
         assertThat(codeGenResult.queryTypes[0].typeSpec.typeSpecs[0].methodSpecs[1].name).isEqualTo("lastname")
 
         assertCompiles(codeGenResult.clientProjections.plus(codeGenResult.queryTypes))
@@ -375,7 +420,11 @@ class ClientApiGenTest {
         """.trimIndent()
 
 
-        val codeGenResult = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, generateClientApi = true)).generate() as CodeGenResult
+        val codeGenResult = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+            generateClientApi = true,
+        )).generate() as CodeGenResult
 
         assertThat(codeGenResult.queryTypes[0].typeSpec.typeSpecs[0].methodSpecs[1].name).isEqualTo("index")
 
@@ -401,7 +450,11 @@ class ClientApiGenTest {
             
         """.trimIndent()
 
-        val codeGenResult = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, generateClientApi = true)).generate() as CodeGenResult
+        val codeGenResult = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+            generateClientApi = true,
+        )).generate() as CodeGenResult
 
         assertThat(codeGenResult.queryTypes[0].typeSpec.name).isEqualTo("PersonSearchGraphQLQuery")
         assertThat(codeGenResult.queryTypes[0].typeSpec.typeSpecs[0].methodSpecs[1].name).isEqualTo("index")
@@ -429,7 +482,11 @@ class ClientApiGenTest {
             
         """.trimIndent()
 
-        val codeGenResult = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, generateClientApi = true)).generate() as CodeGenResult
+        val codeGenResult = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+            generateClientApi = true,
+        )).generate() as CodeGenResult
 
         assertThat(codeGenResult.queryTypes.size).isEqualTo(1)
         assertThat(codeGenResult.queryTypes[0].typeSpec.name).isEqualTo("PersonsGraphQLQuery")
@@ -460,7 +517,11 @@ class ClientApiGenTest {
             
         """.trimIndent()
 
-        val codeGenResult = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, generateClientApi = true)).generate() as CodeGenResult
+        val codeGenResult = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+            generateClientApi = true,
+        )).generate() as CodeGenResult
 
         assertThat(codeGenResult.queryTypes.size).isEqualTo(1)
         assertThat(codeGenResult.queryTypes[0].typeSpec.name).isEqualTo("SearchGraphQLQuery")
@@ -498,7 +559,11 @@ class ClientApiGenTest {
             
         """.trimIndent()
 
-        val codeGenResult = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, generateClientApi = true)).generate() as CodeGenResult
+        val codeGenResult = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+            generateClientApi = true,
+        )).generate() as CodeGenResult
 
         assertThat(codeGenResult.clientProjections.size).isEqualTo(3)
         assertThat(codeGenResult.clientProjections[0].typeSpec.name).isEqualTo("SearchProjectionRoot")
@@ -542,7 +607,11 @@ class ClientApiGenTest {
             
         """.trimIndent()
 
-        val codeGenResult = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, generateClientApi = true)).generate() as CodeGenResult
+        val codeGenResult = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+            generateClientApi = true,
+        )).generate() as CodeGenResult
 
         assertThat(codeGenResult.clientProjections.size).isEqualTo(4)
         assertThat(codeGenResult.clientProjections[0].typeSpec.name).isEqualTo("SearchProjectionRoot")
@@ -581,7 +650,11 @@ class ClientApiGenTest {
             }
         """.trimIndent()
 
-        val codeGenResult = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, generateClientApi = true)).generate() as CodeGenResult
+        val codeGenResult = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+            generateClientApi = true,
+        )).generate() as CodeGenResult
 
         assertThat(codeGenResult.clientProjections.size).isEqualTo(3)
         assertThat(codeGenResult.clientProjections[0].typeSpec.name).isEqualTo("SearchProjectionRoot")
@@ -620,7 +693,11 @@ class ClientApiGenTest {
             
         """.trimIndent()
 
-        val codeGenResult = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, generateClientApi = true)).generate() as CodeGenResult
+        val codeGenResult = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+            generateClientApi = true,
+        )).generate() as CodeGenResult
 
         assertThat(codeGenResult.clientProjections.size).isEqualTo(4)
         assertThat(codeGenResult.clientProjections[0].typeSpec.name).isEqualTo("SearchProjectionRoot")
@@ -682,7 +759,12 @@ class ClientApiGenTest {
 
         """.trimIndent()
 
-        val codeGenResult = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, generateClientApi = true, typeMapping = mapOf(Pair("Long", "java.lang.Long")))).generate() as CodeGenResult
+        val codeGenResult = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+            generateClientApi = true,
+            typeMapping = mapOf(Pair("Long", "java.lang.Long")),
+        )).generate() as CodeGenResult
         val projections = codeGenResult.clientProjections
         assertThat(projections.size).isEqualTo(1)
         assertCompiles(codeGenResult.clientProjections.plus(codeGenResult.queryTypes).plus(codeGenResult.dataTypes).plus(codeGenResult.enumTypes))
@@ -705,7 +787,12 @@ class ClientApiGenTest {
 
         """.trimIndent()
 
-        val codeGenResult = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, generateClientApi = true, typeMapping = mapOf(Pair("Long", "java.lang.Long")))).generate() as CodeGenResult
+        val codeGenResult = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+            generateClientApi = true,
+            typeMapping = mapOf(Pair("Long", "java.lang.Long")),
+        )).generate() as CodeGenResult
         val projections = codeGenResult.clientProjections
         assertThat(projections.size).isEqualTo(1)
         assertThat(projections[0].typeSpec.name).isEqualTo("PeopleProjectionRoot")
@@ -735,7 +822,12 @@ class ClientApiGenTest {
           }
         """.trimIndent()
 
-        val codeGenResult = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, generateClientApi = true, typeMapping = mapOf(Pair("Long", "java.lang.Long")))).generate() as CodeGenResult
+        val codeGenResult = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+            generateClientApi = true,
+            typeMapping = mapOf(Pair("Long", "java.lang.Long")),
+        )).generate() as CodeGenResult
         val projections = codeGenResult.clientProjections
         assertThat(projections.size).isEqualTo(2)
         assertThat(projections[1].typeSpec.name).isEqualTo("SearchMovieProjection")
@@ -756,7 +848,12 @@ class ClientApiGenTest {
         """.trimIndent()
 
 
-        val codeGenResult = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, generateClientApi = true, includeQueries = setOf("movieTitles"))).generate() as CodeGenResult
+        val codeGenResult = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+            generateClientApi = true,
+            includeQueries = setOf("movieTitles"),
+        )).generate() as CodeGenResult
 
         assertThat(codeGenResult.queryTypes.size).isEqualTo(1)
         assertThat(codeGenResult.queryTypes[0].typeSpec.name).isEqualTo("MovieTitlesGraphQLQuery")
@@ -775,7 +872,12 @@ class ClientApiGenTest {
         """.trimIndent()
 
 
-        val codeGenResult = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, generateClientApi = true, includeMutations = setOf("updateMovieTitle"))).generate() as CodeGenResult
+        val codeGenResult = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+            generateClientApi = true,
+            includeMutations = setOf("updateMovieTitle"),
+        )).generate() as CodeGenResult
 
         assertThat(codeGenResult.queryTypes.size).isEqualTo(1)
         assertThat(codeGenResult.queryTypes[0].typeSpec.name).isEqualTo("UpdateMovieTitleGraphQLQuery")
@@ -800,7 +902,11 @@ class ClientApiGenTest {
         """.trimIndent()
 
 
-        val codeGenResult = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, generateClientApi = true)).generate() as CodeGenResult
+        val codeGenResult = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+            generateClientApi = true,
+        )).generate() as CodeGenResult
 
         assertThat(codeGenResult.clientProjections.size).isEqualTo(1)
         assertThat(codeGenResult.clientProjections[0].typeSpec.name).isEqualTo("WeirdTypeProjectionRoot")
@@ -830,7 +936,11 @@ class ClientApiGenTest {
         """.trimIndent()
 
 
-        val codeGenResult = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, generateClientApi = true)).generate() as CodeGenResult
+        val codeGenResult = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+            generateClientApi = true,
+        )).generate() as CodeGenResult
 
         assertThat(codeGenResult.clientProjections.size).isEqualTo(2)
         val weirdType = codeGenResult.clientProjections.find { it.typeSpec.name == "NormalTypeWeirdTypeProjection" }

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
@@ -47,7 +47,10 @@ class CodeGenTest {
         """.trimIndent()
 
 
-        val (dataTypes) = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName)).generate() as CodeGenResult
+        val (dataTypes) = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+        )).generate() as CodeGenResult
 
         assertThat(dataTypes.size).isEqualTo(1)
         val typeSpec = dataTypes[0].typeSpec
@@ -71,7 +74,10 @@ class CodeGenTest {
             }
         """.trimIndent()
 
-        val (dataTypes) = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName)).generate() as CodeGenResult
+        val (dataTypes) = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+        )).generate() as CodeGenResult
         val typeSpec = dataTypes[0].typeSpec
         assertThat(typeSpec.fieldSpecs[0].type.toString()).isEqualTo("java.lang.Integer")
         assertThat(typeSpec.fieldSpecs[1].type.toString()).isEqualTo("java.lang.Boolean")
@@ -88,7 +94,10 @@ class CodeGenTest {
             }
         """.trimIndent()
 
-        val (dataTypes) = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName)).generate() as CodeGenResult
+        val (dataTypes) = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+        )).generate() as CodeGenResult
         val typeSpec = dataTypes[0].typeSpec
         assertThat(typeSpec.fieldSpecs[0].type.toString()).isEqualTo("int")
         assertThat(typeSpec.fieldSpecs[1].type.toString()).isEqualTo("boolean")
@@ -122,7 +131,10 @@ class CodeGenTest {
             }
         """.trimIndent()
 
-        val (dataTypes) = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName)).generate() as CodeGenResult
+        val (dataTypes) = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+        )).generate() as CodeGenResult
         val typeSpec = dataTypes[0].typeSpec
         assertThat(typeSpec.fieldSpecs[0].type.toString()).isEqualTo("java.util.List<java.lang.Integer>")
         assertThat(typeSpec.fieldSpecs[1].type.toString()).isEqualTo("java.util.List<java.lang.Boolean>")
@@ -143,7 +155,10 @@ class CodeGenTest {
             }
         """.trimIndent()
 
-        val (dataTypes) = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName)).generate() as CodeGenResult
+        val (dataTypes) = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+        )).generate() as CodeGenResult
 
         assertThat(dataTypes.size).isEqualTo(1)
         assertThat(dataTypes[0].typeSpec.name).isEqualTo("Person")
@@ -167,7 +182,10 @@ class CodeGenTest {
             }
         """.trimIndent()
 
-        val (dataTypes) = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName)).generate() as CodeGenResult
+        val (dataTypes) = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+        )).generate() as CodeGenResult
 
         assertThat(dataTypes.size).isEqualTo(1)
         assertThat(dataTypes[0].typeSpec.name).isEqualTo("Person")
@@ -188,7 +206,10 @@ class CodeGenTest {
             }
         """.trimIndent()
 
-        val (dataTypes) = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName)).generate() as CodeGenResult
+        val (dataTypes) = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+        )).generate() as CodeGenResult
 
         assertThat(dataTypes.size).isEqualTo(1)
         assertThat(dataTypes[0].typeSpec.name).isEqualTo("Person")
@@ -212,7 +233,10 @@ class CodeGenTest {
             }
         """.trimIndent()
 
-        val (dataTypes) = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName)).generate() as CodeGenResult
+        val (dataTypes) = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+        )).generate() as CodeGenResult
 
         assertThat(dataTypes.size).isEqualTo(1)
         assertThat(dataTypes[0].typeSpec.name).isEqualTo("Person")
@@ -239,7 +263,10 @@ class CodeGenTest {
             }
         """.trimIndent()
 
-        val (dataTypes) = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName)).generate() as CodeGenResult
+        val (dataTypes) = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+        )).generate() as CodeGenResult
 
         assertThat(dataTypes.size).isEqualTo(1)
         assertThat(dataTypes[0].typeSpec.name).isEqualTo("Person")
@@ -262,7 +289,10 @@ class CodeGenTest {
             }
         """.trimIndent()
 
-        val (dataTypes) = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = "com.mypackage")).generate() as CodeGenResult
+        val (dataTypes) = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = "com.mypackage",
+        )).generate() as CodeGenResult
 
         assertThat(dataTypes.size).isEqualTo(1)
         assertThat(dataTypes[0].typeSpec.name).isEqualTo("Person")
@@ -285,7 +315,10 @@ class CodeGenTest {
             }
         """.trimIndent()
 
-        val (dataTypes) = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName)).generate() as CodeGenResult
+        val (dataTypes) = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+        )).generate() as CodeGenResult
 
         assertThat(dataTypes.size).isEqualTo(1)
         assertThat(dataTypes[0].typeSpec.name).isEqualTo("Person")
@@ -312,7 +345,10 @@ class CodeGenTest {
             }
         """.trimIndent()
 
-        val (dataTypes) = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName)).generate() as CodeGenResult
+        val (dataTypes) = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+        )).generate() as CodeGenResult
 
         assertThat(dataTypes.size).isEqualTo(1)
         assertThat(dataTypes[0].typeSpec.name).isEqualTo("Person")
@@ -345,7 +381,10 @@ class CodeGenTest {
             }
         """.trimIndent()
 
-        val (dataTypes, interfaces) = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName)).generate() as CodeGenResult
+        val (dataTypes, interfaces) = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+        )).generate() as CodeGenResult
 
         assertThat(dataTypes.size).isEqualTo(1)
         val employee = dataTypes.single().typeSpec
@@ -402,7 +441,10 @@ class CodeGenTest {
 
         """.trimIndent()
 
-        val (dataTypes) = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName)).generate() as CodeGenResult
+        val (dataTypes) = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+        )).generate() as CodeGenResult
 
         //Check data class
         assertThat(dataTypes.size).isEqualTo(1)
@@ -447,7 +489,10 @@ class CodeGenTest {
             }
         """.trimIndent()
 
-        val (dataTypes) = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName)).generate() as CodeGenResult
+        val (dataTypes) = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+        )).generate() as CodeGenResult
 
         assertThat(dataTypes).extracting("typeSpec.name").contains("Car", "Engine", "Performance")
         assertThat(dataTypes)
@@ -477,7 +522,10 @@ class CodeGenTest {
             }
         """.trimIndent()
 
-        val codeGenResult = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName)).generate() as CodeGenResult
+        val codeGenResult = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+        )).generate() as CodeGenResult
 
         //Check generated enum type
         assertThat(codeGenResult.enumTypes.size).isEqualTo(1)
@@ -503,7 +551,10 @@ class CodeGenTest {
             }
         """.trimIndent()
 
-        val codeGenResult = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName)).generate() as CodeGenResult
+        val codeGenResult = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+        )).generate() as CodeGenResult
         val dataFetchers = codeGenResult.dataFetchers
         val dataTypes = codeGenResult.dataTypes
 
@@ -530,7 +581,11 @@ class CodeGenTest {
         """.trimIndent()
 
 
-        val (dataTypes) = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, typeMapping = mapOf(Pair("Date", "java.time.LocalDateTime")))).generate() as CodeGenResult
+        val (dataTypes) = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+            typeMapping = mapOf(Pair("Date", "java.time.LocalDateTime")),
+        )).generate() as CodeGenResult
 
         assertThat(dataTypes.size).isEqualTo(1)
         assertThat(dataTypes[0].typeSpec.name).isEqualTo("Person")
@@ -556,7 +611,10 @@ class CodeGenTest {
         """.trimIndent()
 
 
-        val (dataTypes) = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName)).generate() as CodeGenResult
+        val (dataTypes) = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+        )).generate() as CodeGenResult
 
         assertThat(dataTypes.size).isEqualTo(1)
         assertThat(dataTypes[0].typeSpec.name).isEqualTo("MovieFilter")
@@ -728,7 +786,10 @@ class CodeGenTest {
             }
         """.trimIndent()
 
-        val (dataTypes) = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName)).generate() as CodeGenResult
+        val (dataTypes) = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+        )).generate() as CodeGenResult
 
         assertThat(dataTypes[0].typeSpec.methodSpecs).extracting("name").contains("toString")
         val expectedInputString = """
@@ -753,7 +814,10 @@ class CodeGenTest {
             }
         """.trimIndent()
 
-        val (dataTypes) = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName)).generate() as CodeGenResult
+        val (dataTypes) = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+        )).generate() as CodeGenResult
 
         assertThat(dataTypes[0].typeSpec.methodSpecs).extracting("name").contains("toString")
         val expectedInputString = """
@@ -780,7 +844,10 @@ class CodeGenTest {
             }
         """.trimIndent()
 
-        val (dataTypes) = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName)).generate() as CodeGenResult
+        val (dataTypes) = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+        )).generate() as CodeGenResult
 
         assertThat(dataTypes[0].typeSpec.methodSpecs).extracting("name").contains("toString")
         val expectedInputString = """
@@ -813,7 +880,10 @@ class CodeGenTest {
             }
         """.trimIndent()
 
-        val (dataTypes) = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName)).generate() as CodeGenResult
+        val (dataTypes) = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+        )).generate() as CodeGenResult
 
         assertThat(dataTypes[0].typeSpec.methodSpecs).extracting("name").contains("toString")
         val expectedInputString = """
@@ -838,7 +908,10 @@ class CodeGenTest {
             }
         """.trimIndent()
 
-        val (dataTypes) = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName)).generate() as CodeGenResult
+        val (dataTypes) = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+        )).generate() as CodeGenResult
         assertThat(dataTypes[0].typeSpec.methodSpecs).extracting("name").contains("toString")
 
         var expectedInputString = """
@@ -881,7 +954,10 @@ class CodeGenTest {
             }
         """.trimIndent()
 
-        val (dataTypes) = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName)).generate() as CodeGenResult
+        val (dataTypes) = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+        )).generate() as CodeGenResult
         assertThat(dataTypes[0].typeSpec.methodSpecs).extracting("name").contains("toString")
 
         val expectedInputString = """
@@ -907,7 +983,10 @@ class CodeGenTest {
             }
         """.trimIndent()
 
-        val (dataTypes) = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName)).generate() as CodeGenResult
+        val (dataTypes) = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+        )).generate() as CodeGenResult
         assertThat(dataTypes[0].typeSpec.methodSpecs).extracting("name").contains("toString")
 
         val expectedInputString = """
@@ -932,8 +1011,10 @@ class CodeGenTest {
             }
         """.trimIndent()
 
-        val (dataTypes) = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName,
-                typeMapping = mapOf(Pair("LocalTime", "java.time.LocalDateTime"), Pair("LocalDate", "java.lang.Integer")))).generate() as CodeGenResult
+        val (dataTypes) = CodeGen(CodeGenConfig(
+            schemas = setOf(schema), packageName = basePackageName,
+            typeMapping = mapOf(Pair("LocalTime", "java.time.LocalDateTime"), Pair("LocalDate", "java.lang.Integer")),
+        )).generate() as CodeGenResult
         assertThat(dataTypes[0].typeSpec.methodSpecs).extracting("name").contains("toString")
 
         val expectedInputString = """
@@ -957,7 +1038,10 @@ class CodeGenTest {
             }
         """.trimIndent()
 
-        val (dataTypes) = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName)).generate() as CodeGenResult
+        val (dataTypes) = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+        )).generate() as CodeGenResult
         assertThat(dataTypes[0].typeSpec.methodSpecs).extracting("name").contains("toString")
 
         val expectedInputString = """
@@ -988,7 +1072,10 @@ class CodeGenTest {
         """.trimIndent()
 
 
-        val (dataTypes) = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName)).generate() as CodeGenResult
+        val (dataTypes) = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+        )).generate() as CodeGenResult
 
         assertThat(dataTypes.size).isEqualTo(1)
         assertThat(dataTypes[0].typeSpec.name).isEqualTo("MovieFilter")
@@ -1013,7 +1100,10 @@ class CodeGenTest {
             }
         """.trimIndent()
 
-        val (dataTypes) = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName)).generate() as CodeGenResult
+        val (dataTypes) = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+        )).generate() as CodeGenResult
 
         assertThat(dataTypes[0].typeSpec.methodSpecs).extracting("name").contains("toString")
         val expectedString = """
@@ -1038,7 +1128,10 @@ class CodeGenTest {
         """.trimIndent()
 
 
-        val result = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName)).generate() as CodeGenResult
+        val result = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+        )).generate() as CodeGenResult
         val type = result.constants[0].typeSpec
         assertThat(type.typeSpecs).extracting("name").containsExactly("QUERY", "PERSON")
         assertThat(type.typeSpecs[0].fieldSpecs).extracting("name").containsExactly("TYPE_NAME", "People")
@@ -1063,7 +1156,10 @@ class CodeGenTest {
         """.trimIndent()
 
 
-        val result = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName)).generate() as CodeGenResult
+        val result = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+        )).generate() as CodeGenResult
         val type = result.constants[0].typeSpec
         assertThat(type.typeSpecs).extracting("name").containsExactly("QUERY", "PERSON", "PERSONFILTER")
         assertThat(type.typeSpecs[2].fieldSpecs).extracting("name").containsExactly("TYPE_NAME", "Email")
@@ -1092,7 +1188,10 @@ class CodeGenTest {
         """.trimIndent()
 
 
-        val result = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName)).generate() as CodeGenResult
+        val result = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+        )).generate() as CodeGenResult
         val type = result.constants[0].typeSpec
         assertThat(type.typeSpecs).extracting("name").containsExactly("QUERY", "PERSON", "PERSONFILTER")
         assertThat(type.typeSpecs[2].fieldSpecs).extracting("name").containsExactly("TYPE_NAME", "Email", "BirthYear")
@@ -1117,7 +1216,10 @@ class CodeGenTest {
         """.trimIndent()
 
 
-        val result = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName)).generate() as CodeGenResult
+        val result = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+        )).generate() as CodeGenResult
         val type = result.constants[0].typeSpec
         assertThat(type.typeSpecs).extracting("name").containsExactly("QUERY", "PERSON")
         assertThat(type.typeSpecs[1].fieldSpecs).extracting("name").containsExactly("TYPE_NAME", "Firstname", "Lastname", "Email")
@@ -1141,7 +1243,10 @@ class CodeGenTest {
         """.trimIndent()
 
 
-        val result = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName)).generate() as CodeGenResult
+        val result = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+        )).generate() as CodeGenResult
         val type = result.constants[0].typeSpec
         assertThat(type.typeSpecs).extracting("name").containsExactly("QUERY", "PERSON")
         assertThat(type.typeSpecs[0].fieldSpecs).extracting("name").containsExactly("TYPE_NAME", "People", "Friends")
@@ -1165,7 +1270,10 @@ class CodeGenTest {
             }
         """.trimIndent()
 
-        val (dataTypes, interfaces) = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName)).generate() as CodeGenResult
+        val (dataTypes, interfaces) = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+        )).generate() as CodeGenResult
         assertThat(dataTypes[0].typeSpec.name).isEqualTo("Movie")
         assertThat(dataTypes[1].typeSpec.name).isEqualTo("Actor")
         assertThat(interfaces[0].typeSpec.name).isEqualTo("SearchResult")
@@ -1186,7 +1294,10 @@ class CodeGenTest {
             }
         """.trimIndent()
 
-        val (dataTypes) = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName)).generate() as CodeGenResult
+        val (dataTypes) = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+        )).generate() as CodeGenResult
         assertThat(dataTypes.size).isEqualTo(1)
         assertThat(dataTypes[0].typeSpec.name).isEqualTo("Person")
     }
@@ -1200,7 +1311,10 @@ class CodeGenTest {
             }
         """.trimIndent()
 
-        val (dataTypes) = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName)).generate() as CodeGenResult
+        val (dataTypes) = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+        )).generate() as CodeGenResult
         assertThat(dataTypes[0].typeSpec.name).isEqualTo("Person")
         assertThat(dataTypes[0].typeSpec.fieldSpecs).extracting("name").containsExactly("name")
     }

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/EntitiesClientApiGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/EntitiesClientApiGenTest.kt
@@ -44,7 +44,11 @@ class EntitiesClientApiGenTest {
             }
         """.trimIndent()
 
-        val codeGenResult = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, generateClientApi = true)).generate() as CodeGenResult
+        val codeGenResult = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+            generateClientApi = true,
+        )).generate() as CodeGenResult
 
         val projections = codeGenResult.clientProjections.filter {it.typeSpec.name.contains("Entities")}
         assertThat(projections[0].typeSpec.name).isEqualTo("EntitiesProjectionRoot")
@@ -79,7 +83,11 @@ class EntitiesClientApiGenTest {
             }
         """.trimIndent()
 
-        val codeGenResult = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, generateClientApi = true)).generate() as CodeGenResult
+        val codeGenResult = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+            generateClientApi = true,
+        )).generate() as CodeGenResult
 
         val projections = codeGenResult.clientProjections.filter {it.typeSpec.name.contains("Entities")}
         assertThat(projections[0].typeSpec.name).isEqualTo("EntitiesProjectionRoot")
@@ -122,7 +130,11 @@ class EntitiesClientApiGenTest {
 
         """.trimIndent()
 
-        val codeGenResult = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, generateClientApi = true)).generate() as CodeGenResult
+        val codeGenResult = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+            generateClientApi = true,
+        )).generate() as CodeGenResult
 
         val projections = codeGenResult.clientProjections.filter {it.typeSpec.name.contains("Entities")}
         assertThat(projections[0].typeSpec.name).isEqualTo("EntitiesProjectionRoot")
@@ -166,7 +178,11 @@ class EntitiesClientApiGenTest {
 
         """.trimIndent()
 
-        val codeGenResult = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, generateClientApi = true)).generate() as CodeGenResult
+        val codeGenResult = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+            generateClientApi = true,
+        )).generate() as CodeGenResult
 
         val projections = codeGenResult.clientProjections.filter {it.typeSpec.name.contains("Entities")}
         assertThat(projections[0].typeSpec.name).isEqualTo("EntitiesProjectionRoot")
@@ -204,7 +220,11 @@ class EntitiesClientApiGenTest {
             }
         """.trimIndent()
 
-        val codeGenResult = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, generateClientApi = true)).generate() as CodeGenResult
+        val codeGenResult = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+            generateClientApi = true,
+        )).generate() as CodeGenResult
 
         val projections = codeGenResult.clientProjections.filter {it.typeSpec.name.contains("Entities")}
         assertThat(projections[0].typeSpec.name).isEqualTo("EntitiesProjectionRoot")
@@ -237,7 +257,12 @@ class EntitiesClientApiGenTest {
 
         """.trimIndent()
 
-        val codeGenResult = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, generateClientApi = true, typeMapping = mapOf(Pair("Long", "java.lang.Long")))).generate() as CodeGenResult
+        val codeGenResult = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+            generateClientApi = true,
+            typeMapping = mapOf(Pair("Long", "java.lang.Long")),
+        )).generate() as CodeGenResult
         val representations = codeGenResult.dataTypes.filter {it.typeSpec.name.contains("Representation")}
         assertThat(representations.size).isEqualTo(1)
         val projections = codeGenResult.clientProjections
@@ -264,7 +289,12 @@ class EntitiesClientApiGenTest {
             }
         """.trimIndent()
 
-        val codeGenResult = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, generateClientApi = true, skipEntityQueries = true)).generate() as CodeGenResult
+        val codeGenResult = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+            generateClientApi = true,
+            skipEntityQueries = true,
+        )).generate() as CodeGenResult
 
         val projections = codeGenResult.clientProjections.filter {it.typeSpec.name.contains("Entities")}
         assertThat(projections).isEmpty()

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinClientApiGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinClientApiGenTest.kt
@@ -44,7 +44,12 @@ class KotlinClientApiGenTest {
         """.trimIndent()
 
 
-        val codeGenResult = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, generateClientApi = true, language = Language.KOTLIN)).generate() as KotlinCodeGenResult
+        val codeGenResult = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+            language = Language.KOTLIN,
+            generateClientApi = true,
+        )).generate() as KotlinCodeGenResult
 
         assertThat(codeGenResult.queryTypes.size).isEqualTo(1)
         val typeSpec = codeGenResult.queryTypes[0].members[0] as TypeSpec
@@ -66,7 +71,12 @@ class KotlinClientApiGenTest {
         """.trimIndent()
 
 
-        val codeGenResult = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, generateClientApi = true, language = Language.KOTLIN)).generate() as KotlinCodeGenResult
+        val codeGenResult = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+            language = Language.KOTLIN,
+            generateClientApi = true,
+        )).generate() as KotlinCodeGenResult
 
         assertThat(codeGenResult.queryTypes.size).isEqualTo(1)
         val typeSpec = codeGenResult.queryTypes[0].members[0] as TypeSpec
@@ -94,7 +104,12 @@ class KotlinClientApiGenTest {
         """.trimIndent()
 
 
-        val codeGenResult = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, generateClientApi = true, language = Language.KOTLIN)).generate() as KotlinCodeGenResult
+        val codeGenResult = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+            language = Language.KOTLIN,
+            generateClientApi = true,
+        )).generate() as KotlinCodeGenResult
 
         assertThat(codeGenResult.queryTypes.size).isEqualTo(1)
         val typeSpec = codeGenResult.queryTypes[0].members[0] as TypeSpec
@@ -124,7 +139,12 @@ class KotlinClientApiGenTest {
             }
         """.trimIndent()
 
-        val codeGenResult = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, generateClientApi = true, language = Language.KOTLIN)).generate() as KotlinCodeGenResult
+        val codeGenResult = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+            language = Language.KOTLIN,
+            generateClientApi = true,
+        )).generate() as KotlinCodeGenResult
 
         assertThat(codeGenResult.queryTypes.size).isEqualTo(1)
         val typeSpec = codeGenResult.queryTypes[0].members[0] as TypeSpec
@@ -161,7 +181,12 @@ class KotlinClientApiGenTest {
             }
         """.trimIndent()
 
-        val codeGenResult = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, generateClientApi = true, language = Language.KOTLIN)).generate() as KotlinCodeGenResult
+        val codeGenResult = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+            language = Language.KOTLIN,
+            generateClientApi = true,
+        )).generate() as KotlinCodeGenResult
 
         assertThat(codeGenResult.clientProjections.size).isEqualTo(3)
         var projectionType = codeGenResult.clientProjections[0].members[0] as TypeSpec
@@ -203,7 +228,12 @@ class KotlinClientApiGenTest {
             
         """.trimIndent()
 
-        val codeGenResult = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, generateClientApi = true, language = Language.KOTLIN)).generate() as KotlinCodeGenResult
+        val codeGenResult = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+            language = Language.KOTLIN,
+            generateClientApi = true,
+        )).generate() as KotlinCodeGenResult
 
         var projectionType = codeGenResult.clientProjections[0].members[0] as TypeSpec
         assertThat(projectionType.name).isEqualTo("SearchProjectionRoot")
@@ -236,7 +266,12 @@ class KotlinClientApiGenTest {
             }
         """.trimIndent()
 
-        val codeGenResult = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, generateClientApi = true, language = Language.KOTLIN)).generate() as KotlinCodeGenResult
+        val codeGenResult = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+            language = Language.KOTLIN,
+            generateClientApi = true,
+        )).generate() as KotlinCodeGenResult
 
         assertThat(codeGenResult.clientProjections.size).isEqualTo(3)
         val projectionType = codeGenResult.clientProjections[0].members[0] as TypeSpec
@@ -278,7 +313,12 @@ class KotlinClientApiGenTest {
             
         """.trimIndent()
 
-        val codeGenResult = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, generateClientApi = true, language = Language.KOTLIN)).generate() as KotlinCodeGenResult
+        val codeGenResult = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+            language = Language.KOTLIN,
+            generateClientApi = true,
+        )).generate() as KotlinCodeGenResult
 
         assertThat(codeGenResult.clientProjections.size).isEqualTo(4)
         val projectionType = codeGenResult.clientProjections[0].members[0] as TypeSpec
@@ -340,7 +380,13 @@ class KotlinClientApiGenTest {
         """.trimIndent()
 
 
-        val codeGenResult = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, generateClientApi = true, language = Language.KOTLIN)).generate() as KotlinCodeGenResult
+        val codeGenResult = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+            language = Language.KOTLIN,
+            generateClientApi = true,
+            
+        )).generate() as KotlinCodeGenResult
 
         assertThat(codeGenResult.queryTypes.size).isEqualTo(1)
         val typeSpec = codeGenResult.queryTypes[0].members[0] as TypeSpec
@@ -361,7 +407,13 @@ class KotlinClientApiGenTest {
         """.trimIndent()
 
 
-        val codeGenResult = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, generateClientApi = true, language = Language.KOTLIN)).generate() as KotlinCodeGenResult
+        val codeGenResult = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+            language = Language.KOTLIN,
+            generateClientApi = true,
+            
+        )).generate() as KotlinCodeGenResult
 
         val typeSpec = codeGenResult.clientProjections[0].members[0] as TypeSpec
         assertThat(typeSpec.funSpecs.size).isEqualTo(1)
@@ -383,7 +435,13 @@ class KotlinClientApiGenTest {
         """.trimIndent()
 
 
-        val codeGenResult = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, generateClientApi = true, language = Language.KOTLIN)).generate() as KotlinCodeGenResult
+        val codeGenResult = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+            language = Language.KOTLIN,
+            generateClientApi = true,
+            
+        )).generate() as KotlinCodeGenResult
         val projectionTypeSpec = codeGenResult.clientProjections[0].members[0] as TypeSpec
         assertThat(codeGenResult.clientProjections.size).isEqualTo(1)
         assertThat(projectionTypeSpec.name).isEqualTo("PeopleProjectionRoot")
@@ -409,7 +467,13 @@ class KotlinClientApiGenTest {
 
         """.trimIndent()
 
-        val codeGenResult = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, generateClientApi = true, language = Language.KOTLIN)).generate() as KotlinCodeGenResult
+        val codeGenResult = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+            language = Language.KOTLIN,
+            generateClientApi = true,
+            
+        )).generate() as KotlinCodeGenResult
         assertThat(codeGenResult.clientProjections.size).isEqualTo(2)
         val projectionTypeSpec = codeGenResult.clientProjections[0].members[0] as TypeSpec
         assertThat(projectionTypeSpec.name).isEqualTo("MoviesProjectionRoot")
@@ -432,7 +496,13 @@ class KotlinClientApiGenTest {
             }
         """.trimIndent()
 
-        val codeGenResult = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, generateClientApi = true, language = Language.KOTLIN)).generate() as KotlinCodeGenResult
+        val codeGenResult = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+            language = Language.KOTLIN,
+            generateClientApi = true,
+            
+        )).generate() as KotlinCodeGenResult
         assertThat(codeGenResult.clientProjections.size).isEqualTo(2)
         var projectionTypeSpec = codeGenResult.clientProjections[0].members[0] as TypeSpec
         assertThat(projectionTypeSpec.name).isEqualTo("PersonsProjectionRoot")
@@ -454,7 +524,13 @@ class KotlinClientApiGenTest {
             }
         """.trimIndent()
 
-        val codeGenResult = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, generateClientApi = true, language = Language.KOTLIN)).generate() as KotlinCodeGenResult
+        val codeGenResult = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+            language = Language.KOTLIN,
+            generateClientApi = true,
+            
+        )).generate() as KotlinCodeGenResult
         var projectionTypeSpec = codeGenResult.clientProjections[0].members[0] as TypeSpec
         assertThat(projectionTypeSpec.name).isEqualTo("PersonsProjectionRoot")
         projectionTypeSpec = codeGenResult.clientProjections[1].members[0] as TypeSpec
@@ -480,7 +556,13 @@ class KotlinClientApiGenTest {
             }
         """.trimIndent()
 
-        val codeGenResult = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, generateClientApi = true, language = Language.KOTLIN)).generate() as KotlinCodeGenResult
+        val codeGenResult = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+            language = Language.KOTLIN,
+            generateClientApi = true,
+            
+        )).generate() as KotlinCodeGenResult
         var projectionTypeSpec = codeGenResult.clientProjections[0].members[0] as TypeSpec
         assertThat(projectionTypeSpec.name).isEqualTo("PersonsProjectionRoot")
         projectionTypeSpec = codeGenResult.clientProjections[1].members[0] as TypeSpec
@@ -505,7 +587,13 @@ class KotlinClientApiGenTest {
         """.trimIndent()
 
 
-        val codeGenResult = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, generateClientApi = true, language = Language.KOTLIN)).generate() as KotlinCodeGenResult
+        val codeGenResult = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+            language = Language.KOTLIN,
+            generateClientApi = true,
+            
+        )).generate() as KotlinCodeGenResult
         val typeSpec = codeGenResult.queryTypes[0].members[0] as TypeSpec
         assertThat(typeSpec.propertySpecs[0].name).isEqualTo("lastname")
         assertThat(codeGenResult.queryTypes[0].toString()).doesNotContain("import com.netflix.graphql.dgs.codegen.tests.generated.types")
@@ -532,7 +620,13 @@ class KotlinClientApiGenTest {
         """.trimIndent()
 
 
-        val codeGenResult = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, generateClientApi = true, language = Language.KOTLIN)).generate() as KotlinCodeGenResult
+        val codeGenResult = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+            language = Language.KOTLIN,
+            generateClientApi = true,
+            
+        )).generate() as KotlinCodeGenResult
         val typeSpec = codeGenResult.queryTypes[0].members[0] as TypeSpec
         assertThat(typeSpec.propertySpecs[0].name).isEqualTo("index")
         assertThat(codeGenResult.queryTypes[0].toString()).contains("import com.netflix.graphql.dgs.codegen.tests.generated.types.SearchIndex\n")
@@ -558,7 +652,13 @@ class KotlinClientApiGenTest {
         """.trimIndent()
 
 
-        val codeGenResult = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, generateClientApi = true, language = Language.KOTLIN)).generate() as KotlinCodeGenResult
+        val codeGenResult = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+            language = Language.KOTLIN,
+            generateClientApi = true,
+            
+        )).generate() as KotlinCodeGenResult
         val typeSpec = codeGenResult.queryTypes[0].members[0] as TypeSpec
         assertThat(typeSpec.propertySpecs[0].name).isEqualTo("index")
         assertThat(codeGenResult.queryTypes[0].toString()).contains("import com.netflix.graphql.dgs.codegen.tests.generated.types.SearchIndex\n")
@@ -579,8 +679,14 @@ class KotlinClientApiGenTest {
 
         """.trimIndent()
 
-        val codeGenResult = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName,
-                generateClientApi = true, typeMapping = mapOf(Pair("Long", "java.lang.Long")), language = Language.KOTLIN)).generate() as KotlinCodeGenResult
+        val codeGenResult = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+            language = Language.KOTLIN,
+            generateClientApi = true,
+            typeMapping = mapOf(Pair("Long", "java.lang.Long")),
+            
+        )).generate() as KotlinCodeGenResult
         val projections = codeGenResult.clientProjections
         assertThat(projections.size).isEqualTo(1)
     }
@@ -602,8 +708,14 @@ class KotlinClientApiGenTest {
 
         """.trimIndent()
 
-        val codeGenResult = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName,
-                generateClientApi = true, typeMapping = mapOf(Pair("Long", "java.lang.Long")), language = Language.KOTLIN)).generate() as KotlinCodeGenResult
+        val codeGenResult = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+            language = Language.KOTLIN,
+            generateClientApi = true,
+            typeMapping = mapOf(Pair("Long", "java.lang.Long")),
+            
+        )).generate() as KotlinCodeGenResult
         val projections = codeGenResult.clientProjections
         assertThat(projections.size).isEqualTo(1)
         assertThat((projections[0].members[0] as TypeSpec).funSpecs).extracting("name").contains("name", "email")
@@ -629,8 +741,14 @@ class KotlinClientApiGenTest {
           }
         """.trimIndent()
 
-        val codeGenResult = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName,
-                generateClientApi = true, typeMapping = mapOf(Pair("Long", "java.lang.Long")), language = Language.KOTLIN)).generate() as KotlinCodeGenResult
+        val codeGenResult = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+            language = Language.KOTLIN,
+            generateClientApi = true,
+            typeMapping = mapOf(Pair("Long", "java.lang.Long")),
+            
+        )).generate() as KotlinCodeGenResult
         val projections = codeGenResult.clientProjections
         assertThat(projections.size).isEqualTo(2)
         assertThat((projections[1].members[0] as TypeSpec).funSpecs).extracting("name").contains("title", "director")

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
@@ -43,7 +43,11 @@ class KotlinCodeGenTest {
             }
         """.trimIndent()
 
-        val (dataTypes) = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, language = Language.KOTLIN)).generate() as KotlinCodeGenResult
+        val (dataTypes) = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+            language = Language.KOTLIN
+        )).generate() as KotlinCodeGenResult
 
         assertThat(dataTypes.size).isEqualTo(1)
         assertThat(dataTypes[0].name).isEqualTo("Person")
@@ -66,7 +70,11 @@ class KotlinCodeGenTest {
             }
         """.trimIndent()
 
-        val (dataTypes) = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, language = Language.KOTLIN)).generate() as KotlinCodeGenResult
+        val (dataTypes) = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+            language = Language.KOTLIN
+        )).generate() as KotlinCodeGenResult
 
         val type = dataTypes[0].members[0] as TypeSpec
 
@@ -94,7 +102,11 @@ class KotlinCodeGenTest {
             }
         """.trimIndent()
 
-        val (dataTypes) = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, language = Language.KOTLIN)).generate() as KotlinCodeGenResult
+        val (dataTypes) = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+            language = Language.KOTLIN
+        )).generate() as KotlinCodeGenResult
 
         val type = dataTypes[0].members[0] as TypeSpec
 
@@ -120,7 +132,11 @@ class KotlinCodeGenTest {
             }
         """.trimIndent()
 
-        val (dataTypes) = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, language = Language.KOTLIN)).generate() as KotlinCodeGenResult
+        val (dataTypes) = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+            language = Language.KOTLIN
+        )).generate() as KotlinCodeGenResult
 
         val type = dataTypes[0].members[0] as TypeSpec
 
@@ -142,7 +158,11 @@ class KotlinCodeGenTest {
             }
         """.trimIndent()
 
-        val (dataTypes) = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, language = Language.KOTLIN)).generate() as KotlinCodeGenResult
+        val (dataTypes) = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+            language = Language.KOTLIN
+        )).generate() as KotlinCodeGenResult
         assertThat(dataTypes.size).isEqualTo(1)
         val type = dataTypes[0].members[0] as TypeSpec
         assertThat(type.name).isEqualTo("Person")
@@ -162,7 +182,11 @@ class KotlinCodeGenTest {
             }
         """.trimIndent()
 
-        val (dataTypes) = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = "com.mypackage", language = Language.KOTLIN)).generate() as KotlinCodeGenResult
+        val (dataTypes) = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = "com.mypackage",
+            language = Language.KOTLIN
+        )).generate() as KotlinCodeGenResult
 
         assertThat(dataTypes.size).isEqualTo(1)
         assertThat(dataTypes[0].name).isEqualTo("Person")
@@ -183,7 +207,11 @@ class KotlinCodeGenTest {
             }
         """.trimIndent()
 
-        val (dataTypes) = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, language = Language.KOTLIN)).generate() as KotlinCodeGenResult
+        val (dataTypes) = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+            language = Language.KOTLIN
+        )).generate() as KotlinCodeGenResult
         val type = dataTypes[0].members[0] as TypeSpec
 
         assertThat(dataTypes.size).isEqualTo(1)
@@ -211,7 +239,11 @@ class KotlinCodeGenTest {
             }
         """.trimIndent()
 
-        val (dataTypes) = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, language = Language.KOTLIN)).generate() as KotlinCodeGenResult
+        val (dataTypes) = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+            language = Language.KOTLIN
+        )).generate() as KotlinCodeGenResult
         val type = dataTypes[0].members[0] as TypeSpec
 
         assertThat(dataTypes.size).isEqualTo(1)
@@ -236,7 +268,11 @@ class KotlinCodeGenTest {
             }
         """.trimIndent()
 
-        val (dataTypes) = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, language = Language.KOTLIN)).generate() as KotlinCodeGenResult
+        val (dataTypes) = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+            language = Language.KOTLIN
+        )).generate() as KotlinCodeGenResult
         val type = dataTypes[0].members[0] as TypeSpec
 
         assertThat(dataTypes.size).isEqualTo(1)
@@ -269,7 +305,11 @@ class KotlinCodeGenTest {
             }
         """.trimIndent()
 
-        val (dataTypes, interfaces) = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, language = Language.KOTLIN)).generate() as KotlinCodeGenResult
+        val (dataTypes, interfaces) = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+            language = Language.KOTLIN
+        )).generate() as KotlinCodeGenResult
         val type = dataTypes[0].members[0] as TypeSpec
 
         //Check data class
@@ -348,7 +388,11 @@ class KotlinCodeGenTest {
             }
         """.trimIndent()
 
-        val (dataTypes, interfaces) = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, language = Language.KOTLIN)).generate() as KotlinCodeGenResult
+        val (dataTypes, interfaces) = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+            language = Language.KOTLIN
+        )).generate() as KotlinCodeGenResult
         val type = dataTypes[0].members[0] as TypeSpec
 
         //Check data class
@@ -387,7 +431,11 @@ class KotlinCodeGenTest {
 
         """.trimIndent()
 
-        val (dataTypes) = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, language = Language.KOTLIN)).generate() as KotlinCodeGenResult
+        val (dataTypes) = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+            language = Language.KOTLIN
+        )).generate() as KotlinCodeGenResult
         val type = dataTypes[0].members[0] as TypeSpec
 
         //Check data class
@@ -431,7 +479,11 @@ class KotlinCodeGenTest {
             }
         """.trimIndent()
 
-        val (dataTypes) = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, language = Language.KOTLIN)).generate() as KotlinCodeGenResult
+        val (dataTypes) = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+            language = Language.KOTLIN
+        )).generate() as KotlinCodeGenResult
 
         assertThat(dataTypes).flatExtracting("members").extracting("name").contains("Car", "Engine", "Performance")
         val nestedType = dataTypes[1].members[0] as TypeSpec
@@ -454,7 +506,11 @@ class KotlinCodeGenTest {
             }
         """.trimIndent()
 
-        val result = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, language = Language.KOTLIN)).generate() as KotlinCodeGenResult
+        val result = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+            language = Language.KOTLIN
+        )).generate() as KotlinCodeGenResult
         val type = result.enumTypes[0].members[0] as TypeSpec
 
         //Check generated enum type
@@ -479,7 +535,12 @@ class KotlinCodeGenTest {
             }
         """.trimIndent()
 
-        val (dataTypes) = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, typeMapping = mapOf(Pair("Date", "java.time.LocalDateTime")), language = Language.KOTLIN)).generate() as KotlinCodeGenResult
+        val (dataTypes) = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+            language = Language.KOTLIN,
+            typeMapping = mapOf(Pair("Date", "java.time.LocalDateTime"))
+        )).generate() as KotlinCodeGenResult
         val type = dataTypes[0].members[0] as TypeSpec
 
         assertThat(dataTypes.size).isEqualTo(1)
@@ -505,7 +566,11 @@ class KotlinCodeGenTest {
         """.trimIndent()
 
 
-        val (dataTypes) = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, language = Language.KOTLIN)).generate() as KotlinCodeGenResult
+        val (dataTypes) = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+            language = Language.KOTLIN
+        )).generate() as KotlinCodeGenResult
         val type = dataTypes[0].members[0] as TypeSpec
 
         assertThat(type.name).isEqualTo("MovieFilter")
@@ -755,7 +820,11 @@ class KotlinCodeGenTest {
             }
         """.trimIndent()
 
-        val (dataTypes) = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, language = Language.KOTLIN)).generate() as KotlinCodeGenResult
+        val (dataTypes) = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+            language = Language.KOTLIN
+        )).generate() as KotlinCodeGenResult
 
         val type = dataTypes[0].members[0] as TypeSpec
         assertThat(type.funSpecs).extracting("name").contains("toString")
@@ -782,7 +851,11 @@ class KotlinCodeGenTest {
             }
         """.trimIndent()
 
-        val (dataTypes) = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, language = Language.KOTLIN)).generate() as KotlinCodeGenResult
+        val (dataTypes) = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+            language = Language.KOTLIN
+        )).generate() as KotlinCodeGenResult
 
         val type = dataTypes[0].members[0] as TypeSpec
         assertThat(type.funSpecs).extracting("name").contains("toString")
@@ -809,7 +882,11 @@ class KotlinCodeGenTest {
             }
         """.trimIndent()
 
-        val (dataTypes) = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, language = Language.KOTLIN)).generate() as KotlinCodeGenResult
+        val (dataTypes) = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+            language = Language.KOTLIN
+        )).generate() as KotlinCodeGenResult
 
         val type = dataTypes[0].members[0] as TypeSpec
         assertThat(type.funSpecs).extracting("name").contains("toString")
@@ -842,7 +919,11 @@ class KotlinCodeGenTest {
             }
         """.trimIndent()
 
-        val (dataTypes) = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, language = Language.KOTLIN)).generate() as KotlinCodeGenResult
+        val (dataTypes) = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+            language = Language.KOTLIN
+        )).generate() as KotlinCodeGenResult
 
         val type = dataTypes[0].members[0] as TypeSpec
         assertThat(type.funSpecs).extracting("name").contains("toString")
@@ -867,7 +948,11 @@ class KotlinCodeGenTest {
             }
         """.trimIndent()
 
-        val (dataTypes) = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, language = Language.KOTLIN)).generate() as KotlinCodeGenResult
+        val (dataTypes) = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+            language = Language.KOTLIN
+        )).generate() as KotlinCodeGenResult
 
         val type = dataTypes[0].members[0] as TypeSpec
         assertThat(type.funSpecs).extracting("name").contains("toString")
@@ -909,7 +994,11 @@ class KotlinCodeGenTest {
             }
         """.trimIndent()
 
-        val (dataTypes) = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, language = Language.KOTLIN)).generate() as KotlinCodeGenResult
+        val (dataTypes) = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+            language = Language.KOTLIN
+        )).generate() as KotlinCodeGenResult
 
         val type = dataTypes[0].members[0] as TypeSpec
         assertThat(type.funSpecs).extracting("name").contains("toString")
@@ -934,7 +1023,10 @@ class KotlinCodeGenTest {
             }
         """.trimIndent()
 
-        val (dataTypes) = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName)).generate() as CodeGenResult
+        val (dataTypes) = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName
+        )).generate() as CodeGenResult
 
         assertThat(dataTypes[0].typeSpec.methodSpecs).extracting("name").contains("toString")
         val expectedString = """
@@ -959,7 +1051,11 @@ class KotlinCodeGenTest {
             }
         """.trimIndent()
 
-        val (dataTypes) = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, language = Language.KOTLIN)).generate() as KotlinCodeGenResult
+        val (dataTypes) = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+            language = Language.KOTLIN
+        )).generate() as KotlinCodeGenResult
         val type = dataTypes[0].members[0] as TypeSpec
         assertThat(type.funSpecs).extracting("name").contains("toString")
 
@@ -983,7 +1079,11 @@ class KotlinCodeGenTest {
             }
         """.trimIndent()
 
-        val (dataTypes) = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, language = Language.KOTLIN)).generate() as KotlinCodeGenResult
+        val (dataTypes) = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+            language = Language.KOTLIN
+        )).generate() as KotlinCodeGenResult
         val type = dataTypes[0].members[0] as TypeSpec
         assertThat(type.funSpecs).extracting("name").contains("toString")
 
@@ -1008,8 +1108,10 @@ class KotlinCodeGenTest {
             }
         """.trimIndent()
 
-        val (dataTypes) = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, language = Language.KOTLIN,
-                typeMapping = mapOf(Pair("LocalTime", "java.time.LocalDateTime"), Pair("LocalDate", "java.lang.Integer")))).generate() as KotlinCodeGenResult
+        val (dataTypes) = CodeGen(CodeGenConfig(
+            schemas = setOf(schema), packageName = basePackageName, language = Language.KOTLIN,
+            typeMapping = mapOf(Pair("LocalTime", "java.time.LocalDateTime"), Pair("LocalDate", "java.lang.Integer"))
+        )).generate() as KotlinCodeGenResult
         val type = dataTypes[0].members[0] as TypeSpec
         assertThat(type.funSpecs).extracting("name").contains("toString")
 
@@ -1039,7 +1141,11 @@ class KotlinCodeGenTest {
         """.trimIndent()
 
 
-        val (dataTypes) = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, language = Language.KOTLIN)).generate() as KotlinCodeGenResult
+        val (dataTypes) = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+            language = Language.KOTLIN
+        )).generate() as KotlinCodeGenResult
         val type = dataTypes[0].members[0] as TypeSpec
 
         assertThat(type.name).isEqualTo("MovieFilter")
@@ -1062,7 +1168,11 @@ class KotlinCodeGenTest {
         """.trimIndent()
 
 
-        val result = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, language = Language.KOTLIN)).generate() as KotlinCodeGenResult
+        val result = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+            language = Language.KOTLIN
+        )).generate() as KotlinCodeGenResult
         val type = result.constants[0].members[0] as TypeSpec
         assertThat(type.typeSpecs).extracting("name").containsExactly("QUERY", "PERSON")
         assertThat(type.typeSpecs[0].propertySpecs).extracting("name").containsExactly("TYPE_NAME", "People")
@@ -1087,7 +1197,11 @@ class KotlinCodeGenTest {
         """.trimIndent()
 
 
-        val result = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, language = Language.KOTLIN)).generate() as KotlinCodeGenResult
+        val result = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+            language = Language.KOTLIN
+        )).generate() as KotlinCodeGenResult
         val type = result.constants[0].members[0] as TypeSpec
         assertThat(type.typeSpecs).extracting("name").containsExactly("QUERY", "PERSON", "PERSONFILTER")
         assertThat(type.typeSpecs[2].propertySpecs).extracting("name").containsExactly("TYPE_NAME", "Email")
@@ -1115,7 +1229,11 @@ class KotlinCodeGenTest {
         """.trimIndent()
 
 
-        val result = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, language = Language.KOTLIN)).generate() as KotlinCodeGenResult
+        val result = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+            language = Language.KOTLIN
+        )).generate() as KotlinCodeGenResult
         val type = result.constants[0].members[0] as TypeSpec
         assertThat(type.typeSpecs).extracting("name").containsExactly("QUERY", "PERSON", "PERSONFILTER")
         assertThat(type.typeSpecs[2].propertySpecs).extracting("name").containsExactly("TYPE_NAME", "Email", "BirthYear")
@@ -1139,7 +1257,11 @@ class KotlinCodeGenTest {
         """.trimIndent()
 
 
-        val result = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, language = Language.KOTLIN)).generate() as KotlinCodeGenResult
+        val result = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+            language = Language.KOTLIN
+        )).generate() as KotlinCodeGenResult
         val type = result.constants[0].members[0] as TypeSpec
         assertThat(type.typeSpecs).extracting("name").containsExactly("QUERY", "PERSON")
         assertThat(type.typeSpecs[1].propertySpecs).extracting("name").containsExactly("TYPE_NAME", "Firstname", "Lastname", "Email")
@@ -1163,7 +1285,11 @@ class KotlinCodeGenTest {
         """.trimIndent()
 
 
-        val result = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, language = Language.KOTLIN)).generate() as KotlinCodeGenResult
+        val result = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+            language = Language.KOTLIN
+        )).generate() as KotlinCodeGenResult
         val type = result.constants[0].members[0] as TypeSpec
         assertThat(type.typeSpecs).extracting("name").containsExactly("QUERY", "PERSON")
         assertThat(type.typeSpecs[0].propertySpecs).extracting("name").containsExactly("TYPE_NAME", "People", "Friends")
@@ -1189,7 +1315,11 @@ class KotlinCodeGenTest {
             
         """.trimIndent()
 
-        val (dataTypes, interfaces) = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, language = Language.KOTLIN)).generate() as KotlinCodeGenResult
+        val (dataTypes, interfaces) = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+            language = Language.KOTLIN
+        )).generate() as KotlinCodeGenResult
         assertThat(dataTypes).extracting("name").containsExactly("Movie", "Actor")
         assertThat(interfaces).extracting("name").containsExactly("SearchResult")
         val typeSpec = dataTypes[0].members[0] as TypeSpec
@@ -1209,7 +1339,11 @@ class KotlinCodeGenTest {
             }
         """.trimIndent()
 
-        val (dataTypes) = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, language = Language.KOTLIN)).generate() as KotlinCodeGenResult
+        val (dataTypes) = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+            language = Language.KOTLIN
+        )).generate() as KotlinCodeGenResult
         assertThat(dataTypes).extracting("name").containsExactly("Person")
     }
 
@@ -1222,7 +1356,11 @@ class KotlinCodeGenTest {
             }
         """.trimIndent()
 
-        val (dataTypes) = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, language = Language.KOTLIN)).generate() as KotlinCodeGenResult
+        val (dataTypes) = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+            language = Language.KOTLIN
+        )).generate() as KotlinCodeGenResult
         assertThat(dataTypes).extracting("name").containsExactly("Person")
         val type = dataTypes[0].members[0] as TypeSpec
         assertThat(type.propertySpecs).extracting("name").containsExactly("name")

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinEntitiesClientApiGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinEntitiesClientApiGenTest.kt
@@ -45,7 +45,12 @@ class KotlinEntitiesClientApiGenTest {
             }
         """.trimIndent()
 
-        val codeGenResult = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, generateClientApi = true, language = Language.KOTLIN)).generate() as KotlinCodeGenResult
+        val codeGenResult = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+            language = Language.KOTLIN,
+            generateClientApi = true,
+        )).generate() as KotlinCodeGenResult
 
         val projections = codeGenResult.clientProjections.filter { it.name.contains("Entities")}
         assertThat(projections[0].name).isEqualTo("EntitiesProjectionRoot")
@@ -78,7 +83,12 @@ class KotlinEntitiesClientApiGenTest {
             }
         """.trimIndent()
 
-        val codeGenResult = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, generateClientApi = true, language = Language.KOTLIN)).generate() as KotlinCodeGenResult
+        val codeGenResult = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+            language = Language.KOTLIN,
+            generateClientApi = true,
+        )).generate() as KotlinCodeGenResult
 
         val projections = codeGenResult.clientProjections.filter {it.name.contains("Entities")}
         assertThat(projections[0].name).isEqualTo("EntitiesProjectionRoot")
@@ -119,7 +129,12 @@ class KotlinEntitiesClientApiGenTest {
 
         """.trimIndent()
 
-        val codeGenResult = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, generateClientApi = true, language = Language.KOTLIN)).generate() as KotlinCodeGenResult
+        val codeGenResult = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+            language = Language.KOTLIN,
+            generateClientApi = true,
+        )).generate() as KotlinCodeGenResult
 
         val projections = codeGenResult.clientProjections.filter {it.name.contains("Entities")}
         assertThat(projections[0].name).isEqualTo("EntitiesProjectionRoot")
@@ -162,7 +177,12 @@ class KotlinEntitiesClientApiGenTest {
 
         """.trimIndent()
 
-        val codeGenResult = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, generateClientApi = true, language = Language.KOTLIN)).generate() as KotlinCodeGenResult
+        val codeGenResult = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+            language = Language.KOTLIN,
+            generateClientApi = true,
+        )).generate() as KotlinCodeGenResult
 
         val projections = codeGenResult.clientProjections.filter {it.name.contains("Entities")}
         assertThat(projections[0].name).isEqualTo("EntitiesProjectionRoot")
@@ -198,7 +218,12 @@ class KotlinEntitiesClientApiGenTest {
             }
         """.trimIndent()
 
-        val codeGenResult = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, generateClientApi = true, language = Language.KOTLIN)).generate() as KotlinCodeGenResult
+        val codeGenResult = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+            language = Language.KOTLIN,
+            generateClientApi = true,
+        )).generate() as KotlinCodeGenResult
 
         val projections = codeGenResult.clientProjections.filter {it.name.contains("Entities")}
         assertThat(projections[0].name).isEqualTo("EntitiesProjectionRoot")
@@ -229,7 +254,13 @@ class KotlinEntitiesClientApiGenTest {
 
         """.trimIndent()
 
-        val codeGenResult = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, generateClientApi = true, language = Language.KOTLIN, typeMapping = mapOf(Pair("Long", "java.lang.Long")))).generate() as KotlinCodeGenResult
+        val codeGenResult = CodeGen(CodeGenConfig(
+            schemas = setOf(schema),
+            packageName = basePackageName,
+            language = Language.KOTLIN,
+            generateClientApi = true,
+            typeMapping = mapOf(Pair("Long", "java.lang.Long")),
+        )).generate() as KotlinCodeGenResult
         val representations = codeGenResult.dataTypes.filter {it.name.contains("Representation")}
         assertThat(representations.size).isEqualTo(1)
         val projections = codeGenResult.clientProjections

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/RequiredTypeCollectorTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/RequiredTypeCollectorTest.kt
@@ -31,6 +31,7 @@ internal class RequiredTypeCollectorTest {
                 search(filter: Filter): [Show]
                 shows(type: ShowType!): [Show]
                 searchByExample(example: ExampleShow): [Show]
+                searchByExamples(examples: [ExampleShow]): [Show]
             }
             
             input Filter {
@@ -84,5 +85,12 @@ internal class RequiredTypeCollectorTest {
         val types = RequiredTypeCollector(document, setOf("searchByExample", "search")).requiredTypes
 
         assertThat(types).contains("ExampleShow", "Filter", "ShowType", "ExampleActor")
+    }
+
+    @Test
+    fun `Lists of required input types should be included`() {
+
+        val types = RequiredTypeCollector(document, setOf("searchByExamples")).requiredTypes
+        assertThat(types).contains("ExampleShow", "ExampleActor", "ShowType")
     }
 }

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/RequiredTypeCollectorTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/RequiredTypeCollectorTest.kt
@@ -1,0 +1,88 @@
+/*
+ *
+ *  Copyright 2020 Netflix, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package com.netflix.graphql.dgs.codegen
+
+import graphql.language.Document
+import graphql.parser.Parser
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+import org.junit.jupiter.api.Assertions.*
+
+internal class RequiredTypeCollectorTest {
+    private val document = Parser.parse("""
+            type Query {
+                search(filter: Filter): [Show]
+                shows(type: ShowType!): [Show]
+                searchByExample(example: ExampleShow): [Show]
+            }
+            
+            input Filter {
+                title: String
+                type: ShowType
+            }
+            
+            enum ShowType {
+                SERIES,
+                MOVIE
+            }
+            
+            input ExampleShow {
+                title: String
+                actor: ExampleActor
+                type: ShowType
+            }               
+               
+            input ExampleActor {
+                name: String
+            }
+        """.trimIndent())
+
+    @Test
+    fun `Related input types and enums should be included`() {
+
+        val types = RequiredTypeCollector(document, setOf("search")).requiredTypes
+
+        assertThat(types).contains("Filter", "ShowType")
+    }
+
+    @Test
+    fun `Related nested input types and enums should be included`() {
+
+        val types = RequiredTypeCollector(document, setOf("searchByExample")).requiredTypes
+
+        assertThat(types).contains("ExampleShow", "ExampleActor", "ShowType")
+    }
+
+    @Test
+    fun `Unrelated input types should be omitted`() {
+
+        val types = RequiredTypeCollector(document, setOf("searchByExample")).requiredTypes
+
+        assertThat(types).doesNotContain("Filter")
+    }
+
+    @Test
+    fun `All related input types should be included for multiple queries`() {
+
+        val types = RequiredTypeCollector(document, setOf("searchByExample", "search")).requiredTypes
+
+        assertThat(types).contains("ExampleShow", "Filter", "ShowType", "ExampleActor")
+    }
+}

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/SchemaMergingTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/SchemaMergingTest.kt
@@ -29,7 +29,11 @@ class SchemaMergingTest {
 
         val schemaDir = Paths.get("src/test/resources/schemas").toAbsolutePath().toFile()
 
-        val codeGen = CodeGen(config = CodeGenConfig(schemaFiles = setOf(schemaDir), writeToFiles = false, generateClientApi = true))
+        val codeGen = CodeGen(config = CodeGenConfig(
+            schemaFiles = setOf(schemaDir),
+            writeToFiles = false,
+            generateClientApi = true,
+        ))
         val result = codeGen.generate() as CodeGenResult
 
         Assertions.assertThat(result.dataTypes.size).isEqualTo(2)
@@ -44,7 +48,12 @@ class SchemaMergingTest {
 
         val schemaDir = Paths.get("src/test/resources/schemas").toAbsolutePath().toFile()
 
-        val codeGen = CodeGen(config = CodeGenConfig(schemaFiles = setOf(schemaDir), writeToFiles = false, generateClientApi = true, language = Language.KOTLIN))
+        val codeGen = CodeGen(config = CodeGenConfig(
+            schemaFiles = setOf(schemaDir),
+            writeToFiles = false,
+            language = Language.KOTLIN,
+            generateClientApi = true,
+        ))
         val result = codeGen.generate() as KotlinCodeGenResult
         val type = result.dataTypes.find { it.name == "Person" }!!.members[0] as TypeSpec
 

--- a/graphql-dgs-codegen-gradle/src/main/kotlin/com/netflix/graphql/dgs/codegen/gradle/GenerateJavaTask.kt
+++ b/graphql-dgs-codegen-gradle/src/main/kotlin/com/netflix/graphql/dgs/codegen/gradle/GenerateJavaTask.kt
@@ -72,6 +72,9 @@ open class GenerateJavaTask : DefaultTask() {
     @Input
     var generateClient = false
 
+    @Input
+    var generateDataTypes = true
+
     @OutputDirectory
     fun getOutputDir(): File {
         return Paths.get("${generatedSourcesDir}/generated").toFile()
@@ -118,7 +121,8 @@ open class GenerateJavaTask : DefaultTask() {
                 includeQueries = includeQueries.toSet(),
                 includeMutations = includeMutations.toSet(),
                 skipEntityQueries = skipEntityQueries,
-                shortProjectionNames = shortProjectionNames
+                shortProjectionNames = shortProjectionNames,
+                generateDataTypes = generateDataTypes
         )
 
         LOGGER.info("Codegen config: {}", config)


### PR DESCRIPTION
There are two distinct usecases for codegen:

1. To generate types for a service you're _implementing_
2. To generate types for a service you're _using_

In the second scenario, you really only care about the types that are relevant to the queries you're using.
You can now configure codegen to only generate (input) types based on the queries you need, so you can create a small client even when using a huge composed schema.
