### PR TITLE
Add snakeCaseConstantNames as a Gradle Task Input

### DIFF
--- a/graphql-dgs-codegen-gradle/src/main/kotlin/com/netflix/graphql/dgs/codegen/gradle/GenerateJavaTask.kt
+++ b/graphql-dgs-codegen-gradle/src/main/kotlin/com/netflix/graphql/dgs/codegen/gradle/GenerateJavaTask.kt
@@ -109,6 +109,9 @@ open class GenerateJavaTask : DefaultTask() {
     @Input
     var kotlinAllFieldsOptional = false
 
+    @Input
+    var snakeCaseConstantNames = false
+
     @TaskAction
     fun generate() {
         val schemaPaths = schemaPaths.map { Paths.get(it.toString()).toFile() }.toSet()
@@ -139,6 +142,7 @@ open class GenerateJavaTask : DefaultTask() {
             omitNullInputFields = omitNullInputFields,
             maxProjectionDepth = maxProjectionDepth,
             kotlinAllFieldsOptional = kotlinAllFieldsOptional,
+            snakeCaseConstantNames = snakeCaseConstantNames
         )
 
         LOGGER.info("Codegen config: {}", config)


### PR DESCRIPTION
Missed adding the `snakeCaseConstantNames` as a Gradle Task Input in https://github.com/Netflix/dgs-codegen/pull/104.
Without it users can't leverage the flag in their Gradle Builds.