### PR TITLE
Create empty companion objects for data classes

### DIFF
--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinDataTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinDataTypeGenerator.kt
@@ -161,6 +161,8 @@ abstract class AbstractKotlinDataTypeGenerator(private val packageName: String, 
                     .build()
             )
         }
+        kotlinType.addType(TypeSpec.companionObjectBuilder().build())
+
         val typeSpec = kotlinType.build()
 
         val fileSpec = FileSpec.builder(getPackageName(), typeSpec.name!!).addType(typeSpec).build()

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
@@ -176,6 +176,9 @@ class KotlinCodeGenTest {
         assertThat(dataTypes.size).isEqualTo(1)
         val type = dataTypes[0].members[0] as TypeSpec
         assertThat(type.name).isEqualTo("Person")
+        val companion = type.typeSpecs[0]
+        assertThat(companion.isCompanion).isTrue
+        assertThat(companion.name).isNull()
     }
 
     @Test
@@ -384,7 +387,9 @@ class KotlinCodeGenTest {
                 |  public override val lastname: String? = null,
                 |  @JsonProperty("company")
                 |  public val company: String? = null
-                |) : Person
+                |) : Person {
+                |  public companion object
+                |}
                 |""".trimMargin()
         )
     }
@@ -1560,7 +1565,9 @@ class KotlinCodeGenTest {
                 |  public override val company: String? = null,
                 |  @JsonProperty("imdbProfile")
                 |  public val imdbProfile: String? = null
-                |) : Employee
+                |) : Employee {
+                |  public companion object
+                |}
                 |""".trimMargin()
         )
     }


### PR DESCRIPTION
This PR should add companion objects for data classes and minimal tests for the same. For issue #75