### PR TITLE
Generate interface methods for non-interface fields only (in Java)

### DIFF
--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/DataTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/DataTypeGenerator.kt
@@ -50,7 +50,9 @@ class DataTypeGenerator(private val config: CodeGenConfig, private val document:
             overrideGetter = true
             val fieldDefinitions = definition.fieldDefinitions
                 .filterSkipped()
-                .map { Field(it.name, typeUtils.findReturnType(it.type, useInterfaceType, true)) }
+                .map {
+                    Field(it.name, typeUtils.findReturnType(it.type, useInterfaceType, true))
+                }
                 .plus(extensions.flatMap { it.fieldDefinitions }.filterSkipped().map { Field(it.name, typeUtils.findReturnType(it.type, useInterfaceType, true)) })
             val interfaceName = "I$name"
             implements = listOf(interfaceName) + implements
@@ -59,7 +61,9 @@ class DataTypeGenerator(private val config: CodeGenConfig, private val document:
 
         val fieldDefinitions = definition.fieldDefinitions
             .filterSkipped()
-            .map { Field(it.name, typeUtils.findReturnType(it.type, useInterfaceType), overrideGetter = overrideGetter) }
+            .map {
+                Field(it.name, typeUtils.findReturnType(it.type, useInterfaceType), overrideGetter = overrideGetter)
+            }
             .plus(extensions.flatMap { it.fieldDefinitions }.filterSkipped().map { Field(it.name, typeUtils.findReturnType(it.type, useInterfaceType), overrideGetter = overrideGetter) })
 
         return generate(name, unionTypes.plus(implements), fieldDefinitions, false)
@@ -101,7 +105,7 @@ class InputTypeGenerator(config: CodeGenConfig, document: Document) : BaseDataTy
     }
 }
 
-internal data class Field(val name: String, val type: com.squareup.javapoet.TypeName, val initialValue: CodeBlock? = null, val overrideGetter: Boolean = false)
+internal data class Field(val name: String, val type: com.squareup.javapoet.TypeName, val initialValue: CodeBlock? = null, val overrideGetter: Boolean = false, val interfaceType: com.squareup.javapoet.TypeName? = null)
 
 abstract class BaseDataTypeGenerator(internal val packageName: String, private val config: CodeGenConfig, document: Document) {
     internal val typeUtils = TypeUtils(packageName, config, document)

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/InterfaceGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/InterfaceGenerator.kt
@@ -90,12 +90,5 @@ class InterfaceGenerator(config: CodeGenConfig, private val document: Document) 
                 .returns(returnType)
                 .build()
         )
-
-        javaType.addMethod(
-            MethodSpec.methodBuilder("set${fieldName.capitalize()}")
-                .addModifiers(Modifier.ABSTRACT, Modifier.PUBLIC)
-                .addParameter(returnType, fieldName)
-                .build()
-        )
     }
 }

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/InterfaceGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/InterfaceGenerator.kt
@@ -37,7 +37,25 @@ class InterfaceGenerator(config: CodeGenConfig, private val document: Document) 
             .addModifiers(Modifier.PUBLIC)
 
         definition.fieldDefinitions.forEach {
-            addInterfaceMethod(it, javaType)
+            // Only generate getters/setters for fields that are not interfaces.
+            //
+            // interface Pet {
+            // 	 parent: Pet
+            // }
+            // type Dog implements Pet {
+            // 	 parent: Dog
+            // }
+            // type Bird implements Pet {
+            // 	 parent: Bird
+            // }
+            // For the schema above, we currently generate Dog::setParent(Dog dog), but the interface
+            // would have Pet::setParent(Pet pet) leading to missing overrides in the generated
+            // implementation classes. This is not an issue if the overridden field has the same base type,
+            // however.
+            // Ref: https://github.com/graphql/graphql-js/issues/776
+            if (! isFieldAnInterface(it)) {
+                addInterfaceMethod(it, javaType)
+            }
         }
 
         val implementations = document.getDefinitionsOfType(ObjectTypeDefinition::class.java).asSequence()
@@ -55,7 +73,14 @@ class InterfaceGenerator(config: CodeGenConfig, private val document: Document) 
         return CodeGenResult(interfaces = listOf(javaFile))
     }
 
+    private fun isFieldAnInterface(fieldDefinition: FieldDefinition): Boolean {
+        return document.getDefinitionsOfType(InterfaceTypeDefinition::class.java).asSequence()
+            .filter { node -> node.name == typeUtils.findInnerType(fieldDefinition.type).name }
+            .toList().isNotEmpty()
+    }
+
     private fun addInterfaceMethod(fieldDefinition: FieldDefinition, javaType: TypeSpec.Builder) {
+
         val returnType = typeUtils.findReturnType(fieldDefinition.type)
 
         val fieldName = fieldDefinition.name

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/TypeUtils.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/TypeUtils.kt
@@ -146,6 +146,30 @@ class TypeUtils(private val packageName: String, private val config: CodeGenConf
         }
     }
 
+    fun findInnerType(fieldType: Type<*>, useInterfaceType: Boolean = false, useWildcardType: Boolean = false): TypeName {
+        val visitor = object : NodeVisitorStub() {
+            override fun visitTypeName(node: TypeName, context: TraverserContext<Node<Node<*>>>): TraversalControl {
+                context.setAccumulate(node)
+                return TraversalControl.CONTINUE
+            }
+            override fun visitListType(node: ListType, context: TraverserContext<Node<Node<*>>>): TraversalControl {
+                val typeName = context.getCurrentAccumulate<TypeName>()
+
+                context.setAccumulate(typeName)
+                return TraversalControl.CONTINUE
+            }
+            override fun visitNonNullType(node: NonNullType, context: TraverserContext<Node<Node<*>>>): TraversalControl {
+                val typeName = context.getCurrentAccumulate<TypeName>()
+                context.setAccumulate(typeName)
+                return TraversalControl.CONTINUE
+            }
+            override fun visitNode(node: Node<*>, context: TraverserContext<Node<Node<*>>>): TraversalControl {
+                throw AssertionError("Unknown field type: $node")
+            }
+        }
+        return NodeTraverser().postOrder(visitor, fieldType) as TypeName
+    }
+
     fun isStringInput(name: com.squareup.javapoet.TypeName): Boolean {
         if (config.typeMapping.containsValue(name.toString())) {
             return when (name) {

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/TypeUtils.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/TypeUtils.kt
@@ -146,6 +146,7 @@ class TypeUtils(private val packageName: String, private val config: CodeGenConf
         }
     }
 
+    // Return the raw type for nullable, non-nullable and parameterized fields
     fun findInnerType(fieldType: Type<*>, useInterfaceType: Boolean = false, useWildcardType: Boolean = false): TypeName {
         val visitor = object : NodeVisitorStub() {
             override fun visitTypeName(node: TypeName, context: TraverserContext<Node<Node<*>>>): TraversalControl {

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
@@ -447,11 +447,7 @@ class CodeGenTest {
                |public interface Person {
                |  String getFirstname();
                |
-               |  void setFirstname(String firstname);
-               |
                |  String getLastname();
-               |
-               |  void setLastname(String lastname);
                |}
                |""".trimMargin()
         )
@@ -518,15 +514,62 @@ class CodeGenTest {
                 |public interface Pet {
                 |  String getId();
                 |
-                |  void setId(String id);
-                |
                 |  String getName();
                 |
-                |  void setName(String name);
-                |
                 |  List<String> getAddress();
+                |}
+            |""".trimMargin()
+        )
+
+        assertCompilesJava(dataTypes + interfaces)
+    }
+
+    @Test
+    fun generateInterfaceClassWithInterfaceFieldsOfDifferentType() {
+        val schema = """
+            interface Pet {
+	            name: String
+                diet: Diet
+             }
+             
+            interface Diet {
+                calories: String
+            }
+            
+            type Vegetarian implements Diet {
+                calories: String
+                vegetables: [String]
+            }
+            
+            type Dog implements Pet {
+	            name: String
+                diet: Vegetarian
+            }
+        """.trimIndent()
+
+        val (dataTypes, interfaces) = CodeGen(
+            CodeGenConfig(
+                schemas = setOf(schema),
+                packageName = basePackageName,
+            )
+        ).generate() as CodeGenResult
+
+        Truth.assertThat(interfaces[0].toString()).isEqualTo(
+            """
+                |package com.netflix.graphql.dgs.codegen.tests.generated.types;
                 |
-                |  void setAddress(List<String> address);
+                |import com.fasterxml.jackson.annotation.JsonSubTypes;
+                |import com.fasterxml.jackson.annotation.JsonTypeInfo;
+                |import java.lang.String;
+                |
+                |@JsonTypeInfo(
+                |    use = JsonTypeInfo.Id.NAME,
+                |    include = JsonTypeInfo.As.PROPERTY,
+                |    property = "__typename"
+                |)
+                |@JsonSubTypes(@JsonSubTypes.Type(value = Dog.class, name = "Dog"))
+                |public interface Pet {
+                |  String getName();
                 |}
             |""".trimMargin()
         )
@@ -589,11 +632,7 @@ class CodeGenTest {
                |public interface Person {
                |  String getFirstname();
                |
-               |  void setFirstname(String firstname);
-               |
                |  String getLastname();
-               |
-               |  void setLastname(String lastname);
                |}
                |""".trimMargin()
         )
@@ -1614,11 +1653,7 @@ class CodeGenTest {
                |public interface Person {
                |  String getFirstname();
                |
-               |  void setFirstname(String firstname);
-               |
                |  String getLastname();
-               |
-               |  void setLastname(String lastname);
                |}
                |""".trimMargin()
         )
@@ -1641,15 +1676,9 @@ class CodeGenTest {
                |public interface Employee {
                |  String getFirstname();
                |
-               |  void setFirstname(String firstname);
-               |
                |  String getLastname();
                |
-               |  void setLastname(String lastname);
-               |
                |  String getCompany();
-               |
-               |  void setCompany(String company);
                |}
                |""".trimMargin()
         )

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
@@ -1699,6 +1699,81 @@ class KotlinCodeGenTest {
     }
 
     @Test
+    fun generateInterfaceClassWithInterfaceFields() {
+        // schema contains nullable, non-nullable and list types as interface fields  and fields that are
+        // not interfaces
+        val schema = """
+            interface Pet {
+                id: ID!
+	            name: String
+                address: [String!]!
+                mother: Pet!
+                father: Pet
+            	parents: [Pet]
+             }
+            type Dog implements Pet {
+                id: ID!
+	            name: String
+                address: [String!]!
+                mother: Dog!
+                father: Dog
+            	parents: [Dog]
+            }
+            type Bird implements Pet {
+                id: ID!
+	            name: String
+                address: [String!]!
+                mother: Bird!
+                father: Bird
+            	parents: [Bird]
+            }
+        """.trimIndent()
+
+        val (dataTypes, interfaces) = CodeGen(
+            CodeGenConfig(
+                schemas = setOf(schema),
+                packageName = basePackageName,
+                language = Language.KOTLIN
+            )
+        ).generate() as KotlinCodeGenResult
+
+        Truth.assertThat(interfaces[0].toString()).isEqualTo(
+            """
+                |package com.netflix.graphql.dgs.codegen.tests.generated.types
+                |
+                |import com.fasterxml.jackson.`annotation`.JsonSubTypes
+                |import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+                |import kotlin.String
+                |import kotlin.collections.List
+                |
+                |@JsonTypeInfo(
+                |  use = JsonTypeInfo.Id.NAME,
+                |  include = JsonTypeInfo.As.PROPERTY,
+                |  property = "__typename"
+                |)
+                |@JsonSubTypes(value = [
+                |  JsonSubTypes.Type(value = Dog::class, name = "Dog"),
+                |  JsonSubTypes.Type(value = Bird::class, name = "Bird")
+                |])
+                |public interface Pet {
+                |  public val id: String
+                |
+                |  public val name: String?
+                |
+                |  public val address: List<String>
+                |
+                |  public val mother: Pet
+                |
+                |  public val father: Pet?
+                |
+                |  public val parents: List<Pet?>?
+                |}
+            |""".trimMargin()
+        )
+        assertCompilesKotlin(dataTypes + interfaces)
+    }
+
+    @Test
     fun generateWithJavaTypeDirective() {
         val schema = """
           type Query {


### PR DESCRIPTION
```
             interface Pet {
            	 parent: Pet
             }
             type Dog implements Pet {
             	 parent: Dog
             }
             type Bird implements Pet {
             	 parent: Bird
             }
```
For the schema above, for Java, we currently generate `Dog::setParent(Dog dog)`, but the interface would have `Pet::setParent(Pet pet)` leading to missing overrides for `Dog::setParent(Pet pet)` in the generated implementation class for `Dog`. This is not an issue if the overridden field has the same base type, however.

Kotlin handles the overrides fine, so this is not an issue there.

To avoid complexity, we are choosing to not support this feature for Java. With the changes, the generated interface class would only have abstract methods for  fields that are not interfaces. 

I also chose not to make this configurable to avoid adding too many code paths to support this.