### PR TITLE
Fix name clashes in generated projections caused when field names are concatenated together.

### DIFF
--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ClientApiGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ClientApiGenerator.kt
@@ -165,7 +165,7 @@ class ClientApiGenerator(private val config: CodeGenConfig, private val document
         val codeGenResult = fieldDefinitions.filterSkipped()
             .mapNotNull { if (it.type.findTypeDefinition(document) != null) Pair(it, it.type.findTypeDefinition(document)) else null }
             .map {
-                val projectionName = "${prefix}${it.first.name.capitalize()}Projection"
+                val projectionName = "${prefix}_${it.first.name.capitalize()}Projection"
                 javaType.addMethod(
                     MethodSpec.methodBuilder(ReservedKeywordSanitizer.sanitize(it.first.name))
                         .returns(ClassName.get(getPackageName(), projectionName))
@@ -181,7 +181,7 @@ class ClientApiGenerator(private val config: CodeGenConfig, private val document
                 )
                 val processedEdges = mutableSetOf<Pair<String, String>>()
                 processedEdges.add(Pair(it.second!!.name, type.name))
-                createSubProjection(it.second!!, javaType.build(), javaType.build(), "${prefix}${it.first.name.capitalize()}", processedEdges, 1)
+                createSubProjection(it.second!!, javaType.build(), javaType.build(), "${prefix}_${it.first.name.capitalize()}", processedEdges, 1)
             }
             .fold(CodeGenResult()) { total, current -> total.merge(current) }
 
@@ -268,7 +268,7 @@ class ClientApiGenerator(private val config: CodeGenConfig, private val document
     private fun addFragmentProjectionMethod(javaType: TypeSpec.Builder, rootType: TypeSpec, prefix: String, it: TypeDefinition<*>, processedEdges: Set<Pair<String, String>>, queryDepth: Int): CodeGenResult {
         val rootRef = if (javaType.build().name == rootType.name) "this" else "getRoot()"
 
-        val projectionName = "${prefix}${it.name.capitalize()}Projection"
+        val projectionName = "${prefix}_${it.name.capitalize()}Projection"
         javaType.addMethod(
             MethodSpec.methodBuilder("on${it.name}")
                 .addModifiers(Modifier.PUBLIC)
@@ -283,7 +283,7 @@ class ClientApiGenerator(private val config: CodeGenConfig, private val document
                 .build()
         )
 
-        return createFragment(it as ObjectTypeDefinition, javaType.build(), rootType, "${prefix}${it.name.capitalize()}", processedEdges, queryDepth)
+        return createFragment(it as ObjectTypeDefinition, javaType.build(), rootType, "${prefix}_${it.name.capitalize()}", processedEdges, queryDepth)
     }
 
     private fun createFragment(type: ObjectTypeDefinition, parent: TypeSpec, root: TypeSpec, prefix: String, processedEdges: Set<Pair<String, String>>, queryDepth: Int): CodeGenResult {
@@ -354,7 +354,7 @@ class ClientApiGenerator(private val config: CodeGenConfig, private val document
                 .mapNotNull { if (it.type.findTypeDefinition(document) != null) Pair(it, it.type.findTypeDefinition(document)) else null }
                 .filter { !processedEdges.contains(Pair(it.second!!.name, type.name)) }
                 .map {
-                    val projectionName = "${truncatePrefix(prefix)}${it.first.name.capitalize()}Projection"
+                    val projectionName = "${truncatePrefix(prefix)}_${it.first.name.capitalize()}Projection"
                     javaType.addMethod(
                         MethodSpec.methodBuilder(ReservedKeywordSanitizer.sanitize(it.first.name))
                             .returns(ClassName.get(getPackageName(), projectionName))
@@ -370,7 +370,7 @@ class ClientApiGenerator(private val config: CodeGenConfig, private val document
                     )
                     val updatedProcessedEdges = processedEdges.toMutableSet()
                     updatedProcessedEdges.add(Pair(it.second!!.name, type.name))
-                    createSubProjection(it.second!!, javaType.build(), root, "${truncatePrefix(prefix)}${it.first.name.capitalize()}", updatedProcessedEdges, queryDepth + 1)
+                    createSubProjection(it.second!!, javaType.build(), root, "${truncatePrefix(prefix)}_${it.first.name.capitalize()}", updatedProcessedEdges, queryDepth + 1)
                 }.fold(CodeGenResult()) { total, current -> total.merge(current) }
         } else CodeGenResult()
 

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/ClientApiGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/ClientApiGenerator.kt
@@ -152,7 +152,7 @@ class KotlinClientApiGenerator(private val config: CodeGenConfig, private val do
         val codeGenResult = fieldDefinitions.filterSkipped()
             .mapNotNull { if (it.type.findTypeDefinition(document) != null) Pair(it, it.type.findTypeDefinition(document)) else null }
             .map {
-                val projectionName = "${prefix}${it.first.name.capitalize()}Projection"
+                val projectionName = "${prefix}_${it.first.name.capitalize()}Projection"
                 javaType.addFunction(
                     FunSpec.builder(it.first.name)
                         .returns(ClassName.bestGuess("${getPackageName()}.$projectionName"))
@@ -169,7 +169,7 @@ class KotlinClientApiGenerator(private val config: CodeGenConfig, private val do
                 )
                 val processedEdges = mutableSetOf<Pair<String, String>>()
                 processedEdges.add(Pair(it.second!!.name, type.name))
-                createSubProjection(it.second!!, javaType.build(), javaType.build(), "${prefix}${it.first.name.capitalize()}", processedEdges, 1)
+                createSubProjection(it.second!!, javaType.build(), javaType.build(), "${prefix}_${it.first.name.capitalize()}", processedEdges, 1)
             }.fold(KotlinCodeGenResult()) { total, current -> total.merge(current) }
 
         fieldDefinitions.filterSkipped().forEach {
@@ -236,10 +236,10 @@ class KotlinClientApiGenerator(private val config: CodeGenConfig, private val do
             concreteTypes.map {
                 javaType.addFunction(
                     FunSpec.builder("on${it.name}")
-                        .returns(ClassName.bestGuess("${getPackageName()}.${prefix}${it.name.capitalize()}Projection"))
+                        .returns(ClassName.bestGuess("${getPackageName()}.${prefix}_${it.name.capitalize()}Projection"))
                         .addCode(
                             """
-                                val fragment = ${prefix}${it.name.capitalize()}Projection(this, root)
+                                val fragment = ${prefix}_${it.name.capitalize()}Projection(this, root)
                                 fragments.add(fragment)
                                 return fragment;
                             """.trimIndent()
@@ -247,7 +247,7 @@ class KotlinClientApiGenerator(private val config: CodeGenConfig, private val do
                         .build()
                 )
 
-                createFragment(it, javaType.build(), rootType, "${prefix}${it.name.capitalize()}", processedEdges, queryDepth)
+                createFragment(it, javaType.build(), rootType, "${prefix}_${it.name.capitalize()}", processedEdges, queryDepth)
             }.fold(KotlinCodeGenResult()) { total, current -> total.merge(current) }
         } else KotlinCodeGenResult()
     }
@@ -259,10 +259,10 @@ class KotlinClientApiGenerator(private val config: CodeGenConfig, private val do
             memberTypes.map {
                 javaType.addFunction(
                     FunSpec.builder("on${it.name}")
-                        .returns(ClassName.bestGuess("${getPackageName()}.${prefix}${it.name.capitalize()}Projection"))
+                        .returns(ClassName.bestGuess("${getPackageName()}.${prefix}_${it.name.capitalize()}Projection"))
                         .addCode(
                             """
-                                val fragment = ${prefix}${it.name.capitalize()}Projection(this, root)
+                                val fragment = ${prefix}_${it.name.capitalize()}Projection(this, root)
                                 fragments.add(fragment)
                                 return fragment;
                             """.trimIndent()
@@ -270,7 +270,7 @@ class KotlinClientApiGenerator(private val config: CodeGenConfig, private val do
                         .build()
                 )
 
-                createFragment(it as ObjectTypeDefinition, javaType.build(), rootType, "${prefix}${it.name.capitalize()}", processedEdges, queryDepth)
+                createFragment(it as ObjectTypeDefinition, javaType.build(), rootType, "${prefix}_${it.name.capitalize()}", processedEdges, queryDepth)
             }.fold(KotlinCodeGenResult()) { total, current -> total.merge(current) }
         } else KotlinCodeGenResult()
     }
@@ -350,7 +350,7 @@ class KotlinClientApiGenerator(private val config: CodeGenConfig, private val do
                 .mapNotNull { if (it.type.findTypeDefinition(document) != null) Pair(it, it.type.findTypeDefinition(document)) else null }
                 .filter { !processedEdges.contains(Pair(it.second!!.name, type.name)) }
                 .map {
-                    val projectionName = "${prefix}${it.first.name.capitalize()}Projection"
+                    val projectionName = "${prefix}_${it.first.name.capitalize()}Projection"
                     javaType.addFunction(
                         FunSpec.builder(it.first.name)
                             .returns(ClassName.bestGuess("${getPackageName()}.$projectionName"))
@@ -366,7 +366,7 @@ class KotlinClientApiGenerator(private val config: CodeGenConfig, private val do
                     )
                     val updatedProcessedEdges = processedEdges.toMutableSet()
                     updatedProcessedEdges.add(Pair(it.second!!.name, type.name))
-                    createSubProjection(it.second!!, javaType.build(), root, "${prefix}${it.first.name.capitalize()}", updatedProcessedEdges, queryDepth + 1)
+                    createSubProjection(it.second!!, javaType.build(), root, "${prefix}_${it.first.name.capitalize()}", updatedProcessedEdges, queryDepth + 1)
                 }.fold(KotlinCodeGenResult()) { total, current -> total.merge(current) }
         } else KotlinCodeGenResult()
 

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/shared/ClassnameShortener.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/shared/ClassnameShortener.kt
@@ -22,17 +22,17 @@ class ClassnameShortener {
     companion object {
         /**
          * Takes a class name, and shortens it by taking each upper case letter, and the first following lower case letter.
-         * Example: ThisIsATest becomes ThIsATe
+         * Example: This_Is_A_Test becomes Th_Is_A_Te
          * This is required to prevent extremely long class/file names for projections.
          */
         fun shorten(name: String): String {
             val sb = StringBuilder()
-
-            val split = name.split(Regex("(?=[A-Z])"))
+            val split = name.replace("_", "").split(Regex("(?=[A-Z])"))
             split.filter { it.isNotEmpty() }.forEach {
                 sb.append(it.substring(0, if (it.length > 1) 2 else 1))
+                sb.append("_")
             }
-            return sb.toString()
+            return sb.trimEnd { it == '_' }.toString()
         }
     }
 }

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/shared/ClassnameShortener.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/shared/ClassnameShortener.kt
@@ -27,11 +27,16 @@ class ClassnameShortener {
          */
         fun shorten(name: String): String {
             val sb = StringBuilder()
-            val split = name.replace("_", "").split(Regex("(?=[A-Z])"))
-            split.filter { it.isNotEmpty() }.forEach {
-                sb.append(it.substring(0, if (it.length > 1) 2 else 1))
-                sb.append("_")
+            val splitByUnderscore = name.split("_")
+            splitByUnderscore.filter { it.isNotEmpty() }.forEach { it ->
+                val fieldSb = StringBuilder()
+                val splitByCapitalized = it.split(Regex("(?=[A-Z])"))
+                splitByCapitalized.filter { it.isNotEmpty() }.forEach {
+                    fieldSb.append(it.substring(0, if (it.length > 1) 2 else 1))
+                }
+                sb.append(fieldSb.toString()).append("_")
             }
+
             return sb.trimEnd { it == '_' }.toString()
         }
     }

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/ClientApiGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/ClientApiGenTest.kt
@@ -248,7 +248,7 @@ class ClientApiGenTest {
         ).generate() as CodeGenResult
         assertThat(codeGenResult.clientProjections.size).isEqualTo(2)
         assertThat(codeGenResult.clientProjections[0].typeSpec.name).isEqualTo("PersonsProjectionRoot")
-        assertThat(codeGenResult.clientProjections[1].typeSpec.name).isEqualTo("PersonsFriendsProjection")
+        assertThat(codeGenResult.clientProjections[1].typeSpec.name).isEqualTo("Persons_FriendsProjection")
         assertThat(codeGenResult.clientProjections[0].typeSpec.methodSpecs).extracting("name").contains("name")
         assertThat(codeGenResult.clientProjections[0].typeSpec.methodSpecs).extracting("name").contains("friends")
         assertThat(codeGenResult.clientProjections[1].typeSpec.methodSpecs).extracting("name").contains("name")
@@ -289,10 +289,10 @@ class ClientApiGenTest {
 
         assertThat(codeGenResult.clientProjections.size).isEqualTo(5)
         assertThat(codeGenResult.clientProjections[0].typeSpec.name).isEqualTo("SearchProjectionRoot")
-        assertThat(codeGenResult.clientProjections[1].typeSpec.name).isEqualTo("SearchMovieProjection")
-        assertThat(codeGenResult.clientProjections[2].typeSpec.name).isEqualTo("SearchMovieDetailsProjection")
-        assertThat(codeGenResult.clientProjections[3].typeSpec.name).isEqualTo("SearchMovieDetailsShowProjection")
-        assertThat(codeGenResult.clientProjections[4].typeSpec.name).isEqualTo("SearchMovieDetailsShowMovieProjection")
+        assertThat(codeGenResult.clientProjections[1].typeSpec.name).isEqualTo("Search_MovieProjection")
+        assertThat(codeGenResult.clientProjections[2].typeSpec.name).isEqualTo("Search_Movie_DetailsProjection")
+        assertThat(codeGenResult.clientProjections[3].typeSpec.name).isEqualTo("Search_Movie_Details_ShowProjection")
+        assertThat(codeGenResult.clientProjections[4].typeSpec.name).isEqualTo("Search_Movie_Details_Show_MovieProjection")
 
         assertCompiles(codeGenResult.clientProjections.plus(codeGenResult.queryTypes).plus(codeGenResult.enumTypes).plus(codeGenResult.dataTypes).plus(codeGenResult.interfaces))
     }
@@ -326,12 +326,12 @@ class ClientApiGenTest {
 
         assertThat(codeGenResult.clientProjections.size).isEqualTo(7)
         assertThat(codeGenResult.clientProjections[0].typeSpec.name).isEqualTo("SearchProjectionRoot")
-        assertThat(codeGenResult.clientProjections[1].typeSpec.name).isEqualTo("SearchShowProjection")
-        assertThat(codeGenResult.clientProjections[2].typeSpec.name).isEqualTo("SearchMovieProjection")
-        assertThat(codeGenResult.clientProjections[3].typeSpec.name).isEqualTo("SearchMovieRelatedProjection")
-        assertThat(codeGenResult.clientProjections[4].typeSpec.name).isEqualTo("SearchMovieRelatedVideoProjection")
-        assertThat(codeGenResult.clientProjections[5].typeSpec.name).isEqualTo("SearchMovieRelatedVideoShowProjection")
-        assertThat(codeGenResult.clientProjections[6].typeSpec.name).isEqualTo("SearchMovieRelatedVideoMovieProjection")
+        assertThat(codeGenResult.clientProjections[1].typeSpec.name).isEqualTo("Search_ShowProjection")
+        assertThat(codeGenResult.clientProjections[2].typeSpec.name).isEqualTo("Search_MovieProjection")
+        assertThat(codeGenResult.clientProjections[3].typeSpec.name).isEqualTo("Search_Movie_RelatedProjection")
+        assertThat(codeGenResult.clientProjections[4].typeSpec.name).isEqualTo("Search_Movie_Related_VideoProjection")
+        assertThat(codeGenResult.clientProjections[5].typeSpec.name).isEqualTo("Search_Movie_Related_Video_ShowProjection")
+        assertThat(codeGenResult.clientProjections[6].typeSpec.name).isEqualTo("Search_Movie_Related_Video_MovieProjection")
 
         assertCompiles(codeGenResult.clientProjections.plus(codeGenResult.queryTypes).plus(codeGenResult.enumTypes).plus(codeGenResult.dataTypes).plus(codeGenResult.interfaces))
     }
@@ -390,7 +390,7 @@ class ClientApiGenTest {
             )
         ).generate() as CodeGenResult
         assertThat(codeGenResult.clientProjections[0].typeSpec.name).isEqualTo("PersonsProjectionRoot")
-        assertThat(codeGenResult.clientProjections[1].typeSpec.name).isEqualTo("PersonsDetailsProjection")
+        assertThat(codeGenResult.clientProjections[1].typeSpec.name).isEqualTo("Persons_DetailsProjection")
         assertThat(codeGenResult.clientProjections[2].typeSpec.name).isEqualTo("DetailsProjectionRoot")
 
         assertCompiles(codeGenResult.clientProjections.plus(codeGenResult.queryTypes))
@@ -427,7 +427,46 @@ class ClientApiGenTest {
 
         assertThat(codeGenResult.clientProjections.size).isEqualTo(2)
         assertThat(codeGenResult.clientProjections[0].typeSpec.name).isEqualTo("MoviesProjectionRoot")
-        assertThat(codeGenResult.clientProjections[1].typeSpec.name).isEqualTo("MoviesActorsProjection")
+        assertThat(codeGenResult.clientProjections[1].typeSpec.name).isEqualTo("Movies_ActorsProjection")
+
+        assertCompiles(codeGenResult.clientProjections.plus(codeGenResult.queryTypes))
+    }
+
+    @Test
+    fun generateSubProjectionTypesWithSimilarQueryAndFieldNames() {
+
+        val schema = """
+            type Query {
+                user: User
+            }
+
+            type User {
+                favoriteMovie: Movie
+                favoriteMovieGenre: Genre
+            }
+
+            type Movie {
+                genre: Genre
+            }
+
+            type Genre {
+                name: String
+            }      
+        """.trimIndent()
+
+        val codeGenResult = CodeGen(
+            CodeGenConfig(
+                schemas = setOf(schema),
+                packageName = basePackageName,
+                generateClientApi = true,
+            )
+        ).generate() as CodeGenResult
+
+        assertThat(codeGenResult.clientProjections.size).isEqualTo(4)
+        assertThat(codeGenResult.clientProjections[0].typeSpec.name).isEqualTo("UserProjectionRoot")
+        assertThat(codeGenResult.clientProjections[1].typeSpec.name).isEqualTo("User_FavoriteMovieProjection")
+        assertThat(codeGenResult.clientProjections[2].typeSpec.name).isEqualTo("User_FavoriteMovie_GenreProjection")
+        assertThat(codeGenResult.clientProjections[3].typeSpec.name).isEqualTo("User_FavoriteMovieGenreProjection")
 
         assertCompiles(codeGenResult.clientProjections.plus(codeGenResult.queryTypes))
     }
@@ -464,8 +503,8 @@ class ClientApiGenTest {
 
         assertThat(codeGenResult.clientProjections.size).isEqualTo(3)
         assertThat(codeGenResult.clientProjections[0].typeSpec.name).isEqualTo("MoviesProjectionRoot")
-        assertThat(codeGenResult.clientProjections[1].typeSpec.name).isEqualTo("MoviesActorsProjection")
-        assertThat(codeGenResult.clientProjections[2].typeSpec.name).isEqualTo("MoAcMoviesProjection")
+        assertThat(codeGenResult.clientProjections[1].typeSpec.name).isEqualTo("Movies_ActorsProjection")
+        assertThat(codeGenResult.clientProjections[2].typeSpec.name).isEqualTo("Mo_Ac_MoviesProjection")
 
         assertCompiles(codeGenResult.clientProjections.plus(codeGenResult.queryTypes))
     }
@@ -632,9 +671,9 @@ class ClientApiGenTest {
         assertThat(codeGenResult.clientProjections.size).isEqualTo(3)
         assertThat(codeGenResult.clientProjections[0].typeSpec.name).isEqualTo("SearchProjectionRoot")
         assertThat(codeGenResult.clientProjections[0].typeSpec.methodSpecs[0].name).isEqualTo("title")
-        assertThat(codeGenResult.clientProjections[1].typeSpec.name).isEqualTo("SearchMovieProjection")
+        assertThat(codeGenResult.clientProjections[1].typeSpec.name).isEqualTo("Search_MovieProjection")
         assertThat(codeGenResult.clientProjections[1].typeSpec.methodSpecs[1].name).isEqualTo("duration")
-        assertThat(codeGenResult.clientProjections[2].typeSpec.name).isEqualTo("SearchSeriesProjection")
+        assertThat(codeGenResult.clientProjections[2].typeSpec.name).isEqualTo("Search_SeriesProjection")
         assertThat(codeGenResult.clientProjections[2].typeSpec.methodSpecs[1].name).isEqualTo("episodes")
 
         assertCompiles(codeGenResult.clientProjections.plus(codeGenResult.queryTypes).plus(codeGenResult.enumTypes).plus(codeGenResult.dataTypes).plus(codeGenResult.interfaces))
@@ -674,11 +713,11 @@ class ClientApiGenTest {
         assertThat(codeGenResult.clientProjections.size).isEqualTo(3)
         assertThat(codeGenResult.clientProjections[0].typeSpec.name).isEqualTo("SearchProjectionRoot")
         assertThat(codeGenResult.clientProjections[0].typeSpec.methodSpecs[0].name).isEqualTo("title")
-        assertThat(codeGenResult.clientProjections[1].typeSpec.name).isEqualTo("SearchMovieProjection")
+        assertThat(codeGenResult.clientProjections[1].typeSpec.name).isEqualTo("Search_MovieProjection")
         assertThat(codeGenResult.clientProjections[1].typeSpec.methodSpecs).extracting("name").contains("duration")
         assertThat(codeGenResult.clientProjections[1].typeSpec.methodSpecs).extracting("name").doesNotContain("title")
         assertThat(codeGenResult.clientProjections[1].typeSpec.methodSpecs).extracting("name").doesNotContain("episodes")
-        assertThat(codeGenResult.clientProjections[2].typeSpec.name).isEqualTo("SearchSeriesProjection")
+        assertThat(codeGenResult.clientProjections[2].typeSpec.name).isEqualTo("Search_SeriesProjection")
         assertThat(codeGenResult.clientProjections[2].typeSpec.methodSpecs).extracting("name").contains("episodes")
         assertThat(codeGenResult.clientProjections[2].typeSpec.methodSpecs).extracting("name").doesNotContain("title")
         assertThat(codeGenResult.clientProjections[2].typeSpec.methodSpecs).extracting("name").doesNotContain("duration")
@@ -723,13 +762,13 @@ class ClientApiGenTest {
 
         assertThat(codeGenResult.clientProjections.size).isEqualTo(4)
         assertThat(codeGenResult.clientProjections[0].typeSpec.name).isEqualTo("SearchProjectionRoot")
-        assertThat(codeGenResult.clientProjections[1].typeSpec.name).isEqualTo("SearchShowProjection")
+        assertThat(codeGenResult.clientProjections[1].typeSpec.name).isEqualTo("Search_ShowProjection")
         assertThat(codeGenResult.clientProjections[1].typeSpec.methodSpecs).extracting("name").contains("title")
-        assertThat(codeGenResult.clientProjections[2].typeSpec.name).isEqualTo("SearchShowMovieProjection")
+        assertThat(codeGenResult.clientProjections[2].typeSpec.name).isEqualTo("Search_Show_MovieProjection")
         assertThat(codeGenResult.clientProjections[2].typeSpec.methodSpecs).extracting("name").contains("duration")
         assertThat(codeGenResult.clientProjections[2].typeSpec.methodSpecs).extracting("name").doesNotContain("title")
         assertThat(codeGenResult.clientProjections[2].typeSpec.methodSpecs).extracting("name").doesNotContain("episodes")
-        assertThat(codeGenResult.clientProjections[3].typeSpec.name).isEqualTo("SearchShowSeriesProjection")
+        assertThat(codeGenResult.clientProjections[3].typeSpec.name).isEqualTo("Search_Show_SeriesProjection")
         assertThat(codeGenResult.clientProjections[3].typeSpec.methodSpecs).extracting("name").contains("episodes")
         assertThat(codeGenResult.clientProjections[3].typeSpec.methodSpecs).extracting("name").doesNotContain("title")
         assertThat(codeGenResult.clientProjections[3].typeSpec.methodSpecs).extracting("name").doesNotContain("duration")
@@ -770,10 +809,10 @@ class ClientApiGenTest {
         assertThat(codeGenResult.clientProjections[0].typeSpec.name).isEqualTo("SearchProjectionRoot")
         assertThat(codeGenResult.clientProjections[0].typeSpec.methodSpecs).extracting("name").contains("onMovie")
         assertThat(codeGenResult.clientProjections[0].typeSpec.methodSpecs).extracting("name").contains("onActor")
-        assertThat(codeGenResult.clientProjections[1].typeSpec.name).isEqualTo("SearchMovieProjection")
+        assertThat(codeGenResult.clientProjections[1].typeSpec.name).isEqualTo("Search_MovieProjection")
         assertThat(codeGenResult.clientProjections[1].typeSpec.methodSpecs).extracting("name").contains("title")
         assertThat(codeGenResult.clientProjections[1].typeSpec.methodSpecs).extracting("name").doesNotContain("name")
-        assertThat(codeGenResult.clientProjections[2].typeSpec.name).isEqualTo("SearchActorProjection")
+        assertThat(codeGenResult.clientProjections[2].typeSpec.name).isEqualTo("Search_ActorProjection")
         assertThat(codeGenResult.clientProjections[2].typeSpec.methodSpecs).extracting("name").contains("name")
         assertThat(codeGenResult.clientProjections[2].typeSpec.methodSpecs).extracting("name").doesNotContain("title")
 
@@ -813,15 +852,15 @@ class ClientApiGenTest {
 
         assertThat(codeGenResult.clientProjections.size).isEqualTo(4)
         assertThat(codeGenResult.clientProjections[0].typeSpec.name).isEqualTo("SearchProjectionRoot")
-        assertThat(codeGenResult.clientProjections[1].typeSpec.name).isEqualTo("SearchResultProjection")
+        assertThat(codeGenResult.clientProjections[1].typeSpec.name).isEqualTo("Search_ResultProjection")
         assertThat(codeGenResult.clientProjections[1].typeSpec.methodSpecs).extracting("name").doesNotContain("title")
         assertThat(codeGenResult.clientProjections[1].typeSpec.methodSpecs).extracting("name").doesNotContain("name")
         assertThat(codeGenResult.clientProjections[1].typeSpec.methodSpecs).extracting("name").contains("onMovie")
         assertThat(codeGenResult.clientProjections[1].typeSpec.methodSpecs).extracting("name").contains("onActor")
-        assertThat(codeGenResult.clientProjections[2].typeSpec.name).isEqualTo("SearchResultMovieProjection")
+        assertThat(codeGenResult.clientProjections[2].typeSpec.name).isEqualTo("Search_Result_MovieProjection")
         assertThat(codeGenResult.clientProjections[2].typeSpec.methodSpecs).extracting("name").contains("title")
         assertThat(codeGenResult.clientProjections[2].typeSpec.methodSpecs).extracting("name").doesNotContain("name")
-        assertThat(codeGenResult.clientProjections[3].typeSpec.name).isEqualTo("SearchResultActorProjection")
+        assertThat(codeGenResult.clientProjections[3].typeSpec.name).isEqualTo("Search_Result_ActorProjection")
         assertThat(codeGenResult.clientProjections[3].typeSpec.methodSpecs).extracting("name").contains("name")
         assertThat(codeGenResult.clientProjections[3].typeSpec.methodSpecs).extracting("name").doesNotContain("title")
 
@@ -949,7 +988,7 @@ class ClientApiGenTest {
         ).generate() as CodeGenResult
         val projections = codeGenResult.clientProjections
         assertThat(projections.size).isEqualTo(2)
-        assertThat(projections[1].typeSpec.name).isEqualTo("SearchMovieProjection")
+        assertThat(projections[1].typeSpec.name).isEqualTo("Search_MovieProjection")
         assertThat(projections[1].typeSpec.methodSpecs.size).isEqualTo(3)
         assertThat(projections[1].typeSpec.methodSpecs).extracting("name").contains("title", "director", "<init>")
 
@@ -1066,7 +1105,7 @@ class ClientApiGenTest {
         ).generate() as CodeGenResult
 
         assertThat(codeGenResult.clientProjections.size).isEqualTo(2)
-        val weirdType = codeGenResult.clientProjections.find { it.typeSpec.name == "NormalTypeWeirdTypeProjection" }
+        val weirdType = codeGenResult.clientProjections.find { it.typeSpec.name == "NormalType_WeirdTypeProjection" }
 
         assertThat(weirdType?.typeSpec?.methodSpecs).extracting("name").contains("__", "_root", "_parent", "_import")
 
@@ -1101,8 +1140,8 @@ class ClientApiGenTest {
         val codeGenResult = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, generateClientApi = true, writeToFiles = false)).generate() as CodeGenResult
 
         assertThat(codeGenResult.clientProjections.size).isEqualTo(6)
-        val workshopAssetsReviewsProjection = codeGenResult.clientProjections.find { it.typeSpec.name == "WorkshopAssetsReviewsProjection" }!!
-        val workshopReviewsProjection = codeGenResult.clientProjections.find { it.typeSpec.name == "WorkshopReviewsProjection" }!!
+        val workshopAssetsReviewsProjection = codeGenResult.clientProjections.find { it.typeSpec.name == "Workshop_Assets_ReviewsProjection" }!!
+        val workshopReviewsProjection = codeGenResult.clientProjections.find { it.typeSpec.name == "Workshop_ReviewsProjection" }!!
 
         assertThat(workshopReviewsProjection.typeSpec.methodSpecs).extracting("name").contains("edges")
         assertThat(workshopAssetsReviewsProjection.typeSpec.methodSpecs).extracting("name").contains("edges")
@@ -1254,10 +1293,10 @@ class ClientApiGenTest {
 
         assertThat(codeGenResult.clientProjections.size).isEqualTo(5)
         assertThat(codeGenResult.clientProjections[0].typeSpec.name).isEqualTo("MoviesProjectionRoot")
-        assertThat(codeGenResult.clientProjections[1].typeSpec.name).isEqualTo("MoviesRatingProjection")
-        assertThat(codeGenResult.clientProjections[2].typeSpec.name).isEqualTo("MoviesRatingReviewProjection")
-        assertThat(codeGenResult.clientProjections[3].typeSpec.name).isEqualTo("MoviesActorsProjection")
-        assertThat(codeGenResult.clientProjections[4].typeSpec.name).isEqualTo("MoviesActorsAgentProjection")
+        assertThat(codeGenResult.clientProjections[1].typeSpec.name).isEqualTo("Movies_RatingProjection")
+        assertThat(codeGenResult.clientProjections[2].typeSpec.name).isEqualTo("Movies_Rating_ReviewProjection")
+        assertThat(codeGenResult.clientProjections[3].typeSpec.name).isEqualTo("Movies_ActorsProjection")
+        assertThat(codeGenResult.clientProjections[4].typeSpec.name).isEqualTo("Movies_Actors_AgentProjection")
 
         assertCompiles(codeGenResult.clientProjections.plus(codeGenResult.queryTypes))
     }

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/EntitiesClientApiGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/EntitiesClientApiGenTest.kt
@@ -56,8 +56,8 @@ class EntitiesClientApiGenTest {
         assertThat(projections[0].typeSpec.name).isEqualTo("EntitiesProjectionRoot")
         assertThat(projections[0].typeSpec.methodSpecs).extracting("name").containsExactly("onMovie")
         assertThat(projections[1].typeSpec.name).isEqualTo("EntitiesMovieKeyProjection")
-        assertThat(projections[2].typeSpec.name).isEqualTo("EntitiesMovieKeyActorProjection")
-        assertThat(projections[3].typeSpec.name).isEqualTo("EntitiesMovieKeyActorFriendsProjection")
+        assertThat(projections[2].typeSpec.name).isEqualTo("EntitiesMovieKey_ActorProjection")
+        assertThat(projections[3].typeSpec.name).isEqualTo("EntitiesMovieKey_Actor_FriendsProjection")
 
         val representations = codeGenResult.dataTypes.filter { it.typeSpec.name.contains("Representation") }
         assertThat(representations.size).isEqualTo(1)
@@ -102,8 +102,8 @@ class EntitiesClientApiGenTest {
         assertThat(projections[0].typeSpec.name).isEqualTo("EntitiesProjectionRoot")
         assertThat(projections[0].typeSpec.methodSpecs).extracting("name").containsExactly("onMovie")
         assertThat(projections[1].typeSpec.name).isEqualTo("EntitiesMovieKeyProjection")
-        assertThat(projections[2].typeSpec.name).isEqualTo("EntitiesMovieKeyActorProjection")
-        assertThat(projections[3].typeSpec.name).isEqualTo("EntitiesMovieKeyActorActorProjection")
+        assertThat(projections[2].typeSpec.name).isEqualTo("EntitiesMovieKey_ActorProjection")
+        assertThat(projections[3].typeSpec.name).isEqualTo("EntitiesMovieKey_Actor_ActorProjection")
 
         val representations = codeGenResult.dataTypes.filter { it.typeSpec.name.contains("Representation") }
         assertThat(representations.size).isEqualTo(2)
@@ -145,7 +145,7 @@ class EntitiesClientApiGenTest {
         assertThat(projections[0].typeSpec.name).isEqualTo("EntitiesProjectionRoot")
         assertThat(projections[0].typeSpec.methodSpecs).extracting("name").containsExactly("onMovie", "onActor")
         assertThat(projections[1].typeSpec.name).isEqualTo("EntitiesMovieKeyProjection")
-        assertThat(projections[2].typeSpec.name).isEqualTo("EntitiesMovieKeyActorsProjection")
+        assertThat(projections[2].typeSpec.name).isEqualTo("EntitiesMovieKey_ActorsProjection")
 
         val representations = codeGenResult.dataTypes.filter { it.typeSpec.name.contains("Representation") }
         assertThat(representations.size).isEqualTo(2)
@@ -194,11 +194,11 @@ class EntitiesClientApiGenTest {
         assertThat(projections[0].typeSpec.name).isEqualTo("EntitiesProjectionRoot")
         assertThat(projections[0].typeSpec.methodSpecs).extracting("name").containsExactlyInAnyOrder("onMovie", "onMovieCast")
         assertThat(projections[1].typeSpec.name).isEqualTo("EntitiesMovieKeyProjection")
-        assertThat(projections[2].typeSpec.name).isEqualTo("EntitiesMovieKeyActorProjection")
+        assertThat(projections[2].typeSpec.name).isEqualTo("EntitiesMovieKey_ActorProjection")
         assertThat(projections[3].typeSpec.name).isEqualTo("EntitiesMovieCastKeyProjection")
-        assertThat(projections[4].typeSpec.name).isEqualTo("EntitiesMovieCastKeyMovieProjection")
-        assertThat(projections[5].typeSpec.name).isEqualTo("EntitiesMovieCastKeyMovieActorProjection")
-        assertThat(projections[6].typeSpec.name).isEqualTo("EntitiesMovieCastKeyActorProjection")
+        assertThat(projections[4].typeSpec.name).isEqualTo("EntitiesMovieCastKey_MovieProjection")
+        assertThat(projections[5].typeSpec.name).isEqualTo("EntitiesMovieCastKey_Movie_ActorProjection")
+        assertThat(projections[6].typeSpec.name).isEqualTo("EntitiesMovieCastKey_ActorProjection")
 
         val representations = codeGenResult.dataTypes.filter { it.typeSpec.name.contains("Representation") }
         assertThat(representations.size).isEqualTo(3)
@@ -244,7 +244,7 @@ class EntitiesClientApiGenTest {
         assertThat(projections[0].typeSpec.name).isEqualTo("EntitiesProjectionRoot")
         assertThat(projections[0].typeSpec.methodSpecs).extracting("name").containsExactlyInAnyOrder("onMovie", "onMovieActor")
         assertThat(projections[1].typeSpec.name).isEqualTo("EntitiesMovieKeyProjection")
-        assertThat(projections[2].typeSpec.name).isEqualTo("EntitiesMovieKeyActorProjection")
+        assertThat(projections[2].typeSpec.name).isEqualTo("EntitiesMovieKey_ActorProjection")
         assertThat(projections[3].typeSpec.name).isEqualTo("EntitiesMovieActorKeyProjection")
 
         val representations = codeGenResult.dataTypes.filter { it.typeSpec.name.contains("Representation") }
@@ -288,7 +288,7 @@ class EntitiesClientApiGenTest {
         assertThat(projections[0].typeSpec.name).isEqualTo("EntitiesProjectionRoot")
         assertThat(projections[0].typeSpec.methodSpecs).extracting("name").containsExactlyInAnyOrder("onMovie")
         assertThat(projections[1].typeSpec.name).isEqualTo("EntitiesMovieKeyProjection")
-        assertThat(projections[2].typeSpec.name).isEqualTo("EntitiesMovieKeyActorProjection")
+        assertThat(projections[2].typeSpec.name).isEqualTo("EntitiesMovieKey_ActorProjection")
 
         val representations = codeGenResult.dataTypes.filter { it.typeSpec.name.contains("Representation") }
         assertThat(representations.size).isEqualTo(2)

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinClientApiGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinClientApiGenTest.kt
@@ -158,9 +158,9 @@ class KotlinClientApiGenTest {
         val projectionType = codeGenResult.clientProjections[0].members[0] as TypeSpec
         assertThat(projectionType.funSpecs[0].name).isEqualTo("title")
         val movieProjectionType = codeGenResult.clientProjections[1].members[0] as TypeSpec
-        assertThat(movieProjectionType.name).isEqualTo("SearchMovieProjection")
+        assertThat(movieProjectionType.name).isEqualTo("Search_MovieProjection")
         val seriesProjectionType = codeGenResult.clientProjections[2].members[0] as TypeSpec
-        assertThat(seriesProjectionType.name).isEqualTo("SearchSeriesProjection")
+        assertThat(seriesProjectionType.name).isEqualTo("Search_SeriesProjection")
     }
 
     @Test
@@ -200,10 +200,10 @@ class KotlinClientApiGenTest {
         assertThat(projectionType.name).isEqualTo("SearchProjectionRoot")
         assertThat(projectionType.funSpecs[0].name).isEqualTo("title")
         projectionType = codeGenResult.clientProjections[1].members[0] as TypeSpec
-        assertThat(projectionType.name).isEqualTo("SearchMovieProjection")
+        assertThat(projectionType.name).isEqualTo("Search_MovieProjection")
         assertThat(projectionType.funSpecs).extracting("name").containsExactly("duration", "toString")
         projectionType = codeGenResult.clientProjections[2].members[0] as TypeSpec
-        assertThat(projectionType.name).isEqualTo("SearchSeriesProjection")
+        assertThat(projectionType.name).isEqualTo("Search_SeriesProjection")
         assertThat(projectionType.funSpecs).extracting("name").containsExactly("episodes", "toString")
     }
 
@@ -247,11 +247,11 @@ class KotlinClientApiGenTest {
         var projectionType = codeGenResult.clientProjections[0].members[0] as TypeSpec
         assertThat(projectionType.name).isEqualTo("SearchProjectionRoot")
         projectionType = codeGenResult.clientProjections[1].members[0] as TypeSpec
-        assertThat(projectionType.name).isEqualTo("SearchShowProjection")
+        assertThat(projectionType.name).isEqualTo("Search_ShowProjection")
         projectionType = codeGenResult.clientProjections[2].members[0] as TypeSpec
-        assertThat(projectionType.name).isEqualTo("SearchShowMovieProjection")
+        assertThat(projectionType.name).isEqualTo("Search_Show_MovieProjection")
         projectionType = codeGenResult.clientProjections[3].members[0] as TypeSpec
-        assertThat(projectionType.name).isEqualTo("SearchShowSeriesProjection")
+        assertThat(projectionType.name).isEqualTo("Search_Show_SeriesProjection")
 
         val superclass = projectionType.superclass as ParameterizedTypeName
         assertThat(superclass.typeArguments[1]).extracting("simpleName").containsExactly("SearchProjectionRoot")
@@ -291,12 +291,12 @@ class KotlinClientApiGenTest {
         assertThat(projectionType.funSpecs).extracting("name").contains("onActor")
 
         val movieProjectionType = codeGenResult.clientProjections[1].members[0] as TypeSpec
-        assertThat(movieProjectionType.name).isEqualTo("SearchMovieProjection")
+        assertThat(movieProjectionType.name).isEqualTo("Search_MovieProjection")
         assertThat(movieProjectionType.funSpecs).extracting("name").contains("title")
         assertThat(movieProjectionType.funSpecs).extracting("name").doesNotContain("name")
 
         val actorProjectionType = codeGenResult.clientProjections[2].members[0] as TypeSpec
-        assertThat(actorProjectionType.name).isEqualTo("SearchActorProjection")
+        assertThat(actorProjectionType.name).isEqualTo("Search_ActorProjection")
         assertThat(actorProjectionType.funSpecs).extracting("name").contains("name")
         assertThat(actorProjectionType.funSpecs).extracting("name").doesNotContain("title")
     }
@@ -337,15 +337,15 @@ class KotlinClientApiGenTest {
         val projectionType = codeGenResult.clientProjections[0].members[0] as TypeSpec
         assertThat(projectionType.name).isEqualTo("SearchProjectionRoot")
         val searchResultProjectionType = codeGenResult.clientProjections[1].members[0] as TypeSpec
-        assertThat(searchResultProjectionType.name).isEqualTo("SearchResultProjection")
+        assertThat(searchResultProjectionType.name).isEqualTo("Search_ResultProjection")
         assertThat(searchResultProjectionType.funSpecs).extracting("name").contains("onMovie")
         assertThat(searchResultProjectionType.funSpecs).extracting("name").contains("onActor")
         val movieProjectionType = codeGenResult.clientProjections[2].members[0] as TypeSpec
-        assertThat(movieProjectionType.name).isEqualTo("SearchResultMovieProjection")
+        assertThat(movieProjectionType.name).isEqualTo("Search_Result_MovieProjection")
         assertThat(movieProjectionType.funSpecs).extracting("name").contains("title")
         assertThat(movieProjectionType.funSpecs).extracting("name").doesNotContain("name")
         val actorProjectionType = codeGenResult.clientProjections[3].members[0] as TypeSpec
-        assertThat(actorProjectionType.name).isEqualTo("SearchResultActorProjection")
+        assertThat(actorProjectionType.name).isEqualTo("Search_Result_ActorProjection")
         assertThat(actorProjectionType.funSpecs).extracting("name").contains("name")
         assertThat(actorProjectionType.funSpecs).extracting("name").doesNotContain("title")
 
@@ -497,7 +497,7 @@ class KotlinClientApiGenTest {
         val projectionTypeSpec = codeGenResult.clientProjections[0].members[0] as TypeSpec
         assertThat(projectionTypeSpec.name).isEqualTo("MoviesProjectionRoot")
         val actorTypeSpec = codeGenResult.clientProjections[1].members[0] as TypeSpec
-        assertThat(actorTypeSpec.name).isEqualTo("MoviesActorsProjection")
+        assertThat(actorTypeSpec.name).isEqualTo("Movies_ActorsProjection")
     }
 
     @Test
@@ -527,7 +527,7 @@ class KotlinClientApiGenTest {
         var projectionTypeSpec = codeGenResult.clientProjections[0].members[0] as TypeSpec
         assertThat(projectionTypeSpec.name).isEqualTo("PersonsProjectionRoot")
         projectionTypeSpec = codeGenResult.clientProjections[1].members[0] as TypeSpec
-        assertThat(projectionTypeSpec.name).isEqualTo("PersonsFriendsProjection")
+        assertThat(projectionTypeSpec.name).isEqualTo("Persons_FriendsProjection")
     }
 
     @Test
@@ -590,7 +590,7 @@ class KotlinClientApiGenTest {
         var projectionTypeSpec = codeGenResult.clientProjections[0].members[0] as TypeSpec
         assertThat(projectionTypeSpec.name).isEqualTo("PersonsProjectionRoot")
         projectionTypeSpec = codeGenResult.clientProjections[1].members[0] as TypeSpec
-        assertThat(projectionTypeSpec.name).isEqualTo("PersonsDetailsProjection")
+        assertThat(projectionTypeSpec.name).isEqualTo("Persons_DetailsProjection")
         projectionTypeSpec = codeGenResult.clientProjections[2].members[0] as TypeSpec
         assertThat(projectionTypeSpec.name).isEqualTo("DetailsProjectionRoot")
     }
@@ -815,8 +815,8 @@ class KotlinClientApiGenTest {
 
         assertThat(codeGenResult.clientProjections.size).isEqualTo(6)
 
-        val workshopAssetsReviewsProjection = codeGenResult.clientProjections.find { (it.members[0] as TypeSpec).name == "WorkshopAssetsReviewsProjection" }!!
-        val workshopReviewsProjection = codeGenResult.clientProjections.find { (it.members[0] as TypeSpec).name == "WorkshopReviewsProjection" }!!
+        val workshopAssetsReviewsProjection = codeGenResult.clientProjections.find { (it.members[0] as TypeSpec).name == "Workshop_Assets_ReviewsProjection" }!!
+        val workshopReviewsProjection = codeGenResult.clientProjections.find { (it.members[0] as TypeSpec).name == "Workshop_ReviewsProjection" }!!
 
         assertThat((workshopReviewsProjection.members[0] as TypeSpec).funSpecs).extracting("name").contains("edges")
         assertThat((workshopAssetsReviewsProjection.members[0] as TypeSpec).funSpecs).extracting("name").contains("edges")
@@ -851,12 +851,12 @@ class KotlinClientApiGenTest {
 
         assertThat(codeGenResult.clientProjections.size).isEqualTo(7)
         assertThat((codeGenResult.clientProjections[0].members[0] as TypeSpec).name).isEqualTo("SearchProjectionRoot")
-        assertThat((codeGenResult.clientProjections[1].members[0] as TypeSpec).name).isEqualTo("SearchShowProjection")
-        assertThat((codeGenResult.clientProjections[2].members[0] as TypeSpec).name).isEqualTo("SearchMovieProjection")
-        assertThat((codeGenResult.clientProjections[3].members[0] as TypeSpec).name).isEqualTo("SearchMovieRelatedProjection")
-        assertThat((codeGenResult.clientProjections[4].members[0] as TypeSpec).name).isEqualTo("SearchMovieRelatedVideoProjection")
-        assertThat((codeGenResult.clientProjections[5].members[0] as TypeSpec).name).isEqualTo("SearchMovieRelatedVideoShowProjection")
-        assertThat((codeGenResult.clientProjections[6].members[0] as TypeSpec).name).isEqualTo("SearchMovieRelatedVideoMovieProjection")
+        assertThat((codeGenResult.clientProjections[1].members[0] as TypeSpec).name).isEqualTo("Search_ShowProjection")
+        assertThat((codeGenResult.clientProjections[2].members[0] as TypeSpec).name).isEqualTo("Search_MovieProjection")
+        assertThat((codeGenResult.clientProjections[3].members[0] as TypeSpec).name).isEqualTo("Search_Movie_RelatedProjection")
+        assertThat((codeGenResult.clientProjections[4].members[0] as TypeSpec).name).isEqualTo("Search_Movie_Related_VideoProjection")
+        assertThat((codeGenResult.clientProjections[5].members[0] as TypeSpec).name).isEqualTo("Search_Movie_Related_Video_ShowProjection")
+        assertThat((codeGenResult.clientProjections[6].members[0] as TypeSpec).name).isEqualTo("Search_Movie_Related_Video_MovieProjection")
     }
 
     @Test
@@ -961,12 +961,12 @@ class KotlinClientApiGenTest {
         val projectionTypeSpec = codeGenResult.clientProjections[0].members[0] as TypeSpec
         assertThat(projectionTypeSpec.name).isEqualTo("MoviesProjectionRoot")
         val ratingTypeSpec = codeGenResult.clientProjections[1].members[0] as TypeSpec
-        assertThat(ratingTypeSpec.name).isEqualTo("MoviesRatingProjection")
+        assertThat(ratingTypeSpec.name).isEqualTo("Movies_RatingProjection")
         val reviewTypeSpec = codeGenResult.clientProjections[2].members[0] as TypeSpec
-        assertThat(reviewTypeSpec.name).isEqualTo("MoviesRatingReviewProjection")
+        assertThat(reviewTypeSpec.name).isEqualTo("Movies_Rating_ReviewProjection")
         val actorTypeSpec = codeGenResult.clientProjections[3].members[0] as TypeSpec
-        assertThat(actorTypeSpec.name).isEqualTo("MoviesActorsProjection")
+        assertThat(actorTypeSpec.name).isEqualTo("Movies_ActorsProjection")
         val agentTypeSpec = codeGenResult.clientProjections[4].members[0] as TypeSpec
-        assertThat(agentTypeSpec.name).isEqualTo("MoviesActorsAgentProjection")
+        assertThat(agentTypeSpec.name).isEqualTo("Movies_Actors_AgentProjection")
     }
 }

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinEntitiesClientApiGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinEntitiesClientApiGenTest.kt
@@ -58,8 +58,8 @@ class KotlinEntitiesClientApiGenTest {
         assertThat(projections[0].name).isEqualTo("EntitiesProjectionRoot")
         assertThat((projections[0].members[0] as TypeSpec).funSpecs).extracting("name").containsExactly("onMovie")
         assertThat(projections[1].name).isEqualTo("EntitiesMovieKeyProjection")
-        assertThat(projections[2].name).isEqualTo("EntitiesMovieKeyActorProjection")
-        assertThat(projections[3].name).isEqualTo("EntitiesMovieKeyActorFriendsProjection")
+        assertThat(projections[2].name).isEqualTo("EntitiesMovieKey_ActorProjection")
+        assertThat(projections[3].name).isEqualTo("EntitiesMovieKey_Actor_FriendsProjection")
 
         val representations = codeGenResult.dataTypes.filter { it.name.contains("Representation") }
         assertThat(representations.size).isEqualTo(1)
@@ -103,8 +103,8 @@ class KotlinEntitiesClientApiGenTest {
         assertThat(projections[0].name).isEqualTo("EntitiesProjectionRoot")
         assertThat((projections[0].members[0] as TypeSpec).funSpecs).extracting("name").containsExactly("onMovie")
         assertThat(projections[1].name).isEqualTo("EntitiesMovieKeyProjection")
-        assertThat(projections[2].name).isEqualTo("EntitiesMovieKeyActorProjection")
-        assertThat(projections[3].name).isEqualTo("EntitiesMovieKeyActorActorProjection")
+        assertThat(projections[2].name).isEqualTo("EntitiesMovieKey_ActorProjection")
+        assertThat(projections[3].name).isEqualTo("EntitiesMovieKey_Actor_ActorProjection")
 
         val representations = codeGenResult.dataTypes.filter { it.name.contains("Representation") }
         assertThat(representations.size).isEqualTo(2)
@@ -145,7 +145,7 @@ class KotlinEntitiesClientApiGenTest {
         assertThat(projections[0].name).isEqualTo("EntitiesProjectionRoot")
         assertThat((projections[0].members[0] as TypeSpec).funSpecs).extracting("name").containsExactly("onMovie", "onActor")
         assertThat(projections[1].name).isEqualTo("EntitiesMovieKeyProjection")
-        assertThat(projections[2].name).isEqualTo("EntitiesMovieKeyActorsProjection")
+        assertThat(projections[2].name).isEqualTo("EntitiesMovieKey_ActorsProjection")
 
         val representations = codeGenResult.dataTypes.filter { it.name.contains("Representation") }
         assertThat(representations.size).isEqualTo(2)
@@ -193,12 +193,12 @@ class KotlinEntitiesClientApiGenTest {
         assertThat(projections[0].name).isEqualTo("EntitiesProjectionRoot")
         assertThat((projections[0].members[0] as TypeSpec).funSpecs).extracting("name").containsExactlyInAnyOrder("onMovie", "onPerson", "onMovieCast")
         assertThat(projections[1].name).isEqualTo("EntitiesMovieKeyProjection")
-        assertThat(projections[2].name).isEqualTo("EntitiesMovieKeyActorProjection")
+        assertThat(projections[2].name).isEqualTo("EntitiesMovieKey_ActorProjection")
         assertThat(projections[3].name).isEqualTo("EntitiesPersonKeyProjection")
         assertThat(projections[4].name).isEqualTo("EntitiesMovieCastKeyProjection")
-        assertThat(projections[5].name).isEqualTo("EntitiesMovieCastKeyMovieProjection")
-        assertThat(projections[6].name).isEqualTo("EntitiesMovieCastKeyMovieActorProjection")
-        assertThat(projections[7].name).isEqualTo("EntitiesMovieCastKeyActorProjection")
+        assertThat(projections[5].name).isEqualTo("EntitiesMovieCastKey_MovieProjection")
+        assertThat(projections[6].name).isEqualTo("EntitiesMovieCastKey_Movie_ActorProjection")
+        assertThat(projections[7].name).isEqualTo("EntitiesMovieCastKey_ActorProjection")
 
         val representations = codeGenResult.dataTypes.filter { it.name.contains("Representation") }
         assertThat(representations.size).isEqualTo(3)
@@ -243,7 +243,7 @@ class KotlinEntitiesClientApiGenTest {
         assertThat(projections[0].name).isEqualTo("EntitiesProjectionRoot")
         assertThat((projections[0].members[0] as TypeSpec).funSpecs).extracting("name").containsExactlyInAnyOrder("onMovie", "onMovieActor")
         assertThat(projections[1].name).isEqualTo("EntitiesMovieKeyProjection")
-        assertThat(projections[2].name).isEqualTo("EntitiesMovieKeyActorProjection")
+        assertThat(projections[2].name).isEqualTo("EntitiesMovieKey_ActorProjection")
         assertThat(projections[3].name).isEqualTo("EntitiesMovieActorKeyProjection")
 
         val representations = codeGenResult.dataTypes.filter { it.name.contains("Representation") }
@@ -286,7 +286,7 @@ class KotlinEntitiesClientApiGenTest {
         assertThat(projections[0].name).isEqualTo("EntitiesProjectionRoot")
         assertThat((projections[0].members[0] as TypeSpec).funSpecs).extracting("name").containsExactlyInAnyOrder("onMovie")
         assertThat(projections[1].name).isEqualTo("EntitiesMovieKeyProjection")
-        assertThat(projections[2].name).isEqualTo("EntitiesMovieKeyActorProjection")
+        assertThat(projections[2].name).isEqualTo("EntitiesMovieKey_ActorProjection")
 
         val representations = codeGenResult.dataTypes.filter { it.name.contains("Representation") }
         assertThat(representations.size).isEqualTo(2)

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ClassnameShortenerTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ClassnameShortenerTest.kt
@@ -37,10 +37,10 @@ class ClassnameShortenerTest {
         @JvmStatic
         fun inputAndExpectedProvider(): Stream<Arguments> {
             return Stream.of(
-                Arguments.arguments("ThisIsATest", "ThIsATe"),
+                Arguments.arguments("This_Is_A_Test", "Th_Is_A_Te"),
                 Arguments.arguments("T", "T"),
                 Arguments.arguments("lowercase", "lo"),
-                Arguments.arguments("lowercaseAndUppercase", "loAnUp"),
+                Arguments.arguments("lowercase_And_Uppercase", "lo_An_Up"),
             )
         }
     }

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ClassnameShortenerTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ClassnameShortenerTest.kt
@@ -41,6 +41,7 @@ class ClassnameShortenerTest {
                 Arguments.arguments("T", "T"),
                 Arguments.arguments("lowercase", "lo"),
                 Arguments.arguments("lowercase_And_Uppercase", "lo_An_Up"),
+                Arguments.arguments("Movies_SupplementalData", "Mo_SuDa")
             )
         }
     }


### PR DESCRIPTION
Fixes Issue: https://github.com/Netflix/dgs-codegen/issues/31
This PR fixes name clashes in the following scenario:
```
            type Query {
                user: User
            }

            type User {
                favoriteMovie: Movie
                favoriteMovieGenre: Genre
            }

            type Movie {
                genre: Genre
            }

            type Genre {
                name: String
            }      
```

This would produce 2 classes with `UserFavoriteMovieGenreProjection` for 
1)  user => favoriteMovie with field genre => UserFavoriteMovieGenreProjection
2) user => favoriteMovieGenre return Genre => UserFavoriteMovieGenreProjection



With this PR, we add "_" between fields, so it becomes
1) User_FavoriteMovie_GenreProjection for (1)
2) User_FavoriteMovieGenreProjection for (2)