### PR TITLE
Added the "kotlinAllFieldsOptional" option

### DIFF
--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
@@ -315,7 +315,8 @@ data class CodeGenConfig(
     val shortProjectionNames: Boolean = false,
     val generateDataTypes: Boolean = true,
     val omitNullInputFields: Boolean = false,
-    val maxProjectionDepth: Int = 10
+    val maxProjectionDepth: Int = 10,
+    val kotlinAllFieldsOptional: Boolean = false,
 ) {
     val packageNameClient: String
         get() = "$packageName.$subPackageNameClient"

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinTypeUtils.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinTypeUtils.kt
@@ -71,7 +71,10 @@ class KotlinTypeUtils(private val packageName: String, val config: CodeGenConfig
     }
 
     fun isNullable(fieldType: Type<*>): Boolean {
-        return fieldType !is NonNullType
+        return if (config.kotlinAllFieldsOptional)
+            true
+        else
+            fieldType !is NonNullType
     }
 
     private fun TypeName.toKtTypeName(): KtTypeName {

--- a/graphql-dgs-codegen-gradle/src/main/kotlin/com/netflix/graphql/dgs/codegen/gradle/GenerateJavaTask.kt
+++ b/graphql-dgs-codegen-gradle/src/main/kotlin/com/netflix/graphql/dgs/codegen/gradle/GenerateJavaTask.kt
@@ -106,6 +106,9 @@ open class GenerateJavaTask : DefaultTask() {
     @Input
     var maxProjectionDepth = 10
 
+    @Input
+    var kotlinAllFieldsOptional = false
+
     @TaskAction
     fun generate() {
         val schemaPaths = schemaPaths.map { Paths.get(it.toString()).toFile() }.toSet()
@@ -135,6 +138,7 @@ open class GenerateJavaTask : DefaultTask() {
             generateDataTypes = generateDataTypes,
             omitNullInputFields = omitNullInputFields,
             maxProjectionDepth = maxProjectionDepth,
+            kotlinAllFieldsOptional = kotlinAllFieldsOptional,
         )
 
         LOGGER.info("Codegen config: {}", config)


### PR DESCRIPTION
When the `kotlinAllFieldsOptional` setting is set to `true`, it generates nullable fields in Kotlin even when a field is defined non-Nullable in the schema.
The use of non-nullable in schemas is very opinionated, and depending on its use one setting might work better than the other on the Kotlin side.

Also see this discussion: https://github.com/Netflix/dgs-framework/discussions/79