### PR TITLE
Add option to omit null fields from inputs

### DIFF
--- a/graphql-dgs-codegen-core/build.gradle
+++ b/graphql-dgs-codegen-core/build.gradle
@@ -53,6 +53,7 @@ dependencies {
     testImplementation "com.google.testing.compile:compile-testing:0.+"
     testImplementation "com.google.truth:truth:1.+"
     testImplementation "org.assertj:assertj-core:3.11.+"
+    testImplementation "org.jetbrains.kotlin:kotlin-compiler-embeddable:1.4.31"
 
     testImplementation(platform("org.junit:junit-bom:5.7.+"))
     testImplementation("org.junit.jupiter:junit-jupiter")

--- a/graphql-dgs-codegen-core/build.gradle
+++ b/graphql-dgs-codegen-core/build.gradle
@@ -49,6 +49,7 @@ dependencies {
     implementation "com.github.ajalt.clikt:clikt:3.1.+"
     implementation "com.fasterxml.jackson.core:jackson-annotations:2.12.+"
 
+    testImplementation "com.google.jimfs:jimfs:1.2"
     testImplementation "com.google.testing.compile:compile-testing:0.+"
     testImplementation "com.google.truth:truth:1.+"
     testImplementation "org.assertj:assertj-core:3.11.+"

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
@@ -314,6 +314,7 @@ data class CodeGenConfig(
     val skipEntityQueries: Boolean = false,
     val shortProjectionNames: Boolean = false,
     val generateDataTypes: Boolean = true,
+    val omitNullInputFields: Boolean = false,
     val maxProjectionDepth: Int = 10
 ) {
     val packageNameClient: String

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/DataTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/DataTypeGenerator.kt
@@ -271,7 +271,7 @@ abstract class BaseDataTypeGenerator(internal val packageName: String, private v
 
     private fun defaultString(fieldSpec: FieldSpec, index: Int, fieldDefinitions: List<Field>): String {
         val inputField = """"${fieldSpec.name}:" + ${fieldSpec.name}"""
-        val suffix = """+ "${if (index < fieldDefinitions.size - 1) "," else ""}" +"""
+        val suffix = """ + "${if (index < fieldDefinitions.size - 1) "," else ""}" + """
         val expression = if (config.omitNullInputFields && !fieldSpec.type.isPrimitive) {
             return """(${fieldSpec.name} == null ? "" : $inputField)"""
         } else {
@@ -281,7 +281,7 @@ abstract class BaseDataTypeGenerator(internal val packageName: String, private v
     }
 
     private fun quotedString(fieldSpec: FieldSpec, index: Int, fieldDefinitions: List<Field>): String {
-        val suffix = """+ "${if (index < fieldDefinitions.size - 1) "," else ""}" +"""
+        val suffix = """ + "${if (index < fieldDefinitions.size - 1) "," else ""}" + """
         val expression = if (config.omitNullInputFields) {
             """(${fieldSpec.name} == null ? "" : "${fieldSpec.name}:\"" + ${fieldSpec.name} + "\"")"""
         } else {

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinDataTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinDataTypeGenerator.kt
@@ -213,7 +213,7 @@ abstract class AbstractKotlinDataTypeGenerator(private val packageName: String, 
 
     private fun defaultString(field: Field, index: Int, fields: List<Field>): String {
         val inputField = """"${field.name}:" + ${field.name}"""
-        val suffix = """+ "${if (index < fields.size - 1) "," else ""}" +"""
+        val suffix = """ + "${if (index < fields.size - 1) "," else ""}" + """
         val expression = if (config.omitNullInputFields && !field.nullable) {
             """(if (${field.name} == null) "" else $inputField)"""
         } else {
@@ -224,9 +224,9 @@ abstract class AbstractKotlinDataTypeGenerator(private val packageName: String, 
 
     private fun quotedString(field: Field, index: Int, fields: List<Field>): String {
         val quoted = """"${field.name}:\"" + ${field.name} + "\"""""
-        val suffix = """+ "${if (index < fields.size - 1) "," else ""}" +"""
+        val suffix = """ + "${if (index < fields.size - 1) "," else ""}" + """
         val expression = if (!field.nullable) {
-            "$quoted"
+            quoted
         } else if (config.omitNullInputFields) {
             """(if (${field.name} == null) "" else $quoted)"""
         } else {

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinDataTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinDataTypeGenerator.kt
@@ -190,7 +190,11 @@ abstract class AbstractKotlinDataTypeGenerator(private val packageName: String, 
                 }
                 is ClassName -> {
                     if (typeUtils.isStringInput(fieldTypeName)) {
-                        """"${field.name}" to (if (${field.name} == null) null else "\"" + ${field.name} + "\"")"""
+                        if (field.nullable) {
+                            """"${field.name}" to (if (${field.name} == null) null else "\"" + ${field.name} + "\"")"""
+                        } else {
+                            """"${field.name}" to ("\"" + ${field.name} + "\"")"""
+                        }
                     } else {
                         """"${field.name}" to ${field.name}"""
                     }

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/ClassConstructor.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/ClassConstructor.kt
@@ -1,0 +1,32 @@
+/*
+ *
+ *  Copyright 2020 Netflix, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *  
+ */
+
+package com.netflix.graphql.dgs.codegen
+
+class ClassConstructor(private val clazz: Class<*>) {
+    fun create(vararg args: Any?): Any {
+        val constructor = try {
+            clazz.constructors.find { it.parameterCount == args.size }
+                ?: throw RuntimeException("No constructor with ${args.size} arguments")
+        } catch (e: Exception) {
+            throw RuntimeException("Could not get constructor. Available options are: ${clazz.constructors.toList()}", e)
+        }
+
+        return constructor.newInstance(*args)
+    }
+}

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/ClientApiGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/ClientApiGenTest.kt
@@ -53,7 +53,7 @@ class ClientApiGenTest {
         assertThat(codeGenResult.queryTypes.size).isEqualTo(1)
         assertThat(codeGenResult.queryTypes[0].typeSpec.name).isEqualTo("PeopleGraphQLQuery")
 
-        assertCompiles(codeGenResult.clientProjections.plus(codeGenResult.queryTypes))
+        assertCompilesJava(codeGenResult.clientProjections.plus(codeGenResult.queryTypes))
     }
 
     @Test
@@ -81,7 +81,7 @@ class ClientApiGenTest {
         assertThat(codeGenResult.queryTypes.size).isEqualTo(1)
         assertThat(codeGenResult.queryTypes[0].typeSpec.name).isEqualTo("UpdateMovieGraphQLQuery")
 
-        assertCompiles(codeGenResult.clientProjections.plus(codeGenResult.queryTypes))
+        assertCompilesJava(codeGenResult.clientProjections.plus(codeGenResult.queryTypes))
     }
 
     @Test
@@ -115,7 +115,7 @@ class ClientApiGenTest {
         assertThat(codeGenResult.queryTypes.size).isEqualTo(1)
         assertThat(codeGenResult.queryTypes[0].typeSpec.name).isEqualTo("UpdateMovieGraphQLQuery")
 
-        assertCompiles(codeGenResult.clientProjections.plus(codeGenResult.queryTypes).plus(codeGenResult.dataTypes))
+        assertCompilesJava(codeGenResult.clientProjections.plus(codeGenResult.queryTypes).plus(codeGenResult.dataTypes))
     }
 
     @Test
@@ -163,7 +163,7 @@ class ClientApiGenTest {
                     "}"
             )
         )
-        assertCompiles(codeGenResult.clientProjections.plus(codeGenResult.queryTypes).plus(codeGenResult.dataTypes))
+        assertCompilesJava(codeGenResult.clientProjections.plus(codeGenResult.queryTypes).plus(codeGenResult.dataTypes))
     }
 
     @Test
@@ -194,7 +194,7 @@ class ClientApiGenTest {
                 .contains("super(\"mutation\");\ngetInput().put(\"movieId\", movieId);")
         )
 
-        assertCompiles(codeGenResult.clientProjections.plus(codeGenResult.queryTypes).plus(codeGenResult.dataTypes))
+        assertCompilesJava(codeGenResult.clientProjections.plus(codeGenResult.queryTypes).plus(codeGenResult.dataTypes))
     }
 
     @Test
@@ -222,7 +222,7 @@ class ClientApiGenTest {
         assertThat(codeGenResult.clientProjections.size).isEqualTo(1)
         assertThat(codeGenResult.clientProjections[0].typeSpec.name).isEqualTo("PeopleProjectionRoot")
 
-        assertCompiles(codeGenResult.clientProjections)
+        assertCompilesJava(codeGenResult.clientProjections)
     }
 
     @Test
@@ -253,7 +253,7 @@ class ClientApiGenTest {
         assertThat(codeGenResult.clientProjections[0].typeSpec.methodSpecs).extracting("name").contains("friends")
         assertThat(codeGenResult.clientProjections[1].typeSpec.methodSpecs).extracting("name").contains("name")
 
-        assertCompiles(codeGenResult.clientProjections.plus(codeGenResult.queryTypes))
+        assertCompilesJava(codeGenResult.clientProjections.plus(codeGenResult.queryTypes))
     }
 
     @Test
@@ -294,7 +294,7 @@ class ClientApiGenTest {
         assertThat(codeGenResult.clientProjections[3].typeSpec.name).isEqualTo("Search_Movie_Details_ShowProjection")
         assertThat(codeGenResult.clientProjections[4].typeSpec.name).isEqualTo("Search_Movie_Details_Show_MovieProjection")
 
-        assertCompiles(codeGenResult.clientProjections.plus(codeGenResult.queryTypes).plus(codeGenResult.enumTypes).plus(codeGenResult.dataTypes).plus(codeGenResult.interfaces))
+        assertCompilesJava(codeGenResult.clientProjections.plus(codeGenResult.queryTypes).plus(codeGenResult.enumTypes).plus(codeGenResult.dataTypes).plus(codeGenResult.interfaces))
     }
 
     @Test
@@ -333,7 +333,7 @@ class ClientApiGenTest {
         assertThat(codeGenResult.clientProjections[5].typeSpec.name).isEqualTo("Search_Movie_Related_Video_ShowProjection")
         assertThat(codeGenResult.clientProjections[6].typeSpec.name).isEqualTo("Search_Movie_Related_Video_MovieProjection")
 
-        assertCompiles(codeGenResult.clientProjections.plus(codeGenResult.queryTypes).plus(codeGenResult.enumTypes).plus(codeGenResult.dataTypes).plus(codeGenResult.interfaces))
+        assertCompilesJava(codeGenResult.clientProjections.plus(codeGenResult.queryTypes).plus(codeGenResult.enumTypes).plus(codeGenResult.dataTypes).plus(codeGenResult.interfaces))
     }
 
     @Test
@@ -360,7 +360,7 @@ class ClientApiGenTest {
         assertThat(codeGenResult.clientProjections[0].typeSpec.name).isEqualTo("PersonsProjectionRoot")
         assertThat(codeGenResult.clientProjections[1].typeSpec.name).isEqualTo("FriendsProjectionRoot")
 
-        assertCompiles(codeGenResult.clientProjections.plus(codeGenResult.queryTypes))
+        assertCompilesJava(codeGenResult.clientProjections.plus(codeGenResult.queryTypes))
     }
 
     @Test
@@ -393,7 +393,7 @@ class ClientApiGenTest {
         assertThat(codeGenResult.clientProjections[1].typeSpec.name).isEqualTo("Persons_DetailsProjection")
         assertThat(codeGenResult.clientProjections[2].typeSpec.name).isEqualTo("DetailsProjectionRoot")
 
-        assertCompiles(codeGenResult.clientProjections.plus(codeGenResult.queryTypes))
+        assertCompilesJava(codeGenResult.clientProjections.plus(codeGenResult.queryTypes))
     }
 
     @Test
@@ -429,7 +429,7 @@ class ClientApiGenTest {
         assertThat(codeGenResult.clientProjections[0].typeSpec.name).isEqualTo("MoviesProjectionRoot")
         assertThat(codeGenResult.clientProjections[1].typeSpec.name).isEqualTo("Movies_ActorsProjection")
 
-        assertCompiles(codeGenResult.clientProjections.plus(codeGenResult.queryTypes))
+        assertCompilesJava(codeGenResult.clientProjections.plus(codeGenResult.queryTypes))
     }
 
     @Test
@@ -468,7 +468,7 @@ class ClientApiGenTest {
         assertThat(codeGenResult.clientProjections[2].typeSpec.name).isEqualTo("User_FavoriteMovie_GenreProjection")
         assertThat(codeGenResult.clientProjections[3].typeSpec.name).isEqualTo("User_FavoriteMovieGenreProjection")
 
-        assertCompiles(codeGenResult.clientProjections.plus(codeGenResult.queryTypes))
+        assertCompilesJava(codeGenResult.clientProjections.plus(codeGenResult.queryTypes))
     }
 
     @Test
@@ -506,7 +506,7 @@ class ClientApiGenTest {
         assertThat(codeGenResult.clientProjections[1].typeSpec.name).isEqualTo("Movies_ActorsProjection")
         assertThat(codeGenResult.clientProjections[2].typeSpec.name).isEqualTo("Mo_Ac_MoviesProjection")
 
-        assertCompiles(codeGenResult.clientProjections.plus(codeGenResult.queryTypes))
+        assertCompilesJava(codeGenResult.clientProjections.plus(codeGenResult.queryTypes))
     }
 
     @Test
@@ -533,7 +533,7 @@ class ClientApiGenTest {
         ).generate() as CodeGenResult
         assertThat(codeGenResult.queryTypes[0].typeSpec.typeSpecs[0].methodSpecs[1].name).isEqualTo("lastname")
 
-        assertCompiles(codeGenResult.clientProjections.plus(codeGenResult.queryTypes))
+        assertCompilesJava(codeGenResult.clientProjections.plus(codeGenResult.queryTypes))
     }
 
     @Test
@@ -565,7 +565,7 @@ class ClientApiGenTest {
 
         assertThat(codeGenResult.queryTypes[0].typeSpec.typeSpecs[0].methodSpecs[1].name).isEqualTo("index")
 
-        assertCompiles(codeGenResult.clientProjections.plus(codeGenResult.queryTypes).plus(codeGenResult.enumTypes))
+        assertCompilesJava(codeGenResult.clientProjections.plus(codeGenResult.queryTypes).plus(codeGenResult.enumTypes))
     }
 
     @Test
@@ -598,7 +598,7 @@ class ClientApiGenTest {
         assertThat(codeGenResult.queryTypes[0].typeSpec.name).isEqualTo("PersonSearchGraphQLQuery")
         assertThat(codeGenResult.queryTypes[0].typeSpec.typeSpecs[0].methodSpecs[1].name).isEqualTo("index")
 
-        assertCompiles(codeGenResult.clientProjections.plus(codeGenResult.queryTypes).plus(codeGenResult.enumTypes).plus(codeGenResult.dataTypes))
+        assertCompilesJava(codeGenResult.clientProjections.plus(codeGenResult.queryTypes).plus(codeGenResult.enumTypes).plus(codeGenResult.dataTypes))
     }
 
     @Test
@@ -632,7 +632,7 @@ class ClientApiGenTest {
         assertThat(codeGenResult.queryTypes.size).isEqualTo(1)
         assertThat(codeGenResult.queryTypes[0].typeSpec.name).isEqualTo("PersonsGraphQLQuery")
 
-        assertCompiles(codeGenResult.clientProjections.plus(codeGenResult.queryTypes).plus(codeGenResult.enumTypes).plus(codeGenResult.dataTypes))
+        assertCompilesJava(codeGenResult.clientProjections.plus(codeGenResult.queryTypes).plus(codeGenResult.enumTypes).plus(codeGenResult.dataTypes))
     }
 
     @Test
@@ -676,7 +676,7 @@ class ClientApiGenTest {
         assertThat(codeGenResult.clientProjections[2].typeSpec.name).isEqualTo("Search_SeriesProjection")
         assertThat(codeGenResult.clientProjections[2].typeSpec.methodSpecs[1].name).isEqualTo("episodes")
 
-        assertCompiles(codeGenResult.clientProjections.plus(codeGenResult.queryTypes).plus(codeGenResult.enumTypes).plus(codeGenResult.dataTypes).plus(codeGenResult.interfaces))
+        assertCompilesJava(codeGenResult.clientProjections.plus(codeGenResult.queryTypes).plus(codeGenResult.enumTypes).plus(codeGenResult.dataTypes).plus(codeGenResult.interfaces))
     }
 
     @Test
@@ -722,7 +722,7 @@ class ClientApiGenTest {
         assertThat(codeGenResult.clientProjections[2].typeSpec.methodSpecs).extracting("name").doesNotContain("title")
         assertThat(codeGenResult.clientProjections[2].typeSpec.methodSpecs).extracting("name").doesNotContain("duration")
 
-        assertCompiles(codeGenResult.clientProjections.plus(codeGenResult.queryTypes).plus(codeGenResult.enumTypes).plus(codeGenResult.dataTypes).plus(codeGenResult.interfaces))
+        assertCompilesJava(codeGenResult.clientProjections.plus(codeGenResult.queryTypes).plus(codeGenResult.enumTypes).plus(codeGenResult.dataTypes).plus(codeGenResult.interfaces))
     }
 
     @Test
@@ -776,7 +776,7 @@ class ClientApiGenTest {
         val superclass = codeGenResult.clientProjections[3].typeSpec.superclass as ParameterizedTypeName
         assertThat(superclass.typeArguments[1]).extracting("simpleName").containsExactly("SearchProjectionRoot")
 
-        assertCompiles(codeGenResult.clientProjections.plus(codeGenResult.queryTypes).plus(codeGenResult.enumTypes).plus(codeGenResult.dataTypes).plus(codeGenResult.interfaces))
+        assertCompilesJava(codeGenResult.clientProjections.plus(codeGenResult.queryTypes).plus(codeGenResult.enumTypes).plus(codeGenResult.dataTypes).plus(codeGenResult.interfaces))
     }
 
     @Test
@@ -816,7 +816,7 @@ class ClientApiGenTest {
         assertThat(codeGenResult.clientProjections[2].typeSpec.methodSpecs).extracting("name").contains("name")
         assertThat(codeGenResult.clientProjections[2].typeSpec.methodSpecs).extracting("name").doesNotContain("title")
 
-        assertCompiles(codeGenResult.clientProjections.plus(codeGenResult.queryTypes).plus(codeGenResult.enumTypes).plus(codeGenResult.dataTypes).plus(codeGenResult.interfaces))
+        assertCompilesJava(codeGenResult.clientProjections.plus(codeGenResult.queryTypes).plus(codeGenResult.enumTypes).plus(codeGenResult.dataTypes).plus(codeGenResult.interfaces))
     }
 
     @Test
@@ -893,7 +893,7 @@ class ClientApiGenTest {
                 |""".trimMargin()
         )
 
-        assertCompiles(codeGenResult.clientProjections.plus(codeGenResult.queryTypes).plus(codeGenResult.enumTypes).plus(codeGenResult.dataTypes).plus(codeGenResult.interfaces))
+        assertCompilesJava(codeGenResult.clientProjections.plus(codeGenResult.queryTypes).plus(codeGenResult.enumTypes).plus(codeGenResult.dataTypes).plus(codeGenResult.interfaces))
     }
 
     @Test
@@ -921,7 +921,7 @@ class ClientApiGenTest {
         ).generate() as CodeGenResult
         val projections = codeGenResult.clientProjections
         assertThat(projections.size).isEqualTo(1)
-        assertCompiles(codeGenResult.clientProjections.plus(codeGenResult.queryTypes).plus(codeGenResult.dataTypes).plus(codeGenResult.enumTypes))
+        assertCompilesJava(codeGenResult.clientProjections.plus(codeGenResult.queryTypes).plus(codeGenResult.dataTypes).plus(codeGenResult.enumTypes))
     }
 
     @Test
@@ -955,7 +955,7 @@ class ClientApiGenTest {
         assertThat(projections[0].typeSpec.methodSpecs.size).isEqualTo(2)
         assertThat(projections[0].typeSpec.methodSpecs).extracting("name").containsExactly("name", "email")
 
-        assertCompiles(codeGenResult.clientProjections.plus(codeGenResult.queryTypes).plus(codeGenResult.dataTypes).plus(codeGenResult.enumTypes))
+        assertCompilesJava(codeGenResult.clientProjections.plus(codeGenResult.queryTypes).plus(codeGenResult.dataTypes).plus(codeGenResult.enumTypes))
     }
 
     @Test
@@ -992,7 +992,7 @@ class ClientApiGenTest {
         assertThat(projections[1].typeSpec.methodSpecs.size).isEqualTo(3)
         assertThat(projections[1].typeSpec.methodSpecs).extracting("name").contains("title", "director", "<init>")
 
-        assertCompiles(codeGenResult.clientProjections.plus(codeGenResult.queryTypes).plus(codeGenResult.dataTypes).plus(codeGenResult.enumTypes))
+        assertCompilesJava(codeGenResult.clientProjections.plus(codeGenResult.queryTypes).plus(codeGenResult.dataTypes).plus(codeGenResult.enumTypes))
     }
 
     @Test
@@ -1017,7 +1017,7 @@ class ClientApiGenTest {
         assertThat(codeGenResult.queryTypes.size).isEqualTo(1)
         assertThat(codeGenResult.queryTypes[0].typeSpec.name).isEqualTo("MovieTitlesGraphQLQuery")
 
-        assertCompiles(codeGenResult.clientProjections.plus(codeGenResult.queryTypes))
+        assertCompilesJava(codeGenResult.clientProjections.plus(codeGenResult.queryTypes))
     }
 
     @Test
@@ -1042,7 +1042,7 @@ class ClientApiGenTest {
         assertThat(codeGenResult.queryTypes.size).isEqualTo(1)
         assertThat(codeGenResult.queryTypes[0].typeSpec.name).isEqualTo("UpdateMovieTitleGraphQLQuery")
 
-        assertCompiles(codeGenResult.clientProjections.plus(codeGenResult.queryTypes))
+        assertCompilesJava(codeGenResult.clientProjections.plus(codeGenResult.queryTypes))
     }
 
     @Test
@@ -1073,7 +1073,7 @@ class ClientApiGenTest {
         assertThat(codeGenResult.clientProjections[0].typeSpec.name).isEqualTo("WeirdTypeProjectionRoot")
         assertThat(codeGenResult.clientProjections[0].typeSpec.methodSpecs).extracting("name").containsExactly("__", "_root", "_parent", "_import")
 
-        assertCompiles(codeGenResult.clientProjections)
+        assertCompilesJava(codeGenResult.clientProjections)
     }
 
     @Test
@@ -1109,7 +1109,7 @@ class ClientApiGenTest {
 
         assertThat(weirdType?.typeSpec?.methodSpecs).extracting("name").contains("__", "_root", "_parent", "_import")
 
-        assertCompiles(codeGenResult.clientProjections)
+        assertCompilesJava(codeGenResult.clientProjections)
     }
 
     @Test
@@ -1191,7 +1191,7 @@ class ClientApiGenTest {
         assertThat(codeGenResult.dataTypes).extracting("typeSpec").extracting("name").containsExactly("ShowFilter", "SimilarityInput")
         assertThat(codeGenResult.enumTypes).extracting("typeSpec").extracting("name").containsExactly("ShowType")
 
-        assertCompiles(codeGenResult.clientProjections + codeGenResult.dataTypes + codeGenResult.enumTypes)
+        assertCompilesJava(codeGenResult.clientProjections + codeGenResult.dataTypes + codeGenResult.enumTypes)
     }
 
     @Test
@@ -1238,7 +1238,7 @@ class ClientApiGenTest {
         assertThat(codeGenResult.dataTypes).extracting("typeSpec").extracting("name").containsExactly("ShowFilter", "SimilarityInput")
         assertThat(codeGenResult.enumTypes).extracting("typeSpec").extracting("name").containsExactly("ShowType")
 
-        assertCompiles(codeGenResult.clientProjections + codeGenResult.dataTypes + codeGenResult.enumTypes)
+        assertCompilesJava(codeGenResult.clientProjections + codeGenResult.dataTypes + codeGenResult.enumTypes)
     }
 
     @Test
@@ -1298,6 +1298,6 @@ class ClientApiGenTest {
         assertThat(codeGenResult.clientProjections[3].typeSpec.name).isEqualTo("Movies_ActorsProjection")
         assertThat(codeGenResult.clientProjections[4].typeSpec.name).isEqualTo("Movies_Actors_AgentProjection")
 
-        assertCompiles(codeGenResult.clientProjections.plus(codeGenResult.queryTypes))
+        assertCompilesJava(codeGenResult.clientProjections.plus(codeGenResult.queryTypes))
     }
 }

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
@@ -68,7 +68,7 @@ class CodeGenTest {
         assertThat(typeSpec.fieldSpecs).extracting("name").contains("firstname", "lastname")
         assertThat(typeSpec.methodSpecs).flatExtracting("parameters").extracting("name").contains("firstname", "lastname")
         dataTypes[0].writeTo(System.out)
-        assertCompiles(dataTypes)
+        assertCompilesJava(dataTypes)
     }
 
     @Test
@@ -180,7 +180,7 @@ class CodeGenTest {
         val toString = assertThat(dataTypes[0].typeSpec.methodSpecs).filteredOn("name", "toString")
         toString.extracting("code").allMatch { it.toString().contains("return \"Person{") }
 
-        assertCompiles(dataTypes)
+        assertCompilesJava(dataTypes)
     }
 
     @Test
@@ -208,7 +208,7 @@ class CodeGenTest {
         assertThat(dataTypes[0].typeSpec.name).isEqualTo("Person")
         assertThat(dataTypes[0].typeSpec.methodSpecs).extracting("name").contains("equals")
 
-        assertCompiles(dataTypes)
+        assertCompilesJava(dataTypes)
     }
 
     @Test
@@ -234,7 +234,7 @@ class CodeGenTest {
         assertThat(dataTypes[0].typeSpec.name).isEqualTo("Person")
         assertThat(dataTypes[0].typeSpec.methodSpecs).extracting("name").contains("equals")
 
-        assertCompiles(dataTypes)
+        assertCompilesJava(dataTypes)
     }
 
     @Test
@@ -266,7 +266,7 @@ class CodeGenTest {
         assertThat(builderType.methodSpecs).extracting("name").contains("firstname", "lastname", "build")
         assertThat(builderType.methodSpecs).filteredOn("name", "firstname").extracting("returnType.simpleName").contains("com.netflix.graphql.dgs.codegen.tests.generated.types.Person.Builder")
         assertThat(builderType.methodSpecs).filteredOn("name", "build").extracting("returnType.simpleName").contains("Person")
-        assertCompiles(dataTypes)
+        assertCompilesJava(dataTypes)
     }
 
     @Test
@@ -294,7 +294,7 @@ class CodeGenTest {
         assertThat(dataTypes[0].typeSpec.name).isEqualTo("Person")
         assertThat(dataTypes[0].typeSpec.methodSpecs).extracting("name").contains("hashCode")
 
-        assertCompiles(dataTypes)
+        assertCompilesJava(dataTypes)
     }
 
     @Test
@@ -322,7 +322,7 @@ class CodeGenTest {
         assertThat(dataTypes[0].typeSpec.name).isEqualTo("Person")
         assertThat(dataTypes[0].packageName).isEqualTo("com.mypackage.types")
 
-        assertCompiles(dataTypes)
+        assertCompilesJava(dataTypes)
     }
 
     @Test
@@ -354,7 +354,7 @@ class CodeGenTest {
         type.extracting("rawType.canonicalName").contains("java.util.List")
         type.flatExtracting("typeArguments").extracting("canonicalName").contains("java.lang.String")
 
-        assertCompiles(dataTypes)
+        assertCompilesJava(dataTypes)
     }
 
     @Test
@@ -386,7 +386,7 @@ class CodeGenTest {
         type.extracting("rawType.canonicalName").contains("java.util.List")
         type.flatExtracting("typeArguments").extracting("canonicalName").contains("java.lang.String")
 
-        assertCompiles(dataTypes)
+        assertCompilesJava(dataTypes)
     }
 
     @Test
@@ -453,7 +453,7 @@ class CodeGenTest {
                |""".trimMargin()
         )
 
-        assertCompiles(dataTypes + interfaces)
+        assertCompilesJava(dataTypes + interfaces)
     }
 
     @Test
@@ -493,7 +493,7 @@ class CodeGenTest {
             .extracting("type", ParameterizedTypeName::class.java)
             .contains(parameterizedType)
 
-        assertCompiles(dataTypes)
+        assertCompilesJava(dataTypes)
     }
 
     @Test
@@ -538,7 +538,7 @@ class CodeGenTest {
             .extracting("type.simpleName")
             .containsExactly("Performance")
 
-        assertCompiles(dataTypes)
+        assertCompilesJava(dataTypes)
     }
 
     @Test
@@ -569,7 +569,7 @@ class CodeGenTest {
         assertThat(codeGenResult.enumTypes[0].typeSpec.enumConstants.size).isEqualTo(3)
         assertThat(codeGenResult.enumTypes[0].typeSpec.enumConstants).containsKeys("ENGINEER", "MANAGER", "DIRECTOR")
 
-        assertCompiles(codeGenResult.enumTypes)
+        assertCompilesJava(codeGenResult.enumTypes)
     }
 
     @Test
@@ -598,7 +598,7 @@ class CodeGenTest {
         assertThat(dataFetchers.size).isEqualTo(1)
         assertThat(dataFetchers[0].typeSpec.name).isEqualTo("PeopleDatafetcher")
         assertThat(dataFetchers[0].packageName).isEqualTo(dataFetcherPackageName)
-        assertCompiles(dataFetchers + dataTypes)
+        assertCompilesJava(dataFetchers + dataTypes)
     }
 
     @Test
@@ -632,7 +632,7 @@ class CodeGenTest {
         assertThat(dataTypes[0].typeSpec.fieldSpecs.size).isEqualTo(3)
         assertThat(dataTypes[0].typeSpec.fieldSpecs).extracting("name").contains("firstname", "lastname", "birthDate")
         dataTypes[0].writeTo(System.out)
-        assertCompiles(dataTypes)
+        assertCompilesJava(dataTypes)
     }
 
     @Test
@@ -662,7 +662,7 @@ class CodeGenTest {
         assertThat(dataTypes[0].typeSpec.fieldSpecs.size).isEqualTo(1)
         assertThat(dataTypes[0].typeSpec.fieldSpecs).extracting("name").contains("genre")
 
-        assertCompiles(dataTypes)
+        assertCompilesJava(dataTypes)
     }
 
     @Test
@@ -694,7 +694,7 @@ class CodeGenTest {
         assertThat(colorField.type.toString()).isEqualTo("$typesPackageName.Color")
         assertThat(colorField.initializer.toString()).isEqualTo("$typesPackageName.Color.red")
 
-        assertCompiles(enumTypes + dataTypes)
+        assertCompilesJava(enumTypes + dataTypes)
     }
 
     @Test
@@ -721,7 +721,7 @@ class CodeGenTest {
         assertThat(colorField.name).isEqualTo("names")
         assertThat(colorField.initializer.toString()).isEqualTo("java.util.Collections.emptyList()")
 
-        assertCompiles(dataTypes)
+        assertCompilesJava(dataTypes)
     }
 
     @Test
@@ -748,7 +748,7 @@ class CodeGenTest {
         assertThat(colorField.name).isEqualTo("names")
         assertThat(colorField.initializer.toString()).isEqualTo("""java.util.Arrays.asList("A", "B")""")
 
-        assertCompiles(dataTypes)
+        assertCompilesJava(dataTypes)
     }
 
     @Test
@@ -775,7 +775,7 @@ class CodeGenTest {
         assertThat(colorField.name).isEqualTo("numbers")
         assertThat(colorField.initializer.toString()).isEqualTo("""java.util.Arrays.asList(1, 2, 3)""")
 
-        assertCompiles(dataTypes)
+        assertCompilesJava(dataTypes)
     }
 
     @Test
@@ -807,7 +807,7 @@ class CodeGenTest {
         assertThat(colorField.name).isEqualTo("colors")
         assertThat(colorField.initializer.toString()).isEqualTo("""java.util.Arrays.asList(Color.red)""")
 
-        assertCompiles(dataTypes + enumTypes)
+        assertCompilesJava(dataTypes + enumTypes)
     }
 
     @Test
@@ -1115,7 +1115,7 @@ class CodeGenTest {
 
         assertThat(dataTypes[0].typeSpec.fieldSpecs.size).isEqualTo(2)
         assertThat(dataTypes[0].typeSpec.fieldSpecs).extracting("name").contains("genre", "releaseYear")
-        assertCompiles(dataTypes)
+        assertCompilesJava(dataTypes)
     }
 
     @Test
@@ -1145,7 +1145,7 @@ class CodeGenTest {
         """.trimIndent()
         val generatedString = dataTypes[0].typeSpec.methodSpecs.single { it.name == "toString" }.code.toString().trimIndent()
         assertThat(expectedString).isEqualTo(generatedString)
-        assertCompiles(dataTypes)
+        assertCompilesJava(dataTypes)
     }
 
     @Test
@@ -1379,7 +1379,7 @@ class CodeGenTest {
         val typeSpec = dataTypes[0].typeSpec
         assertThat(typeSpec.name).isEqualTo("Person")
         assertThat(dataTypes[0].packageName).isEqualTo("$basePackageName.mytypes")
-        assertCompiles(dataTypes)
+        assertCompilesJava(dataTypes)
     }
 
     @Test
@@ -1616,7 +1616,7 @@ class CodeGenTest {
                 |""".trimMargin()
         )
 
-        assertCompiles(dataTypes + interfaces)
+        assertCompilesJava(dataTypes + interfaces)
     }
 
     @Test
@@ -1634,7 +1634,7 @@ class CodeGenTest {
         """.trimIndent()
 
         val codeGenResult = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, generateClientApi = true, typeMapping = mapOf())).generate() as CodeGenResult
-        assertCompiles(codeGenResult.javaFiles)
+        assertCompilesJava(codeGenResult.javaFiles)
     }
 
     @Test
@@ -1803,12 +1803,12 @@ class CodeGenTest {
         assertThat(parameterizedTypeName.typeArguments[0]).extracting("simpleName").containsExactly("String")
         assertThat(movieFilter.typeSpec.fieldSpecs[4].type).extracting("simpleName").containsExactly("Rating")
 
-        assertCompiles(dataTypes.plus(interfaces).plus(result.enumTypes))
+        assertCompilesJava(dataTypes.plus(interfaces).plus(result.enumTypes))
     }
 
     private fun compileAndGetConstructor(dataTypes: List<JavaFile>, type: String): ClassConstructor {
         val packageNameAsUnixPath = basePackageName.replace(".", "/")
-        val compilation = assertCompiles(dataTypes)
+        val compilation = assertCompilesJava(dataTypes)
         val temporaryFilesystem = Jimfs.newFileSystem(Configuration.unix())
         val classpath = compilation.generatedFiles()
             .filter { it.kind == JavaFileObject.Kind.CLASS }
@@ -1828,19 +1828,6 @@ class CodeGenTest {
 
         val clazz = URLClassLoader(classpath).loadClass("$basePackageName.types.$type")
         return ClassConstructor(clazz)
-    }
-
-    private class ClassConstructor(private val clazz: Class<*>) {
-        fun create(vararg args: Any?): Any {
-            val constructor = try {
-                clazz.constructors.find { it.parameterCount == args.size }
-                    ?: throw RuntimeException("No constructor with ${args.size} arguments")
-            } catch (e: Exception) {
-                throw RuntimeException("Could not get constructor. Available options are: ${clazz.constructors.toList()}", e)
-            }
-
-            return constructor.newInstance(*args)
-        }
     }
 
     private val CodeGenResult.javaFiles: Collection<JavaFile>

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
@@ -832,12 +832,11 @@ class CodeGenTest {
             )
         ).generate() as CodeGenResult
 
-        val createDefaultMovieFilter = compileAndGetConstructor(dataTypes, "MovieFilter")
-        val createMovieFilter = compileAndGetConstructor(dataTypes, "MovieFilter", String::class.java, Int::class.javaObjectType, Boolean::class.javaObjectType)
+        val movieFilter = compileAndGetConstructor(dataTypes, "MovieFilter")
 
-        assertThat(createDefaultMovieFilter(emptyArray<Any>()).toString())
+        assertThat(movieFilter.create().toString())
             .isEqualTo("""{genre:null,rating:3,viewed:true}""")
-        assertThat(createMovieFilter(arrayOf(null, 7, null)).toString())
+        assertThat(movieFilter.create(null, 7, null).toString())
             .isEqualTo("""{genre:null,rating:7,viewed:null}""")
     }
 
@@ -862,8 +861,8 @@ class CodeGenTest {
             )
         ).generate() as CodeGenResult
 
-        val createMovieFilter = compileAndGetConstructor(dataTypes, "MovieFilter", String::class.java, Int::class.java)
-        assertThat(createMovieFilter(arrayOf("hi", 1)).toString())
+        val movieFilter = compileAndGetConstructor(dataTypes, "MovieFilter")
+        assertThat(movieFilter.create("hi", 1).toString())
             .isEqualTo("""{genre:"hi",rating:1}""")
     }
 
@@ -890,8 +889,8 @@ class CodeGenTest {
             )
         ).generate() as CodeGenResult
 
-        val createMovieFilter = compileAndGetConstructor(dataTypes, "MovieFilter")
-        assertThat(createMovieFilter(emptyArray<Any>()).toString())
+        val movieFilter = compileAndGetConstructor(dataTypes, "MovieFilter")
+        assertThat(movieFilter.create().toString())
             .isEqualTo("""{genre:"horror",rating:3,average:1.2,viewed:true}""")
     }
 
@@ -924,8 +923,8 @@ class CodeGenTest {
             )
         ).generate() as CodeGenResult
 
-        val createMovieFilter = compileAndGetConstructor(dataTypes, "MovieFilter")
-        assertThat(createMovieFilter(emptyArray<Any>()).toString())
+        val movieFilter = compileAndGetConstructor(dataTypes, "MovieFilter")
+        assertThat(movieFilter.create().toString())
             .isEqualTo("""{genre:"horror",rating:3,average:1.2,viewed:true,identifier:"jhw"}""")
     }
 
@@ -950,8 +949,8 @@ class CodeGenTest {
         ).generate() as CodeGenResult
         assertThat(dataTypes[0].typeSpec.methodSpecs).extracting("name").contains("toString")
 
-        val movieFilterString = compileAndGetConstructor(dataTypes, "MovieFilter", List::class.java, List::class.java)
-        assertThat(movieFilterString(arrayOf(listOf("hello", "world"), listOf("bye"))).toString())
+        val movieFilter = compileAndGetConstructor(dataTypes, "MovieFilter")
+        assertThat(movieFilter.create(listOf("hello", "world"), listOf("bye")).toString())
             .isEqualTo("""{genre:["hello", "world"],actors:["bye"]}""")
 
         assertThat(dataTypes[0].typeSpec.methodSpecs).extracting("name").contains("serializeListOfString")
@@ -994,10 +993,10 @@ class CodeGenTest {
             )
         ).generate() as CodeGenResult
 
-        val createMovieFilter = compileAndGetConstructor(dataTypes, "MovieFilter", List::class.java)
+        val movieFilter = compileAndGetConstructor(dataTypes, "MovieFilter")
 
-        assertThat(createMovieFilter(arrayOf(emptyList<Int>())).toString()).isEqualTo("{genre:[]}")
-        assertThat(createMovieFilter(arrayOf(listOf(1, 2, 3))).toString()).isEqualTo("{genre:[1, 2, 3]}")
+        assertThat(movieFilter.create(emptyList<Int>()).toString()).isEqualTo("{genre:[]}")
+        assertThat(movieFilter.create(listOf(1, 2, 3)).toString()).isEqualTo("{genre:[1, 2, 3]}")
     }
 
     @Test
@@ -1022,16 +1021,14 @@ class CodeGenTest {
             )
         ).generate() as CodeGenResult
 
-        val createMovieFilter = compileAndGetConstructor(dataTypes, "MovieFilter", LocalDateTime::class.java, LocalDate::class.java, LocalTime::class.java, OffsetDateTime::class.java)
+        val movieFilter = compileAndGetConstructor(dataTypes, "MovieFilter")
 
         assertThat(
-            createMovieFilter(
-                arrayOf(
-                    LocalDateTime.now(clock),
-                    LocalDate.now(clock),
-                    LocalTime.now(clock),
-                    OffsetDateTime.now(clock)
-                )
+            movieFilter.create(
+                LocalDateTime.now(clock),
+                LocalDate.now(clock),
+                LocalTime.now(clock),
+                OffsetDateTime.now(clock)
             ).toString()
         ).isEqualTo("""{localDateTime:"1969-12-31T21:00",localDate:"1969-12-31",localTime:"21:00",dateTime:"1969-12-31T21:00-03:00"}""")
     }
@@ -1056,9 +1053,9 @@ class CodeGenTest {
             )
         ).generate() as CodeGenResult
 
-        val createMovieFilter = compileAndGetConstructor(dataTypes, "MovieFilter", LocalDateTime::class.java, Int::class.javaObjectType)
+        val movieFilter = compileAndGetConstructor(dataTypes, "MovieFilter")
 
-        assertThat(createMovieFilter(arrayOf(LocalDateTime.now(clock), 98)).toString())
+        assertThat(movieFilter.create(LocalDateTime.now(clock), 98).toString())
             .isEqualTo("""{time:"1969-12-31T21:00",date:98}""")
     }
 
@@ -1082,9 +1079,9 @@ class CodeGenTest {
             )
         ).generate() as CodeGenResult
 
-        val createMovieFilter = compileAndGetConstructor(dataTypes, "MovieFilter", List::class.java, List::class.java)
+        val movieFilter = compileAndGetConstructor(dataTypes, "MovieFilter")
 
-        assertThat(createMovieFilter(arrayOf(listOf("hi"), listOf(LocalDateTime.now(clock)))).toString())
+        assertThat(movieFilter.create(listOf("hi"), listOf(LocalDateTime.now(clock))).toString())
             .isEqualTo("""{names:["hi"],localDateTime:["1969-12-31T21:00"]}""")
     }
 
@@ -1665,11 +1662,11 @@ class CodeGenTest {
             )
         ).generate() as CodeGenResult
 
-        val constructor = compileAndGetConstructor(dataTypes, "MovieFilter", String::class.java, String::class.java, Int::class.java, Int::class.javaObjectType, List::class.java, List::class.java)
+        val movieFilter = compileAndGetConstructor(dataTypes, "MovieFilter")
 
-        assertThat(constructor(arrayOf("a", "b", 1, 2, listOf("x"), listOf(3))).toString())
+        assertThat(movieFilter.create("a", "b", 1, 2, listOf("x"), listOf(3)).toString())
             .isEqualTo("""{mandatoryString:"a",optionalString:"b",mandatoryInt:1,optionalInt:2,mandatoryList:["x"],optionalList:[3]}""")
-        assertThat(constructor(arrayOf("a", null, 1, null, listOf("x"), null)).toString())
+        assertThat(movieFilter.create("a", null, 1, null, listOf("x"), null).toString())
             .isEqualTo("""{mandatoryString:"a",mandatoryInt:1,mandatoryList:["x"]}""")
     }
 
@@ -1809,7 +1806,7 @@ class CodeGenTest {
         assertCompiles(dataTypes.plus(interfaces).plus(result.enumTypes))
     }
 
-    private fun compileAndGetConstructor(dataTypes: List<JavaFile>, type: String, vararg constructorTypes: Class<*>): (Array<*>) -> Any {
+    private fun compileAndGetConstructor(dataTypes: List<JavaFile>, type: String): ClassConstructor {
         val packageNameAsUnixPath = basePackageName.replace(".", "/")
         val compilation = assertCompiles(dataTypes)
         val temporaryFilesystem = Jimfs.newFileSystem(Configuration.unix())
@@ -1830,12 +1827,20 @@ class CodeGenTest {
             .toTypedArray()
 
         val clazz = URLClassLoader(classpath).loadClass("$basePackageName.types.$type")
-        val constructor = try {
-            clazz.getConstructor(*constructorTypes)
-        } catch (e: Exception) {
-            throw RuntimeException("Could not get constructor. Available options are: ${clazz.constructors.toList()}", e)
+        return ClassConstructor(clazz)
+    }
+
+    private class ClassConstructor(private val clazz: Class<*>) {
+        fun create(vararg args: Any?): Any {
+            val constructor = try {
+                clazz.constructors.find { it.parameterCount == args.size }
+                    ?: throw RuntimeException("No constructor with ${args.size} arguments")
+            } catch (e: Exception) {
+                throw RuntimeException("Could not get constructor. Available options are: ${clazz.constructors.toList()}", e)
+            }
+
+            return constructor.newInstance(*args)
         }
-        return { args -> constructor.newInstance(*args) }
     }
 
     private val CodeGenResult.javaFiles: Collection<JavaFile>

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
@@ -829,7 +829,7 @@ class CodeGenTest {
 
         assertThat(dataTypes[0].typeSpec.methodSpecs).extracting("name").contains("toString")
         val expectedInputString = """
-            return "{" + "genre:" + (genre != null?"\"":"") + genre + (genre != null?"\"":"") + "," +"rating:" + rating + "," +"viewed:" + viewed + "" +"}";
+            return "{" + (genre == null ? "genre:null" : "genre:\"" + genre + "\"") + "," + "rating:" + rating + "," + "viewed:" + viewed + "" + "}";
         """.trimIndent()
         val generatedInputString = dataTypes[0].typeSpec.methodSpecs.single { it.name == "toString" }.code.toString().trimIndent()
         assertThat(expectedInputString).isEqualTo(generatedInputString)
@@ -859,7 +859,7 @@ class CodeGenTest {
 
         assertThat(dataTypes[0].typeSpec.methodSpecs).extracting("name").contains("toString")
         val expectedInputString = """
-            return "{" + "genre:" + (genre != null?"\"":"") + genre + (genre != null?"\"":"") + "," +"rating:" + rating + "" +"}";
+            return "{" + (genre == null ? "genre:null" : "genre:\"" + genre + "\"") + "," + "rating:" + rating + "" + "}";
         """.trimIndent()
         val generatedInputString = dataTypes[0].typeSpec.methodSpecs.single { it.name == "toString" }.code.toString().trimIndent()
         assertThat(expectedInputString).isEqualTo(generatedInputString)
@@ -891,7 +891,7 @@ class CodeGenTest {
 
         assertThat(dataTypes[0].typeSpec.methodSpecs).extracting("name").contains("toString")
         val expectedInputString = """
-            return "{" + "genre:" + (genre != null?"\"":"") + genre + (genre != null?"\"":"") + "," +"rating:" + rating + "," +"average:" + average + "," +"viewed:" + viewed + "" +"}";
+            return "{" + (genre == null ? "genre:null" : "genre:\"" + genre + "\"") + "," + "rating:" + rating + "," + "average:" + average + "," + "viewed:" + viewed + "" + "}";
         """.trimIndent()
         val generatedInputString = dataTypes[0].typeSpec.methodSpecs.single { it.name == "toString" }.code.toString().trimIndent()
         assertThat(expectedInputString).isEqualTo(generatedInputString)
@@ -929,7 +929,7 @@ class CodeGenTest {
 
         assertThat(dataTypes[0].typeSpec.methodSpecs).extracting("name").contains("toString")
         val expectedInputString = """
-            return "{" + "genre:" + (genre != null?"\"":"") + genre + (genre != null?"\"":"") + "," +"rating:" + rating + "," +"average:" + average + "," +"viewed:" + viewed + "," +"identifier:" + (identifier != null?"\"":"") + identifier + (identifier != null?"\"":"") + "" +"}";
+            return "{" + (genre == null ? "genre:null" : "genre:\"" + genre + "\"") + "," + "rating:" + rating + "," + "average:" + average + "," + "viewed:" + viewed + "," + (identifier == null ? "identifier:null" : "identifier:\"" + identifier + "\"") + "" + "}";
         """.trimIndent()
         val generatedInputString = dataTypes[0].typeSpec.methodSpecs.single { it.name == "toString" }.code.toString().trimIndent()
         assertThat(expectedInputString).isEqualTo(generatedInputString)
@@ -1007,7 +1007,7 @@ class CodeGenTest {
         assertThat(dataTypes[0].typeSpec.methodSpecs).extracting("name").contains("toString")
 
         val expectedInputString = """
-            return "{" + "genre:" + genre + "" +"}";
+            return "{" + "genre:" + genre + "" + "}";
         """.trimIndent()
         val generatedInputString = dataTypes[0].typeSpec.methodSpecs.single { it.name == "toString" }.code.toString().trimIndent()
         assertThat(expectedInputString).isEqualTo(generatedInputString)
@@ -1038,7 +1038,7 @@ class CodeGenTest {
         assertThat(dataTypes[0].typeSpec.methodSpecs).extracting("name").contains("toString")
 
         val expectedInputString = """
-            return "{" + "localDateTime:" + (localDateTime != null?"\"":"") + localDateTime + (localDateTime != null?"\"":"") + "," +"localDate:" + (localDate != null?"\"":"") + localDate + (localDate != null?"\"":"") + "," +"localTime:" + (localTime != null?"\"":"") + localTime + (localTime != null?"\"":"") + "," +"dateTime:" + (dateTime != null?"\"":"") + dateTime + (dateTime != null?"\"":"") + "" +"}";
+            return "{" + (localDateTime == null ? "localDateTime:null" : "localDateTime:\"" + localDateTime + "\"") + "," + (localDate == null ? "localDate:null" : "localDate:\"" + localDate + "\"") + "," + (localTime == null ? "localTime:null" : "localTime:\"" + localTime + "\"") + "," + (dateTime == null ? "dateTime:null" : "dateTime:\"" + dateTime + "\"") + "" + "}";
         """.trimIndent()
         val generatedInputString = dataTypes[0].typeSpec.methodSpecs.single { it.name == "toString" }.code.toString().trimIndent()
         assertThat(expectedInputString).isEqualTo(generatedInputString)
@@ -1068,7 +1068,7 @@ class CodeGenTest {
         assertThat(dataTypes[0].typeSpec.methodSpecs).extracting("name").contains("toString")
 
         val expectedInputString = """
-            return "{" + "time:" + (time != null?"\"":"") + time + (time != null?"\"":"") + "," +"date:" + date + "" +"}";
+            return "{" + (time == null ? "time:null" : "time:\"" + time + "\"") + "," + "date:" + date + "" + "}";
         """.trimIndent()
         val generatedInputString = dataTypes[0].typeSpec.methodSpecs.single { it.name == "toString" }.code.toString().trimIndent()
         assertThat(generatedInputString).isEqualTo(expectedInputString)

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/EntitiesClientApiGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/EntitiesClientApiGenTest.kt
@@ -64,7 +64,7 @@ class EntitiesClientApiGenTest {
         assertThat(representations[0].typeSpec.name).isEqualTo("MovieRepresentation")
         assertThat(representations[0].typeSpec.fieldSpecs).extracting("name").containsExactlyInAnyOrder("__typename", "movieId")
 
-        assertCompiles(codeGenResult.clientProjections.plus(codeGenResult.queryTypes).plus(codeGenResult.dataTypes))
+        assertCompilesJava(codeGenResult.clientProjections.plus(codeGenResult.queryTypes).plus(codeGenResult.dataTypes))
     }
 
     @Test
@@ -112,7 +112,7 @@ class EntitiesClientApiGenTest {
         assertThat(representations[1].typeSpec.name).isEqualTo("IActorRepresentation")
         assertThat(representations[1].typeSpec.fieldSpecs).extracting("name").containsExactlyInAnyOrder("__typename", "name")
 
-        assertCompiles(codeGenResult.clientProjections.plus(codeGenResult.queryTypes).plus(codeGenResult.dataTypes).plus(codeGenResult.interfaces))
+        assertCompilesJava(codeGenResult.clientProjections.plus(codeGenResult.queryTypes).plus(codeGenResult.dataTypes).plus(codeGenResult.interfaces))
     }
 
     @Test
@@ -154,7 +154,7 @@ class EntitiesClientApiGenTest {
         assertThat(representations[0].typeSpec.fieldSpecs[1]).extracting("type")
             .toString().contains("java.util.List<com.netflix.graphql.dgs.codegen.tests.generated.client.ActorRepresentation>")
 
-        assertCompiles(codeGenResult.clientProjections.plus(codeGenResult.queryTypes).plus(codeGenResult.dataTypes))
+        assertCompilesJava(codeGenResult.clientProjections.plus(codeGenResult.queryTypes).plus(codeGenResult.dataTypes))
     }
 
     @Test
@@ -209,7 +209,7 @@ class EntitiesClientApiGenTest {
         assertThat(representations[2].typeSpec.name).isEqualTo("MovieCastRepresentation")
         assertThat(representations[2].typeSpec.fieldSpecs).extracting("name").containsExactlyInAnyOrder("__typename", "movie", "actor")
 
-        assertCompiles(codeGenResult.clientProjections.plus(codeGenResult.queryTypes).plus(codeGenResult.dataTypes))
+        assertCompilesJava(codeGenResult.clientProjections.plus(codeGenResult.queryTypes).plus(codeGenResult.dataTypes))
     }
 
     @Test
@@ -254,7 +254,7 @@ class EntitiesClientApiGenTest {
         assertThat(representations[1].typeSpec.name).isEqualTo("MovieActorRepresentation")
         assertThat(representations[1].typeSpec.fieldSpecs).extracting("name").containsExactlyInAnyOrder("__typename", "name")
 
-        assertCompiles(codeGenResult.clientProjections.plus(codeGenResult.queryTypes).plus(codeGenResult.dataTypes))
+        assertCompilesJava(codeGenResult.clientProjections.plus(codeGenResult.queryTypes).plus(codeGenResult.dataTypes))
     }
 
     @Test
@@ -297,7 +297,7 @@ class EntitiesClientApiGenTest {
         assertThat(representations[1].typeSpec.name).isEqualTo("PersonRepresentation")
         assertThat(representations[1].typeSpec.fieldSpecs).extracting("name").containsExactlyInAnyOrder("__typename", "name", "age")
 
-        assertCompiles(codeGenResult.clientProjections.plus(codeGenResult.queryTypes).plus(codeGenResult.dataTypes))
+        assertCompilesJava(codeGenResult.clientProjections.plus(codeGenResult.queryTypes).plus(codeGenResult.dataTypes))
     }
 
     @Test
@@ -327,7 +327,7 @@ class EntitiesClientApiGenTest {
         assertThat(representations.size).isEqualTo(1)
         val projections = codeGenResult.clientProjections
         assertThat(projections.size).isEqualTo(3)
-        assertCompiles(codeGenResult.clientProjections.plus(codeGenResult.queryTypes).plus(codeGenResult.dataTypes))
+        assertCompilesJava(codeGenResult.clientProjections.plus(codeGenResult.queryTypes).plus(codeGenResult.dataTypes))
     }
 
     @Test

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
@@ -869,7 +869,7 @@ class KotlinCodeGenTest {
         val type = dataTypes[0].members[0] as TypeSpec
         assertThat(type.funSpecs).extracting("name").contains("toString")
         val expectedInputString = """
-            return "{" + "genre:" + "${'$'}{if(genre != null) "\"" else ""}" + genre + "${'$'}{if(genre != null) "\"" else ""}" + "," +"rating:" + rating + "," +"views:" + views + "," +"stars:" + stars + "" +"}"
+            return "{" + (if (genre == null) "genre:null" else "genre:\"" + genre + "\"") + "," + "rating:" + rating + "," + "views:" + views + "," + "stars:" + stars + "" + "}"
         """.trimIndent()
         val generatedInputString = type.funSpecs.single { it.name == "toString" }.body.toString().trimIndent()
         assertThat(expectedInputString).isEqualTo(generatedInputString)
@@ -902,7 +902,7 @@ class KotlinCodeGenTest {
         val type = dataTypes[0].members[0] as TypeSpec
         assertThat(type.funSpecs).extracting("name").contains("toString")
         val expectedInputString = """
-            return "{" + "genre:" + "\"" + genre + "\"" + "," +"rating:" + rating + "," +"views:" + views + "," +"stars:" + stars + "" +"}"
+            return "{" + "genre:\"" + genre + "\"" + "," + "rating:" + rating + "," + "views:" + views + "," + "stars:" + stars + "" + "}"
         """.trimIndent()
         val generatedInputString = type.funSpecs.single { it.name == "toString" }.body.toString().trimIndent()
         assertThat(expectedInputString).isEqualTo(generatedInputString)
@@ -935,7 +935,7 @@ class KotlinCodeGenTest {
         val type = dataTypes[0].members[0] as TypeSpec
         assertThat(type.funSpecs).extracting("name").contains("toString")
         val expectedInputString = """
-            return "{" + "genre:" + "\"" + genre + "\"" + "," +"rating:" + rating + "," +"average:" + average + "," +"viewed:" + viewed + "" +"}"
+            return "{" + "genre:\"" + genre + "\"" + "," + "rating:" + rating + "," + "average:" + average + "," + "viewed:" + viewed + "" + "}"
         """.trimIndent()
         val generatedInputString = type.funSpecs.single { it.name == "toString" }.body.toString().trimIndent()
         assertThat(expectedInputString).isEqualTo(generatedInputString)
@@ -974,7 +974,7 @@ class KotlinCodeGenTest {
         val type = dataTypes[0].members[0] as TypeSpec
         assertThat(type.funSpecs).extracting("name").contains("toString")
         val expectedInputString = """
-            return "{" + "genre:" + "${'$'}{if(genre != null) "\"" else ""}" + genre + "${'$'}{if(genre != null) "\"" else ""}" + "," +"rating:" + rating + "," +"average:" + average + "," +"viewed:" + viewed + "," +"identifier:" + "${'$'}{if(identifier != null) "\"" else ""}" + identifier + "${'$'}{if(identifier != null) "\"" else ""}" + "" +"}"
+            return "{" + (if (genre == null) "genre:null" else "genre:\"" + genre + "\"") + "," + "rating:" + rating + "," + "average:" + average + "," + "viewed:" + viewed + "," + (if (identifier == null) "identifier:null" else "identifier:\"" + identifier + "\"") + "" + "}"
         """.trimIndent()
         val generatedInputString = type.funSpecs.single { it.name == "toString" }.body.toString().trimIndent()
         assertThat(expectedInputString).isEqualTo(generatedInputString)
@@ -1052,7 +1052,7 @@ class KotlinCodeGenTest {
         val type = dataTypes[0].members[0] as TypeSpec
         assertThat(type.funSpecs).extracting("name").contains("toString")
         val expectedInputString = """
-            return "{" + "genre:" + genre + "" +"}"
+            return "{" + "genre:" + genre + "" + "}"
         """.trimIndent()
         val generatedInputString = type.funSpecs.single { it.name == "toString" }.body.toString().trimIndent()
         assertThat(expectedInputString).isEqualTo(generatedInputString)
@@ -1113,7 +1113,7 @@ class KotlinCodeGenTest {
         assertThat(type.funSpecs).extracting("name").contains("toString")
 
         val expectedInputString = """
-           return "{" + "localDateTime:" + "${'$'}{if(localDateTime != null) "\"" else ""}" + localDateTime + "${'$'}{if(localDateTime != null) "\"" else ""}" + "," +"localDate:" + "${'$'}{if(localDate != null) "\"" else ""}" + localDate + "${'$'}{if(localDate != null) "\"" else ""}" + "," +"localTime:" + "${'$'}{if(localTime != null) "\"" else ""}" + localTime + "${'$'}{if(localTime != null) "\"" else ""}" + "," +"dateTime:" + "${'$'}{if(dateTime != null) "\"" else ""}" + dateTime + "${'$'}{if(dateTime != null) "\"" else ""}" + "" +"}"
+           return "{" + (if (localDateTime == null) "localDateTime:null" else "localDateTime:\"" + localDateTime + "\"") + "," + (if (localDate == null) "localDate:null" else "localDate:\"" + localDate + "\"") + "," + (if (localTime == null) "localTime:null" else "localTime:\"" + localTime + "\"") + "," + (if (dateTime == null) "dateTime:null" else "dateTime:\"" + dateTime + "\"") + "" + "}"
         """.trimIndent()
         val generatedInputString = type.funSpecs.single { it.name == "toString" }.body.toString().trimIndent()
         assertThat(generatedInputString).isEqualTo(expectedInputString)
@@ -1173,7 +1173,7 @@ class KotlinCodeGenTest {
         assertThat(type.funSpecs).extracting("name").contains("toString")
 
         val expectedInputString = """
-            return "{" + "time:" + "${'$'}{if(time != null) "\"" else ""}" + time + "${'$'}{if(time != null) "\"" else ""}" + "," +"date:" + date + "" +"}"
+            return "{" + (if (time == null) "time:null" else "time:\"" + time + "\"") + "," + "date:" + date + "" + "}"
         """.trimIndent()
         val generatedInputString = type.funSpecs.single { it.name == "toString" }.body.toString().trimIndent()
         assertThat(generatedInputString).isEqualTo(expectedInputString)

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
@@ -869,7 +869,12 @@ class KotlinCodeGenTest {
         val type = dataTypes[0].members[0] as TypeSpec
         assertThat(type.funSpecs).extracting("name").contains("toString")
         val expectedInputString = """
-            return "{" + (if (genre == null) "genre:null" else "genre:\"" + genre + "\"") + "," + "rating:" + rating + "," + "views:" + views + "," + "stars:" + stars + "" + "}"
+            return linkedMapOf(
+            "genre" to (if (genre == null) null else "\"" + genre + "\""),
+            "rating" to rating,
+            "views" to views,
+            "stars" to stars,
+            ).map { it.key + ":" + it.value }.joinToString(",", "{", "}")
         """.trimIndent()
         val generatedInputString = type.funSpecs.single { it.name == "toString" }.body.toString().trimIndent()
         assertThat(expectedInputString).isEqualTo(generatedInputString)
@@ -902,7 +907,12 @@ class KotlinCodeGenTest {
         val type = dataTypes[0].members[0] as TypeSpec
         assertThat(type.funSpecs).extracting("name").contains("toString")
         val expectedInputString = """
-            return "{" + "genre:\"" + genre + "\"" + "," + "rating:" + rating + "," + "views:" + views + "," + "stars:" + stars + "" + "}"
+            return linkedMapOf(
+            "genre" to (if (genre == null) null else "\"" + genre + "\""),
+            "rating" to rating,
+            "views" to views,
+            "stars" to stars,
+            ).map { it.key + ":" + it.value }.joinToString(",", "{", "}")
         """.trimIndent()
         val generatedInputString = type.funSpecs.single { it.name == "toString" }.body.toString().trimIndent()
         assertThat(expectedInputString).isEqualTo(generatedInputString)
@@ -935,7 +945,12 @@ class KotlinCodeGenTest {
         val type = dataTypes[0].members[0] as TypeSpec
         assertThat(type.funSpecs).extracting("name").contains("toString")
         val expectedInputString = """
-            return "{" + "genre:\"" + genre + "\"" + "," + "rating:" + rating + "," + "average:" + average + "," + "viewed:" + viewed + "" + "}"
+            return linkedMapOf(
+            "genre" to (if (genre == null) null else "\"" + genre + "\""),
+            "rating" to rating,
+            "average" to average,
+            "viewed" to viewed,
+            ).map { it.key + ":" + it.value }.joinToString(",", "{", "}")
         """.trimIndent()
         val generatedInputString = type.funSpecs.single { it.name == "toString" }.body.toString().trimIndent()
         assertThat(expectedInputString).isEqualTo(generatedInputString)
@@ -974,7 +989,13 @@ class KotlinCodeGenTest {
         val type = dataTypes[0].members[0] as TypeSpec
         assertThat(type.funSpecs).extracting("name").contains("toString")
         val expectedInputString = """
-            return "{" + (if (genre == null) "genre:null" else "genre:\"" + genre + "\"") + "," + "rating:" + rating + "," + "average:" + average + "," + "viewed:" + viewed + "," + (if (identifier == null) "identifier:null" else "identifier:\"" + identifier + "\"") + "" + "}"
+            return linkedMapOf(
+            "genre" to (if (genre == null) null else "\"" + genre + "\""),
+            "rating" to rating,
+            "average" to average,
+            "viewed" to viewed,
+            "identifier" to (if (identifier == null) null else "\"" + identifier + "\""),
+            ).map { it.key + ":" + it.value }.joinToString(",", "{", "}")
         """.trimIndent()
         val generatedInputString = type.funSpecs.single { it.name == "toString" }.body.toString().trimIndent()
         assertThat(expectedInputString).isEqualTo(generatedInputString)
@@ -1005,7 +1026,10 @@ class KotlinCodeGenTest {
         val type = dataTypes[0].members[0] as TypeSpec
         assertThat(type.funSpecs).extracting("name").contains("toString")
         var expectedInputString = """
-            return "{" + "genre:" + serializeListOfString(genre) + "," +"actors:" + serializeListOfString(actors) + "" +"}"
+            return linkedMapOf(
+            "genre" to serializeListOfString(genre),
+            "actors" to serializeListOfString(actors),
+            ).map { it.key + ":" + it.value }.joinToString(",", "{", "}")
         """.trimIndent()
         var generatedInputString = type.funSpecs.single { it.name == "toString" }.body.toString().trimIndent()
         assertThat(expectedInputString).isEqualTo(generatedInputString)
@@ -1052,7 +1076,9 @@ class KotlinCodeGenTest {
         val type = dataTypes[0].members[0] as TypeSpec
         assertThat(type.funSpecs).extracting("name").contains("toString")
         val expectedInputString = """
-            return "{" + "genre:" + genre + "" + "}"
+            return linkedMapOf(
+            "genre" to genre,
+            ).map { it.key + ":" + it.value }.joinToString(",", "{", "}")
         """.trimIndent()
         val generatedInputString = type.funSpecs.single { it.name == "toString" }.body.toString().trimIndent()
         assertThat(expectedInputString).isEqualTo(generatedInputString)
@@ -1113,7 +1139,12 @@ class KotlinCodeGenTest {
         assertThat(type.funSpecs).extracting("name").contains("toString")
 
         val expectedInputString = """
-           return "{" + (if (localDateTime == null) "localDateTime:null" else "localDateTime:\"" + localDateTime + "\"") + "," + (if (localDate == null) "localDate:null" else "localDate:\"" + localDate + "\"") + "," + (if (localTime == null) "localTime:null" else "localTime:\"" + localTime + "\"") + "," + (if (dateTime == null) "dateTime:null" else "dateTime:\"" + dateTime + "\"") + "" + "}"
+            return linkedMapOf(
+            "localDateTime" to (if (localDateTime == null) null else "\"" + localDateTime + "\""),
+            "localDate" to (if (localDate == null) null else "\"" + localDate + "\""),
+            "localTime" to (if (localTime == null) null else "\"" + localTime + "\""),
+            "dateTime" to (if (dateTime == null) null else "\"" + dateTime + "\""),
+            ).map { it.key + ":" + it.value }.joinToString(",", "{", "}")
         """.trimIndent()
         val generatedInputString = type.funSpecs.single { it.name == "toString" }.body.toString().trimIndent()
         assertThat(generatedInputString).isEqualTo(expectedInputString)
@@ -1143,7 +1174,10 @@ class KotlinCodeGenTest {
         assertThat(type.funSpecs).extracting("name").contains("toString")
 
         val expectedInputString = """
-            return "{" + "names:" + serializeListOfString(names) + "," +"localDateTime:" + serializeListOfLocalDateTime(localDateTime) + "" +"}"
+            return linkedMapOf(
+            "names" to serializeListOfString(names),
+            "localDateTime" to serializeListOfLocalDateTime(localDateTime),
+            ).map { it.key + ":" + it.value }.joinToString(",", "{", "}")
         """.trimIndent()
         val generatedInputString = type.funSpecs.single { it.name == "toString" }.body.toString().trimIndent()
         assertThat(generatedInputString).isEqualTo(expectedInputString)
@@ -1173,7 +1207,10 @@ class KotlinCodeGenTest {
         assertThat(type.funSpecs).extracting("name").contains("toString")
 
         val expectedInputString = """
-            return "{" + (if (time == null) "time:null" else "time:\"" + time + "\"") + "," + "date:" + date + "" + "}"
+            return linkedMapOf(
+            "time" to (if (time == null) null else "\"" + time + "\""),
+            "date" to date,
+            ).map { it.key + ":" + it.value }.joinToString(",", "{", "}")
         """.trimIndent()
         val generatedInputString = type.funSpecs.single { it.name == "toString" }.body.toString().trimIndent()
         assertThat(generatedInputString).isEqualTo(expectedInputString)
@@ -1589,5 +1626,48 @@ class KotlinCodeGenTest {
         val codeGenResult = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, generateClientApi = true, typeMapping = mapOf(), language = Language.KOTLIN)).generate() as KotlinCodeGenResult
         assertThat(codeGenResult.dataTypes.first().toString()).contains("com.example.MyType")
         assertThat(codeGenResult.queryTypes.first().toString()).contains("com.example.MyType")
+    }
+
+    @Test
+    fun generateDataTypeThatOmitsNulls() {
+        val schema = """
+            type Query {
+                movies(filter: MovieFilter)
+            }
+            
+            input MovieFilter {
+                mandatoryString: String!
+                optionalString: String
+                mandatoryInt: Int!
+                optionalInt: Int
+                mandatoryList: [String]!
+                optionalList: [Int]
+            }
+        """.trimIndent()
+
+        val (dataTypes) =
+            CodeGen(
+                CodeGenConfig(
+                    schemas = setOf(schema),
+                    packageName = basePackageName,
+                    language = Language.KOTLIN,
+                    omitNullInputFields = true,
+                )
+            ).generate() as KotlinCodeGenResult
+
+        val type = dataTypes[0].members[0] as TypeSpec
+        assertThat(type.funSpecs).extracting("name").contains("toString")
+        val expectedInputString = """
+            return linkedMapOf(
+            "mandatoryString" to (if (mandatoryString == null) null else "\"" + mandatoryString + "\""),
+            "optionalString" to (if (optionalString == null) null else "\"" + optionalString + "\""),
+            "mandatoryInt" to mandatoryInt,
+            "optionalInt" to optionalInt,
+            "mandatoryList" to serializeListOfString(mandatoryList),
+            "optionalList" to optionalList,
+            ).filter { it.value != null }.map { it.key + ":" + it.value }.joinToString(",", "{", "}")
+        """.trimIndent()
+        val generatedInputString = type.funSpecs.single { it.name == "toString" }.body.toString().trimIndent()
+        assertThat(expectedInputString).isEqualTo(generatedInputString)
     }
 }

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
@@ -908,7 +908,7 @@ class KotlinCodeGenTest {
         assertThat(type.funSpecs).extracting("name").contains("toString")
         val expectedInputString = """
             return linkedMapOf(
-            "genre" to (if (genre == null) null else "\"" + genre + "\""),
+            "genre" to ("\"" + genre + "\""),
             "rating" to rating,
             "views" to views,
             "stars" to stars,
@@ -946,7 +946,7 @@ class KotlinCodeGenTest {
         assertThat(type.funSpecs).extracting("name").contains("toString")
         val expectedInputString = """
             return linkedMapOf(
-            "genre" to (if (genre == null) null else "\"" + genre + "\""),
+            "genre" to ("\"" + genre + "\""),
             "rating" to rating,
             "average" to average,
             "viewed" to viewed,
@@ -1659,7 +1659,7 @@ class KotlinCodeGenTest {
         assertThat(type.funSpecs).extracting("name").contains("toString")
         val expectedInputString = """
             return linkedMapOf(
-            "mandatoryString" to (if (mandatoryString == null) null else "\"" + mandatoryString + "\""),
+            "mandatoryString" to ("\"" + mandatoryString + "\""),
             "optionalString" to (if (optionalString == null) null else "\"" + optionalString + "\""),
             "mandatoryInt" to mandatoryInt,
             "optionalInt" to optionalInt,

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/testUtils.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/testUtils.kt
@@ -22,9 +22,49 @@ import com.google.testing.compile.Compilation
 import com.google.testing.compile.CompilationSubject
 import com.google.testing.compile.Compiler.javac
 import com.squareup.javapoet.JavaFile
+import com.squareup.kotlinpoet.FileSpec
+import org.jetbrains.kotlin.cli.common.arguments.K2JVMCompilerArguments
+import org.jetbrains.kotlin.cli.common.messages.MessageRenderer
+import org.jetbrains.kotlin.cli.common.messages.PrintingMessageCollector
+import org.jetbrains.kotlin.cli.jvm.K2JVMCompiler
+import org.jetbrains.kotlin.config.Services
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.Path
 
-fun assertCompiles(javaFiles: Collection<JavaFile>): Compilation {
+fun assertCompilesJava(javaFiles: Collection<JavaFile>): Compilation {
     val result = javac().compile(javaFiles.map(JavaFile::toJavaFileObject))
     CompilationSubject.assertThat(result).succeededWithoutWarnings()
     return result
+}
+
+fun assertCompilesKotlin(files: List<FileSpec>): Path {
+    val srcDir = Files.createTempDirectory("src")
+    val buildDir = Files.createTempDirectory("build")
+    files.forEach { it.writeTo(srcDir) }
+
+    K2JVMCompiler().run {
+        execImpl(
+            PrintingMessageCollector(
+                System.out,
+                MessageRenderer.WITHOUT_PATHS,
+                false,
+            ),
+            Services.EMPTY,
+            K2JVMCompilerArguments().apply {
+                freeArgs = listOf(srcDir.toAbsolutePath().toString())
+                destination = buildDir.toAbsolutePath().toString()
+                classpath = System.getProperty("java.class.path")
+                    .split(System.getProperty("path.separator"))
+                    .filter {
+                        File(it).exists() && File(it).canRead()
+                    }.joinToString(":")
+                noStdlib = true
+                noReflect = true
+                skipRuntimeVersionCheck = true
+            }
+        )
+    }
+
+    return buildDir
 }

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/testUtils.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/testUtils.kt
@@ -18,11 +18,13 @@
 
 package com.netflix.graphql.dgs.codegen
 
+import com.google.testing.compile.Compilation
 import com.google.testing.compile.CompilationSubject
 import com.google.testing.compile.Compiler.javac
 import com.squareup.javapoet.JavaFile
 
-fun assertCompiles(javaFiles: Collection<JavaFile>) {
+fun assertCompiles(javaFiles: Collection<JavaFile>): Compilation {
     val result = javac().compile(javaFiles.map(JavaFile::toJavaFileObject))
     CompilationSubject.assertThat(result).succeededWithoutWarnings()
+    return result
 }

--- a/graphql-dgs-codegen-gradle/src/main/kotlin/com/netflix/graphql/dgs/codegen/gradle/GenerateJavaTask.kt
+++ b/graphql-dgs-codegen-gradle/src/main/kotlin/com/netflix/graphql/dgs/codegen/gradle/GenerateJavaTask.kt
@@ -101,6 +101,9 @@ open class GenerateJavaTask : DefaultTask() {
     var shortProjectionNames = false
 
     @Input
+    var omitNullInputFields = false
+
+    @Input
     var maxProjectionDepth = 10
 
     @TaskAction
@@ -130,6 +133,7 @@ open class GenerateJavaTask : DefaultTask() {
             skipEntityQueries = skipEntityQueries,
             shortProjectionNames = shortProjectionNames,
             generateDataTypes = generateDataTypes,
+            omitNullInputFields = omitNullInputFields,
             maxProjectionDepth = maxProjectionDepth,
         )
 

--- a/graphql-dgs-codegen-gradle/src/test/java/com/netflix/graphql/dgs/CodegenGradlePluginTest.java
+++ b/graphql-dgs-codegen-gradle/src/test/java/com/netflix/graphql/dgs/CodegenGradlePluginTest.java
@@ -84,7 +84,7 @@ public class CodegenGradlePluginTest {
         // Verify the result
         assertThat(result.task(":build").getOutcome()).isEqualTo(SUCCESS);
         // Verify that POJOs are generated in the configured directory
-        assertThat(new File(EXPECTED_PATH +"Result.java").exists()).isTrue();
+        assertThat(new File(EXPECTED_PATH + "Result.java").exists()).isTrue();
 
     }
 
@@ -102,7 +102,8 @@ public class CodegenGradlePluginTest {
         // Verify the result
         assertThat(result.task(":build").getOutcome()).isEqualTo(SUCCESS);
         // Verify that POJOs are generated in the configured directory
-        assertThat(new File(EXPECTED_DEFAULT_PATH +"Result.java").exists()).isTrue();
+        assertThat(new File(EXPECTED_DEFAULT_PATH + "Result.java").exists()).isTrue();
+    }
 
     @Test
     public void sourcesGenerated_OmitNullInputFields() {

--- a/graphql-dgs-codegen-gradle/src/test/java/com/netflix/graphql/dgs/CodegenGradlePluginTest.java
+++ b/graphql-dgs-codegen-gradle/src/test/java/com/netflix/graphql/dgs/CodegenGradlePluginTest.java
@@ -103,5 +103,22 @@ public class CodegenGradlePluginTest {
         assertThat(result.task(":build").getOutcome()).isEqualTo(SUCCESS);
         // Verify that POJOs are generated in the configured directory
         assertThat(new File(EXPECTED_DEFAULT_PATH +"Result.java").exists()).isTrue();
+
+    @Test
+    public void sourcesGenerated_OmitNullInputFields() {
+        // build a project
+        BuildResult result = GradleRunner.create()
+                .withProjectDir(new File("src/test/resources/test-project/"))
+                .withPluginClasspath(pluginClasspath)
+                .withArguments("-c", "smoke_test_settings_omit_null_input_fields.gradle", "-b", "build_omit_null_input_fields.gradle", "clean", "build", "--stacktrace")
+                .forwardOutput()
+                .withDebug(true)
+                .build();
+
+        // Verify the result
+        assertThat(result.task(":build").getOutcome()).isEqualTo(SUCCESS);
+        // Verify that POJOs are generated in the configured directory
+        assertThat(new File(EXPECTED_DEFAULT_PATH + "Result.java").exists()).isTrue();
+        assertThat(new File(EXPECTED_DEFAULT_PATH + "Filter.java").exists()).isTrue();
     }
 }

--- a/graphql-dgs-codegen-gradle/src/test/resources/test-project/build_omit_null_input_fields.gradle
+++ b/graphql-dgs-codegen-gradle/src/test/resources/test-project/build_omit_null_input_fields.gradle
@@ -1,0 +1,36 @@
+/*
+ *
+ *  Copyright 2020 Netflix, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+plugins {
+    id 'java'
+    id 'com.netflix.dgs.codegen'
+}
+
+configurations {
+    // injected by Gradle Runner through test configuration, see CodegenGradlePluginTest
+    CodeGenConfiguration.exclude group: "com.netflix.graphql.dgs.codegen", module: "graphql-dgs-codegen-core"
+}
+
+generateJava {
+    schemaPaths = ["${projectDir}/src/main/resources/schema"]
+    packageName = 'com.netflix.testproject.graphql'
+    typeMapping = [Date:"java.time.LocalDateTime"]
+    omitNullInputFields = true
+    generateClient = true
+    generateDataTypes = true
+}

--- a/graphql-dgs-codegen-gradle/src/test/resources/test-project/smoke_test_settings_omit_null_input_fields.gradle
+++ b/graphql-dgs-codegen-gradle/src/test/resources/test-project/smoke_test_settings_omit_null_input_fields.gradle
@@ -1,0 +1,19 @@
+/*
+ *
+ *  Copyright 2020 Netflix, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+rootProject.buildFileName = 'build_omit_null_input_fields.gradle'

--- a/graphql-dgs-codegen-gradle/src/test/resources/test-project/src/main/java/com/netflix/testproject/Foo.java
+++ b/graphql-dgs-codegen-gradle/src/test/resources/test-project/src/main/java/com/netflix/testproject/Foo.java
@@ -1,6 +1,6 @@
 package com.netflix.testproject;
 
-public class Foo{
+public class Foo {
     public static void main(String[] args) {
         System.out.println("Hello, world!");
     }

--- a/graphql-dgs-codegen-gradle/src/test/resources/test-project/src/main/resources/schema/schema.graphqls
+++ b/graphql-dgs-codegen-gradle/src/test/resources/test-project/src/main/resources/schema/schema.graphqls
@@ -1,8 +1,16 @@
 type Query {
     result: Result!
+    find(filter: Filter!): Result!
 }
 
 type Result {
     isSuccessful: Boolean
     result: String
+}
+
+input Filter {
+    mandatoryString: String!
+    optionalString: String
+    mandatoryNumber: Int!
+    optionalNumber: Int
 }


### PR DESCRIPTION
Hello All, and thank you for this project.

I've noticed that if an input has the value _null_, it will be explicitly added to a query. For instance, consider the example added to the PR:

```graphql
type Query {
    find(filter: Filter!): Result!
}

input Filter {
    mandatoryString: String!
    optionalString: String
    mandatoryNumber: Int!
    optionalNumber: Int
}
```

The following code:

```java
Filter
        .newBuilder()
        .mandatoryString("hi")
        .mandatoryNumber(10)
        .toString();
```

...produces

```graphql
{mandatoryString:"hi", optionalString:null,mandatoryNumber:10,optionalNumber:null}
```

Given that in a query _null_ and the field being omitted [seem to be equivalent](https://spec.graphql.org/June2018/#sec-Type-System.Non-Null) I was hoping that there was a way to omit those null values and instead have the following output:

```graphql
{mandatoryString:"hi", mandatoryNumber:10}
```

This PR adds a new option to the generator: `omitNullInputFields`. It defaults to _false_, maintaining the existing behavior.

Please let me know if I can improve the code and what can help it get merged.

Thank you once again!