### PR TITLE
Handle interfaces in generated representations for entities query.

### DIFF
--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
@@ -266,7 +266,7 @@ class CodeGen(private val config: CodeGenConfig) {
                 .filterIsInstance<ObjectTypeDefinition>()
                 .filter { it.hasDirective("key") }
                 .map { d ->
-                    KotlinEntitiesRepresentationTypeGenerator(config).generate(d, document, generatedRepresentations)
+                    KotlinEntitiesRepresentationTypeGenerator(config, document).generate(d, generatedRepresentations)
                 }.fold(KotlinCodeGenResult()) { t: KotlinCodeGenResult, u: KotlinCodeGenResult -> t.merge(u) }
         } else KotlinCodeGenResult()
     }


### PR DESCRIPTION
If the key for federated entities uses an interface, the generated representation class did not have the appropriate package name for the interface field. Also the corresponding representation for the field itself was missing.
