### PR TITLE
Set default package name, so the plugin works without extra config

### DIFF
--- a/graphql-dgs-codegen-gradle/src/main/kotlin/com/netflix/graphql/dgs/codegen/gradle/GenerateJavaTask.kt
+++ b/graphql-dgs-codegen-gradle/src/main/kotlin/com/netflix/graphql/dgs/codegen/gradle/GenerateJavaTask.kt
@@ -42,7 +42,7 @@ open class GenerateJavaTask : DefaultTask() {
     var schemaPaths = mutableListOf<Any>("${project.projectDir}/src/main/resources/schema")
 
     @Input
-    var packageName = ""
+    var packageName = "com.netflix.dgs.codgen.generated"
 
     @Input
     var subPackageNameClient = "client"


### PR DESCRIPTION
This was the only property that doesn't have a default. Because of that, the plugin would fail without an explicit 
```
generateJava {

}
```
block.

With this fix a user can get started by just 

```
plugins {
    id "com.netflix.dgs.codegen" version "4.3.4"
}
```

without any config.