### PR TITLE
Fixed issue to wrongly use (not existing) 'I'-prefixed interface type for GraphQL Union types

### DIFF
--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/TypeUtils.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/TypeUtils.kt
@@ -138,9 +138,10 @@ class TypeUtils(private val packageName: String, private val config: CodeGenConf
             "IDValue" -> ClassName.get(String::class.java)
             else -> {
                 var simpleName = name
-                if (useInterfaceType
-                        && !document.definitions.filterIsInstance<EnumTypeDefinition>().any { e -> e.name == name }
-                        && !document.definitions.filterIsInstance<UnionTypeDefinition>().any { e -> e.name == name }) {
+                if (useInterfaceType &&
+                    !document.definitions.filterIsInstance<EnumTypeDefinition>().any { e -> e.name == name } &&
+                    !document.definitions.filterIsInstance<UnionTypeDefinition>().any { e -> e.name == name }
+                ) {
                     simpleName = "I$name"
                 }
                 ClassName.get(packageName, simpleName)

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/TypeUtils.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/TypeUtils.kt
@@ -138,7 +138,9 @@ class TypeUtils(private val packageName: String, private val config: CodeGenConf
             "IDValue" -> ClassName.get(String::class.java)
             else -> {
                 var simpleName = name
-                if (useInterfaceType && !document.definitions.filterIsInstance<EnumTypeDefinition>().any { e -> e.name == name }) {
+                if (useInterfaceType
+                        && !document.definitions.filterIsInstance<EnumTypeDefinition>().any { e -> e.name == name }
+                        && !document.definitions.filterIsInstance<UnionTypeDefinition>().any { e -> e.name == name }) {
                     simpleName = "I$name"
                 }
                 ClassName.get(packageName, simpleName)

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
@@ -2103,7 +2103,7 @@ class CodeGenTest {
         val dataTypes = result.dataTypes
 
         assertThat(interfaces).hasSize(5) // IHuman, IDroid, ISearchResultPage, SearchResult, Character
-        assertThat(dataTypes).hasSize(3)  // Character, Human, Droid, SearchResultPage
+        assertThat(dataTypes).hasSize(3) // Human, Droid, SearchResultPage
 
         assertThat(interfaces[0].typeSpec.name).isEqualTo("IHuman")
         assertThat(interfaces[1].typeSpec.name).isEqualTo("IDroid")

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
@@ -2092,11 +2092,11 @@ class CodeGenTest {
         """.trimIndent()
 
         val result = CodeGen(
-                CodeGenConfig(
-                        schemas = setOf(schema),
-                        packageName = basePackageName,
-                        generateInterfaces = true
-                )
+            CodeGenConfig(
+                schemas = setOf(schema),
+                packageName = basePackageName,
+                generateInterfaces = true
+            )
         ).generate() as CodeGenResult
 
         val interfaces = result.interfaces


### PR DESCRIPTION
I stumbled against an issue with the generate-interfaces = true flag when using a GraphQL union type.

It was the first time I introduced a GraphQL Union type in my schema so this case was not covered yet with generate-interfaces = true.
For GraphQL Union types an interface is already generated (without 'I' prefix) and no actual class. With generate-interfaces = true the generator was still trying to prefix reference to Union types with 'I' which is incorrect and does not compile.

The change itself is trivial and a test case is added as well.