### PR TITLE
Remove an unchecked cast in RequiredTypeCollector

### DIFF
--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
@@ -78,7 +78,7 @@ class CodeGen(private val config: CodeGenConfig) {
     }
 
     private fun generateForSchema(schema: String): CodeGenResult {
-        document = Parser().parseDocument(schema)
+        document = Parser.parse(schema)
         requiredTypeCollector = RequiredTypeCollector(document, queries = config.includeQueries, mutations = config.includeMutations)
         val definitions = document.definitions
         val dataTypesResult = generateJavaDataType(definitions)
@@ -189,7 +189,7 @@ class CodeGen(private val config: CodeGenConfig) {
             definitions.filterIsInstance<InputObjectTypeExtensionDefinition>().filter { name == it.name }
 
     private fun generateKotlinForSchema(schema: String): KotlinCodeGenResult {
-        document = Parser().parseDocument(schema)
+        document = Parser.parse(schema)
         requiredTypeCollector = RequiredTypeCollector(document, queries = config.includeQueries, mutations = config.includeMutations)
         val definitions = document.definitions
 

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/RequiredTypeCollectorTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/RequiredTypeCollectorTest.kt
@@ -18,14 +18,11 @@
 
 package com.netflix.graphql.dgs.codegen
 
-import graphql.language.Document
 import graphql.parser.Parser
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
-import org.junit.jupiter.api.Assertions.*
-
-internal class RequiredTypeCollectorTest {
+class RequiredTypeCollectorTest {
     private val document = Parser.parse("""
             type Query {
                 search(filter: Filter): [Show]


### PR DESCRIPTION
Using the TraverserContext to accumulate the result necessitated an
unchecked cast since a generic type was involved; moving the collection
outside of the visitor avoids the issue.

In addition, do some minor clean up, such as avoiding extra collections
allocations for intermediate results in RequiredTypeCollector.