### PR TITLE
Ensure client projections correctly process types before extensions

### DIFF
--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ClientApiGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ClientApiGenerator.kt
@@ -163,7 +163,7 @@ class ClientApiGenerator(private val config: CodeGenConfig, private val document
 
         val fieldDefinitions = type.fieldDefinitions() + document.definitions.filterIsInstance<ObjectTypeExtensionDefinition>().filter { it.name == type.name }.flatMap { it.fieldDefinitions }
         val codeGenResult = fieldDefinitions.filterSkipped()
-            .mapNotNull { if (it.type.findTypeDefinition(document) != null) Pair(it, it.type.findTypeDefinition(document)) else null }
+            .mapNotNull { if (it.type.findTypeDefinition(document, true) != null) Pair(it, it.type.findTypeDefinition(document, true)) else null }
             .map {
                 val projectionName = "${prefix}_${it.first.name.capitalize()}Projection"
                 javaType.addMethod(

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/ClientApiGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/ClientApiGenerator.kt
@@ -150,7 +150,7 @@ class KotlinClientApiGenerator(private val config: CodeGenConfig, private val do
 
         val fieldDefinitions = type.fieldDefinitions() + document.definitions.filterIsInstance<ObjectTypeExtensionDefinition>().filter { it.name == type.name }.flatMap { it.fieldDefinitions }
         val codeGenResult = fieldDefinitions.filterSkipped()
-            .mapNotNull { if (it.type.findTypeDefinition(document) != null) Pair(it, it.type.findTypeDefinition(document)) else null }
+            .mapNotNull { if (it.type.findTypeDefinition(document, true) != null) Pair(it, it.type.findTypeDefinition(document, true)) else null }
             .map {
                 val projectionName = "${prefix}_${it.first.name.capitalize()}Projection"
                 javaType.addFunction(


### PR DESCRIPTION
When subprojectons are created in generated client code, resolution of types before extensions is not guaranteed.  This means that if a graphql schema file extending a type is processed before another graphql schema file that defines that type, the original type information may be discarded by the extension.  This pull request ensures that type definitions are processed before extensions.

Resolves #101 