### PR TITLE
Support for Snake_Case Constant Name generation.

### DIFF
--- a/graphql-dgs-codegen-core/build.gradle
+++ b/graphql-dgs-codegen-core/build.gradle
@@ -48,6 +48,7 @@ dependencies {
     implementation "com.graphql-java:graphql-java:16.+"
     implementation "com.github.ajalt.clikt:clikt:3.1.+"
     implementation "com.fasterxml.jackson.core:jackson-annotations:2.12.+"
+    implementation "commons-lang:commons-lang:2.6"
 
     testImplementation "com.google.jimfs:jimfs:1.2"
     testImplementation "com.google.testing.compile:compile-testing:0.+"

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
@@ -317,6 +317,8 @@ data class CodeGenConfig(
     val omitNullInputFields: Boolean = false,
     val maxProjectionDepth: Int = 10,
     val kotlinAllFieldsOptional: Boolean = false,
+    /** If enabled, the names of the classes available via the DgsConstant class will be snake cased.*/
+    val snakeCaseConstantNames: Boolean = false,
 ) {
     val packageNameClient: String
         get() = "$packageName.$subPackageNameClient"

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/shared/CodeGeneratorUtils.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/shared/CodeGeneratorUtils.kt
@@ -1,0 +1,44 @@
+/*
+ *
+ *  Copyright 2020 Netflix, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package com.netflix.graphql.dgs.codegen.generators.shared
+
+import org.apache.commons.lang.StringUtils
+
+object CodeGeneratorUtils {
+
+    enum class Case {
+        LOWERCASE,
+        UPPERCASE
+    }
+
+    /**
+     * Transforms the input string, that should express a camel case notation, into one that expresses a snake case notation.
+     *
+     * @see StringUtils.splitByCharacterTypeCamelCase
+     * */
+    fun camelCasetoSnakeCase(input: String, case: Case = Case.LOWERCASE): String {
+        val parts = StringUtils.splitByCharacterTypeCamelCase(input)
+        return parts.joinToString(separator = "_") {
+            when (case) {
+                Case.LOWERCASE -> it.toLowerCase()
+                Case.UPPERCASE -> it.toUpperCase()
+            }
+        }
+    }
+}

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/generators/shared/CodeGeneratorUtilsTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/generators/shared/CodeGeneratorUtilsTest.kt
@@ -1,0 +1,48 @@
+/*
+ *
+ *  Copyright 2020 Netflix, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package com.netflix.graphql.dgs.codegen.generators.shared
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import java.util.stream.Stream
+
+internal class CodeGeneratorUtilsTest {
+
+    @ParameterizedTest(name = "{index} => {0}, expected {1}")
+    @MethodSource("toSnakeCaseData")
+    fun toSnakeCase(input: String, output: String) {
+        assertThat(CodeGeneratorUtils.camelCasetoSnakeCase(input)).isEqualTo(output)
+    }
+
+    companion object {
+        @JvmStatic
+        fun toSnakeCaseData(): Stream<Arguments> = Stream.of(
+            "abc" to "abc",
+            "ABC" to "abc",
+            "Abc" to "abc",
+            "1AB" to "1_ab",
+            "1Abc" to "1_abc",
+            "ABCefg" to "ab_cefg",
+            "A1BCefg" to "a_1_b_cefg",
+            "AbCeFg" to "ab_ce_fg",
+        ).map { Arguments.of(it.first, it.second) }
+    }
+}


### PR DESCRIPTION
Fixes #102 . This commit enables users to configure _code generation_ such that names of classes made available via the `DgsConstants` are _snake cased_, instead of just a block of upper cased letters. The flag in question is `snakeCaseConstantNames`, by default it is set to `false` to keep backward compatibility.

For example, given the following GraphQL Schema...

```graphql
type Query { people: [Person] }

type Person {
    firstname: String
    lastname: String
    metadata: PersonMetaData
}

type PersonMetaData { data: [String] }
```

If the `snakeCaseConstantNames` flag is left as is, the following classes will be available.

* `DgsConstants.QUERY`
* `DgsConstants.PERSON`
* `DgsConstants.PERSONMETADATA`

If the flag `snakeCaseConstantNames` is set to `true`, the following will be available:

* `DgsConstants.QUERY`
* `DgsConstants.PERSON`
* `DgsConstants.PERSON_META_DATA`

Note the change on `PERSONMETADATA` vs `PERSON_META_DATA`.

The full Java class, if the flag is enabled, will look as follows:

```java
package com.netflix.graphql.dgs.codegen.tests.generated;

import java.lang.String;

public class DgsConstants {
  public static final String QUERY_TYPE = "Query";

  public static class QUERY {
    public static final String TYPE_NAME = "Query";

    public static final String People = "people";
  }

  public static class PERSON {
    public static final String TYPE_NAME = "Person";

    public static final String Firstname = "firstname";

    public static final String Lastname = "lastname";

    public static final String Metadata = "metadata";
  }

  public static class PERSON_META_DATA {
    public static final String TYPE_NAME = "PersonMetaData";

    public static final String Data = "data";
  }
}
```