### PR TITLE
fix: added extend enum, interface, union support + refactoring

### DIFF
--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
@@ -25,7 +25,7 @@ import com.netflix.graphql.dgs.codegen.generators.shared.SchemaExtensionsUtils.f
 import com.netflix.graphql.dgs.codegen.generators.shared.SchemaExtensionsUtils.findInterfaceExtensions
 import com.netflix.graphql.dgs.codegen.generators.shared.SchemaExtensionsUtils.findTypeExtensions
 import com.netflix.graphql.dgs.codegen.generators.shared.SchemaExtensionsUtils.findUnionExtensions
-import com.netflix.graphql.dgs.codegen.generators.shared.filterSchemaTypeExtensions
+import com.netflix.graphql.dgs.codegen.generators.shared.excludeSchemaTypeExtension
 import com.squareup.javapoet.JavaFile
 import com.squareup.kotlinpoet.FileSpec
 import graphql.language.*
@@ -108,7 +108,7 @@ class CodeGen(private val config: CodeGenConfig) {
     private fun generateJavaEnums(definitions: Collection<Definition<*>>): CodeGenResult {
         return definitions.asSequence()
             .filterIsInstance<EnumTypeDefinition>()
-            .filterSchemaTypeExtensions()
+            .excludeSchemaTypeExtension()
             .filter { config.generateDataTypes || it.name in requiredTypeCollector.requiredTypes }
             .map { EnumTypeGenerator(config).generate(it, findEnumExtensions(it.name, definitions)) }
             .fold(CodeGenResult()) { t: CodeGenResult, u: CodeGenResult -> t.merge(u) }
@@ -121,7 +121,7 @@ class CodeGen(private val config: CodeGenConfig) {
 
         return definitions.asSequence()
             .filterIsInstance<UnionTypeDefinition>()
-            .filterSchemaTypeExtensions()
+            .excludeSchemaTypeExtension()
             .map { UnionTypeGenerator(config).generate(it, findUnionExtensions(it.name, definitions)) }
             .fold(CodeGenResult()) { t: CodeGenResult, u: CodeGenResult -> t.merge(u) }
     }
@@ -133,7 +133,7 @@ class CodeGen(private val config: CodeGenConfig) {
 
         return definitions.asSequence()
             .filterIsInstance<InterfaceTypeDefinition>()
-            .filterSchemaTypeExtensions()
+            .excludeSchemaTypeExtension()
             .map {
                 val extensions = findInterfaceExtensions(it.name, definitions)
                 InterfaceGenerator(config, document).generate(it, extensions)
@@ -188,7 +188,7 @@ class CodeGen(private val config: CodeGenConfig) {
 
         return definitions.asSequence()
             .filterIsInstance<ObjectTypeDefinition>()
-            .filterSchemaTypeExtensions()
+            .excludeSchemaTypeExtension()
             .filter { it.name != "Query" && it.name != "Mutation" && it.name != "RelayPageInfo" }
             .map {
                 DataTypeGenerator(config, document).generate(it, findTypeExtensions(it.name, definitions))
@@ -198,7 +198,7 @@ class CodeGen(private val config: CodeGenConfig) {
     private fun generateJavaInputType(definitions: Collection<Definition<*>>): CodeGenResult {
         val inputTypes = definitions.asSequence()
             .filterIsInstance<InputObjectTypeDefinition>()
-            .filterSchemaTypeExtensions()
+            .excludeSchemaTypeExtension()
             .filter { config.generateDataTypes || it.name in requiredTypeCollector.requiredTypes }
 
         return inputTypes
@@ -217,7 +217,7 @@ class CodeGen(private val config: CodeGenConfig) {
 
         val interfacesResult = definitions.asSequence()
             .filterIsInstance<InterfaceTypeDefinition>()
-            .filterSchemaTypeExtensions()
+            .excludeSchemaTypeExtension()
             .map {
                 val extensions = findInterfaceExtensions(it.name, definitions)
                 KotlinInterfaceTypeGenerator(config).generate(it, document, extensions)
@@ -226,7 +226,7 @@ class CodeGen(private val config: CodeGenConfig) {
 
         val unionResult = definitions.asSequence()
             .filterIsInstance<UnionTypeDefinition>()
-            .filterSchemaTypeExtensions()
+            .excludeSchemaTypeExtension()
             .map {
                 val extensions = findUnionExtensions(it.name, definitions)
                 KotlinUnionTypeGenerator(config).generate(it, extensions)
@@ -235,7 +235,7 @@ class CodeGen(private val config: CodeGenConfig) {
 
         val enumsResult = definitions.asSequence()
             .filterIsInstance<EnumTypeDefinition>()
-            .filterSchemaTypeExtensions()
+            .excludeSchemaTypeExtension()
             .filter { config.generateDataTypes || it.name in requiredTypeCollector.requiredTypes }
             .map {
                 val extensions = findEnumExtensions(it.name, definitions)
@@ -297,7 +297,7 @@ class CodeGen(private val config: CodeGenConfig) {
     private fun generateKotlinDataTypes(definitions: Collection<Definition<*>>): KotlinCodeGenResult {
         return definitions.asSequence()
             .filterIsInstance<ObjectTypeDefinition>()
-            .filterSchemaTypeExtensions()
+            .excludeSchemaTypeExtension()
             .filter { it.name != "Query" && it.name != "Mutation" && it.name != "RelayPageInfo" }
             .filter { config.generateDataTypes || it.name in requiredTypeCollector.requiredTypes }
             .map {

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ConstantsGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ConstantsGenerator.kt
@@ -24,7 +24,7 @@ import com.netflix.graphql.dgs.codegen.generators.shared.CodeGeneratorUtils
 import com.netflix.graphql.dgs.codegen.generators.shared.SchemaExtensionsUtils.findInputExtensions
 import com.netflix.graphql.dgs.codegen.generators.shared.SchemaExtensionsUtils.findInterfaceExtensions
 import com.netflix.graphql.dgs.codegen.generators.shared.SchemaExtensionsUtils.findTypeExtensions
-import com.netflix.graphql.dgs.codegen.generators.shared.filterSchemaTypeExtensions
+import com.netflix.graphql.dgs.codegen.generators.shared.excludeSchemaTypeExtension
 import com.squareup.javapoet.FieldSpec
 import com.squareup.javapoet.JavaFile
 import com.squareup.javapoet.TypeName
@@ -38,7 +38,7 @@ class ConstantsGenerator(private val config: CodeGenConfig, private val document
             .addModifiers(Modifier.PUBLIC)
 
         document.definitions.filterIsInstance<ObjectTypeDefinition>()
-            .filterSchemaTypeExtensions()
+            .excludeSchemaTypeExtension()
             .map {
                 val constantsType = createConstantTypeBuilder(config, it.name)
 
@@ -55,7 +55,7 @@ class ConstantsGenerator(private val config: CodeGenConfig, private val document
             }
 
         document.definitions.filterIsInstance<InputObjectTypeDefinition>()
-            .filterSchemaTypeExtensions()
+            .excludeSchemaTypeExtension()
             .map {
                 val constantsType = createConstantTypeBuilder(config, it.name)
                 constantsType.addField(FieldSpec.builder(TypeName.get(String::class.java), "TYPE_NAME").addModifiers(Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL).initializer(""""${it.name}"""").build())
@@ -71,7 +71,7 @@ class ConstantsGenerator(private val config: CodeGenConfig, private val document
             }
 
         document.definitions.filterIsInstance<InterfaceTypeDefinition>()
-            .filterSchemaTypeExtensions()
+            .excludeSchemaTypeExtension()
             .map {
                 val constantsType = createConstantTypeBuilder(config, it.name)
 
@@ -88,7 +88,7 @@ class ConstantsGenerator(private val config: CodeGenConfig, private val document
             }
 
         document.definitions.filterIsInstance<UnionTypeDefinition>()
-            .filterSchemaTypeExtensions()
+            .excludeSchemaTypeExtension()
             .map {
                 val constantsType = createConstantTypeBuilder(config, it.name)
                 constantsType.addField(FieldSpec.builder(TypeName.get(String::class.java), "TYPE_NAME").addModifiers(Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL).initializer(""""${it.name}"""").build())

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ConstantsGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ConstantsGenerator.kt
@@ -21,6 +21,10 @@ package com.netflix.graphql.dgs.codegen.generators.java
 import com.netflix.graphql.dgs.codegen.CodeGenConfig
 import com.netflix.graphql.dgs.codegen.CodeGenResult
 import com.netflix.graphql.dgs.codegen.generators.shared.CodeGeneratorUtils
+import com.netflix.graphql.dgs.codegen.generators.shared.SchemaExtensionsUtils.findInputExtensions
+import com.netflix.graphql.dgs.codegen.generators.shared.SchemaExtensionsUtils.findInterfaceExtensions
+import com.netflix.graphql.dgs.codegen.generators.shared.SchemaExtensionsUtils.findTypeExtensions
+import com.netflix.graphql.dgs.codegen.generators.shared.filterSchemaTypeExtensions
 import com.squareup.javapoet.FieldSpec
 import com.squareup.javapoet.JavaFile
 import com.squareup.javapoet.TypeName
@@ -33,50 +37,62 @@ class ConstantsGenerator(private val config: CodeGenConfig, private val document
         val javaType = TypeSpec.classBuilder("DgsConstants")
             .addModifiers(Modifier.PUBLIC)
 
-        document.definitions.filterIsInstance<ObjectTypeDefinition>().filter { it !is ObjectTypeExtensionDefinition }.map {
-            val constantsType = createConstantTypeBuilder(config, it.name)
+        document.definitions.filterIsInstance<ObjectTypeDefinition>()
+            .filterSchemaTypeExtensions()
+            .map {
+                val constantsType = createConstantTypeBuilder(config, it.name)
 
-            val extensions = findExtensions(it.name, document.definitions)
-            val fields = it.fieldDefinitions.plus(extensions.flatMap { it.fieldDefinitions })
+                val extensions = findTypeExtensions(it.name, document.definitions)
+                val fields = it.fieldDefinitions + extensions.flatMap { it.fieldDefinitions }
 
-            constantsType.addField(FieldSpec.builder(TypeName.get(String::class.java), "TYPE_NAME").addModifiers(Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL).initializer(""""${it.name}"""").build())
+                constantsType.addField(FieldSpec.builder(TypeName.get(String::class.java), "TYPE_NAME").addModifiers(Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL).initializer(""""${it.name}"""").build())
 
-            fields.forEach { field ->
-                addFieldNameConstant(constantsType, field.name)
+                fields.forEach { field ->
+                    addFieldNameConstant(constantsType, field.name)
+                }
+
+                javaType.addType(constantsType.build())
             }
 
-            javaType.addType(constantsType.build())
-        }
+        document.definitions.filterIsInstance<InputObjectTypeDefinition>()
+            .filterSchemaTypeExtensions()
+            .map {
+                val constantsType = createConstantTypeBuilder(config, it.name)
+                constantsType.addField(FieldSpec.builder(TypeName.get(String::class.java), "TYPE_NAME").addModifiers(Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL).initializer(""""${it.name}"""").build())
 
-        document.definitions.filterIsInstance<InputObjectTypeDefinition>().filter { it !is InputObjectTypeExtensionDefinition }.map {
-            val constantsType = createConstantTypeBuilder(config, it.name)
-            constantsType.addField(FieldSpec.builder(TypeName.get(String::class.java), "TYPE_NAME").addModifiers(Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL).initializer(""""${it.name}"""").build())
+                val extensions = findInputExtensions(it.name, document.definitions)
+                val fields = it.inputValueDefinitions + extensions.flatMap { it.inputValueDefinitions }
 
-            val extensions = findInputExtensions(it.name, document.definitions)
-            val fields = it.inputValueDefinitions.plus(extensions.flatMap { it.inputValueDefinitions })
+                fields.forEach { field ->
+                    addFieldNameConstant(constantsType, field.name)
+                }
 
-            fields.forEach { field ->
-                addFieldNameConstant(constantsType, field.name)
+                javaType.addType(constantsType.build())
             }
 
-            javaType.addType(constantsType.build())
-        }
+        document.definitions.filterIsInstance<InterfaceTypeDefinition>()
+            .filterSchemaTypeExtensions()
+            .map {
+                val constantsType = createConstantTypeBuilder(config, it.name)
 
-        document.definitions.filterIsInstance<InterfaceTypeDefinition>().map {
-            val constantsType = createConstantTypeBuilder(config, it.name)
+                constantsType.addField(FieldSpec.builder(TypeName.get(String::class.java), "TYPE_NAME").addModifiers(Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL).initializer(""""${it.name}"""").build())
 
-            constantsType.addField(FieldSpec.builder(TypeName.get(String::class.java), "TYPE_NAME").addModifiers(Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL).initializer(""""${it.name}"""").build())
-            it.fieldDefinitions.forEach { field ->
-                addFieldNameConstant(constantsType, field.name)
+                val extensions = findInterfaceExtensions(it.name, document.definitions)
+                val merged = it.fieldDefinitions + extensions.flatMap { it.fieldDefinitions }
+
+                merged.forEach { field ->
+                    addFieldNameConstant(constantsType, field.name)
+                }
+
+                javaType.addType(constantsType.build())
             }
 
-            javaType.addType(constantsType.build())
-        }
-
-        document.definitions.filterIsInstance<UnionTypeDefinition>().map {
-            val constantsType = createConstantTypeBuilder(config, it.name)
-            constantsType.addField(FieldSpec.builder(TypeName.get(String::class.java), "TYPE_NAME").addModifiers(Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL).initializer(""""${it.name}"""").build())
-        }
+        document.definitions.filterIsInstance<UnionTypeDefinition>()
+            .filterSchemaTypeExtensions()
+            .map {
+                val constantsType = createConstantTypeBuilder(config, it.name)
+                constantsType.addField(FieldSpec.builder(TypeName.get(String::class.java), "TYPE_NAME").addModifiers(Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL).initializer(""""${it.name}"""").build())
+            }
 
         if (document.definitions.firstOrNull { it is ObjectTypeDefinition && it.name == "Query" } != null) {
             javaType.addField(FieldSpec.builder(TypeName.get(String::class.java), "QUERY_TYPE").addModifiers(Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL).initializer(""""Query"""").build())
@@ -107,10 +123,4 @@ class ConstantsGenerator(private val config: CodeGenConfig, private val document
     private fun addFieldNameConstant(constantsType: TypeSpec.Builder, fieldName: String) {
         constantsType.addField(FieldSpec.builder(TypeName.get(String::class.java), ReservedKeywordSanitizer.sanitize(fieldName.capitalize())).addModifiers(Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL).initializer(""""$fieldName"""").build())
     }
-
-    private fun findExtensions(name: String, definitions: List<Definition<Definition<*>>>) =
-        definitions.filterIsInstance<ObjectTypeExtensionDefinition>().filter { name == it.name }
-
-    private fun findInputExtensions(name: String, definitions: List<Definition<Definition<*>>>) =
-        definitions.filterIsInstance<InputObjectTypeExtensionDefinition>().filter { name == it.name }
 }

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/EnumTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/EnumTypeGenerator.kt
@@ -27,11 +27,13 @@ import graphql.language.EnumValueDefinition
 import javax.lang.model.element.Modifier
 
 class EnumTypeGenerator(private val config: CodeGenConfig) {
-    fun generate(definition: EnumTypeDefinition): CodeGenResult {
+    fun generate(definition: EnumTypeDefinition, extensions: List<EnumTypeDefinition>): CodeGenResult {
         val javaType = TypeSpec.enumBuilder(definition.name)
             .addModifiers(Modifier.PUBLIC)
 
-        definition.enumValueDefinitions.forEach {
+        val mergedEnumDefinitions = definition.enumValueDefinitions + extensions.flatMap { it.enumValueDefinitions }
+
+        mergedEnumDefinitions.forEach {
             addEnum(it, javaType)
         }
 

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/InterfaceGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/InterfaceGenerator.kt
@@ -33,11 +33,13 @@ class InterfaceGenerator(config: CodeGenConfig, private val document: Document) 
     private val typeUtils = TypeUtils(packageName, config, document)
     private val useInterfaceType = config.generateInterfaces
 
-    fun generate(definition: InterfaceTypeDefinition): CodeGenResult {
+    fun generate(definition: InterfaceTypeDefinition, extensions: List<InterfaceTypeExtensionDefinition>): CodeGenResult {
         val javaType = TypeSpec.interfaceBuilder(definition.name)
             .addModifiers(Modifier.PUBLIC)
 
-        definition.fieldDefinitions.forEach {
+        val mergedFieldDefinitions = definition.fieldDefinitions + extensions.flatMap { it.fieldDefinitions }
+
+        mergedFieldDefinitions.forEach {
             // Only generate getters/setters for fields that are not interfaces.
             //
             // interface Pet {

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/UnionTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/UnionTypeGenerator.kt
@@ -25,14 +25,15 @@ import com.squareup.javapoet.JavaFile
 import com.squareup.javapoet.TypeSpec
 import graphql.language.TypeName
 import graphql.language.UnionTypeDefinition
+import graphql.language.UnionTypeExtensionDefinition
 import javax.lang.model.element.Modifier
 
 class UnionTypeGenerator(private val config: CodeGenConfig) {
-    fun generate(definition: UnionTypeDefinition): CodeGenResult {
+    fun generate(definition: UnionTypeDefinition, extensions: List<UnionTypeExtensionDefinition>): CodeGenResult {
         val javaType = TypeSpec.interfaceBuilder(definition.name)
             .addModifiers(Modifier.PUBLIC)
 
-        val memberTypes = definition.memberTypes.asSequence()
+        val memberTypes = definition.memberTypes.plus(extensions.flatMap { it.memberTypes }).asSequence()
             .filterIsInstance<TypeName>()
             .map { member -> ClassName.get(packageName, member.name) }
             .toList()

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinConstantsGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinConstantsGenerator.kt
@@ -24,7 +24,7 @@ import com.netflix.graphql.dgs.codegen.generators.shared.CodeGeneratorUtils
 import com.netflix.graphql.dgs.codegen.generators.shared.SchemaExtensionsUtils
 import com.netflix.graphql.dgs.codegen.generators.shared.SchemaExtensionsUtils.findInputExtensions
 import com.netflix.graphql.dgs.codegen.generators.shared.SchemaExtensionsUtils.findTypeExtensions
-import com.netflix.graphql.dgs.codegen.generators.shared.filterSchemaTypeExtensions
+import com.netflix.graphql.dgs.codegen.generators.shared.excludeSchemaTypeExtension
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.PropertySpec
@@ -36,7 +36,7 @@ class KotlinConstantsGenerator(private val config: CodeGenConfig, private val do
         val baseConstantsType = TypeSpec.objectBuilder("DgsConstants")
 
         document.definitions.filterIsInstance<ObjectTypeDefinition>()
-            .filterSchemaTypeExtensions()
+            .excludeSchemaTypeExtension()
             .map {
                 val constantsType = createConstantTypeBuilder(config, it.name)
 
@@ -53,7 +53,7 @@ class KotlinConstantsGenerator(private val config: CodeGenConfig, private val do
             }
 
         document.definitions.filterIsInstance<InputObjectTypeDefinition>()
-            .filterSchemaTypeExtensions()
+            .excludeSchemaTypeExtension()
             .map {
                 val constantsType = createConstantTypeBuilder(config, it.name)
 
@@ -68,7 +68,7 @@ class KotlinConstantsGenerator(private val config: CodeGenConfig, private val do
             }
 
         document.definitions.filterIsInstance<InterfaceTypeDefinition>()
-            .filterSchemaTypeExtensions()
+            .excludeSchemaTypeExtension()
             .map {
                 val constantsType = createConstantTypeBuilder(config, it.name)
 
@@ -85,7 +85,7 @@ class KotlinConstantsGenerator(private val config: CodeGenConfig, private val do
             }
 
         document.definitions.filterIsInstance<UnionTypeDefinition>()
-            .filterSchemaTypeExtensions()
+            .excludeSchemaTypeExtension()
             .map {
                 val constantsType = createConstantTypeBuilder(config, it.name)
 

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinConstantsGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinConstantsGenerator.kt
@@ -77,7 +77,7 @@ class KotlinConstantsGenerator(private val config: CodeGenConfig, private val do
                 val extensions = SchemaExtensionsUtils.findInterfaceExtensions(it.name, document.definitions)
                 val fields = it.fieldDefinitions + extensions.flatMap { it.fieldDefinitions }
 
-                it.fieldDefinitions.filter(ReservedKeywordFilter.filterInvalidNames).forEach { field ->
+                fields.filter(ReservedKeywordFilter.filterInvalidNames).forEach { field ->
                     addFieldName(constantsType, field.name)
                 }
 

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinEnumTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinEnumTypeGenerator.kt
@@ -26,10 +26,11 @@ import com.squareup.kotlinpoet.TypeSpec
 import graphql.language.EnumTypeDefinition
 
 class KotlinEnumTypeGenerator(private val config: CodeGenConfig) {
-    fun generate(definition: EnumTypeDefinition): KotlinCodeGenResult {
+    fun generate(definition: EnumTypeDefinition, extensions: List<EnumTypeDefinition>): KotlinCodeGenResult {
         val kotlinType = TypeSpec.classBuilder(definition.name).addModifiers(KModifier.ENUM)
 
-        definition.enumValueDefinitions.forEach {
+        val mergedEnumDefinitions = definition.enumValueDefinitions + extensions.flatMap { it.enumValueDefinitions }
+        mergedEnumDefinitions.forEach {
             kotlinType.addEnumConstant(it.name)
         }
 

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinInterfaceTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinInterfaceTypeGenerator.kt
@@ -23,20 +23,22 @@ import com.netflix.graphql.dgs.codegen.KotlinCodeGenResult
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.TypeSpec
-import graphql.language.Document
-import graphql.language.InterfaceTypeDefinition
-import graphql.language.ObjectTypeDefinition
-import graphql.language.TypeName
+import graphql.language.*
 
 class KotlinInterfaceTypeGenerator(config: CodeGenConfig) {
 
     private val packageName = config.packageNameTypes
     private val typeUtils = KotlinTypeUtils(packageName, config)
 
-    fun generate(definition: InterfaceTypeDefinition, document: Document): KotlinCodeGenResult {
+    fun generate(
+        definition: InterfaceTypeDefinition,
+        document: Document,
+        extensions: List<InterfaceTypeExtensionDefinition>
+    ): KotlinCodeGenResult {
         val interfaceBuilder = TypeSpec.interfaceBuilder(definition.name)
+        val mergedFieldDefinitions = definition.fieldDefinitions + extensions.flatMap { it.fieldDefinitions }
 
-        definition.fieldDefinitions.forEach { field ->
+        mergedFieldDefinitions.forEach { field ->
             val returnType = typeUtils.findReturnType(field.type)
             interfaceBuilder.addProperty(field.name, returnType)
         }

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinUnionTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinUnionTypeGenerator.kt
@@ -25,15 +25,16 @@ import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.TypeSpec
 import graphql.language.TypeName
 import graphql.language.UnionTypeDefinition
+import graphql.language.UnionTypeExtensionDefinition
 
 class KotlinUnionTypeGenerator(config: CodeGenConfig) {
 
     private val packageName = config.packageNameTypes
 
-    fun generate(definition: UnionTypeDefinition): KotlinCodeGenResult {
+    fun generate(definition: UnionTypeDefinition, extensions: List<UnionTypeExtensionDefinition>): KotlinCodeGenResult {
         val interfaceBuilder = TypeSpec.interfaceBuilder(definition.name)
 
-        val memberTypes = definition.memberTypes.asSequence()
+        val memberTypes = definition.memberTypes.plus(extensions.flatMap { it.memberTypes }).asSequence()
             .filterIsInstance<TypeName>()
             .map { member -> ClassName(packageName, member.name) }
             .toList()

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/shared/SchemaExtensionsUtils.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/shared/SchemaExtensionsUtils.kt
@@ -43,11 +43,11 @@ object SchemaExtensionsUtils {
             .toList()
 }
 
-fun <T> List<T>.filterSchemaTypeExtensions(): List<T> {
+fun <T> List<T>.excludeSchemaTypeExtension(): List<T> {
     return this.filter { !isSchemaTypeExtension(it) }
 }
 
-fun <T> Sequence<T>.filterSchemaTypeExtensions(): Sequence<T> {
+fun <T> Sequence<T>.excludeSchemaTypeExtension(): Sequence<T> {
     return this.filter { !isSchemaTypeExtension(it) }
 }
 

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/shared/SchemaExtensionsUtils.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/shared/SchemaExtensionsUtils.kt
@@ -1,0 +1,63 @@
+/*
+ *
+ *  Copyright 2020 Netflix, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package com.netflix.graphql.dgs.codegen.generators.shared
+
+import graphql.language.*
+
+object SchemaExtensionsUtils {
+    fun findTypeExtensions(name: String, definitions: Collection<Definition<*>>) =
+        findExtensions<ObjectTypeExtensionDefinition>(name, definitions)
+
+    fun findInputExtensions(name: String, definitions: Collection<Definition<*>>) =
+        findExtensions<InputObjectTypeExtensionDefinition>(name, definitions)
+
+    fun findEnumExtensions(name: String, definitions: Collection<Definition<*>>) =
+        findExtensions<EnumTypeExtensionDefinition>(name, definitions)
+
+    fun findInterfaceExtensions(name: String, definitions: Collection<Definition<*>>) =
+        findExtensions<InterfaceTypeExtensionDefinition>(name, definitions)
+
+    fun findUnionExtensions(name: String, definitions: Collection<Definition<*>>) =
+        findExtensions<UnionTypeExtensionDefinition>(name, definitions)
+
+    private inline fun <reified R : NamedNode<*>> findExtensions(name: String, definitions: Collection<Definition<*>>) =
+        definitions.asSequence()
+            .filterIsInstance<R>()
+            .filter { name == it.name }
+            .toList()
+}
+
+fun <T> List<T>.filterSchemaTypeExtensions(): List<T> {
+    return this.filter { !isSchemaTypeExtension(it) }
+}
+
+fun <T> Sequence<T>.filterSchemaTypeExtensions(): Sequence<T> {
+    return this.filter { !isSchemaTypeExtension(it) }
+}
+
+private fun <T> isSchemaTypeExtension(it: T): Boolean {
+    return when (it) {
+        is InputObjectTypeExtensionDefinition -> true
+        is ObjectTypeExtensionDefinition -> true
+        is EnumTypeExtensionDefinition -> true
+        is InterfaceTypeExtensionDefinition -> true
+        is UnionTypeExtensionDefinition -> true
+        else -> false
+    }
+}


### PR DESCRIPTION
Detailed problem description(for enum case): https://github.com/Netflix/dgs-codegen/issues/118

Added support for 
```
extend enum
extend interface
extend union
```

Also, I've extracted common logic to reuse it across the codebase.
