### PR TITLE
Fixing Kotlin DgsConstants generator

### DIFF
--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinConstantsGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinConstantsGenerator.kt
@@ -100,7 +100,7 @@ class KotlinConstantsGenerator(private val config: CodeGenConfig, private val do
             else
                 name.toUpperCase()
 
-        return TypeSpec.classBuilder(className)
+        return TypeSpec.objectBuilder(className)
     }
 
     private fun addFieldName(constantsType: TypeSpec.Builder, name: String) {


### PR DESCRIPTION
In 4.5.[0,1] has an issue on the Kotlin Generator that reflects on
a malformed DgsConstants file. The interal components are reflected as
`classes` where they should be objects.

e.g.
```
public object DgsConstants {
  public const val QUERY_TYPE: String = "Query"
  public class Foo  {
    public const val TYPE_NAME: String = "MKTSocialCampaignTemp"
    public const val Concept: String = "concept"
  }
```

Should have

```
public object Foo
```