### PR TITLE
fix: escape double quotes in Strings for toString in generated Input Types

### DIFF
--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/DataTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/DataTypeGenerator.kt
@@ -252,7 +252,7 @@ abstract class BaseDataTypeGenerator(internal val packageName: String, private v
                 }
                 is ClassName -> {
                     if (typeUtils.isStringInput(fieldSpecType)) {
-                        """entries.put("${fieldSpec.name}", ${fieldSpec.name} == null ? null : "\"" + ${fieldSpec.name} + "\"")"""
+                        """entries.put("${fieldSpec.name}", ${fieldSpec.name} == null ? null : "\"" + ${fieldSpec.name}.toString().replace("\"", "\\\"") + "\"")"""
                     } else {
                         """entries.put("${fieldSpec.name}", ${fieldSpec.name})"""
                     }

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinDataTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinDataTypeGenerator.kt
@@ -191,9 +191,9 @@ abstract class AbstractKotlinDataTypeGenerator(private val packageName: String, 
                 is ClassName -> {
                     if (typeUtils.isStringInput(fieldTypeName)) {
                         if (field.nullable) {
-                            """"${field.name}" to (if (${field.name} == null) null else "\"" + ${field.name} + "\"")"""
+                            """"${field.name}" to (if (${field.name} == null) null else "\"" + ${field.name}.toString().replace("\"", "\\\"") + "\"")"""
                         } else {
-                            """"${field.name}" to ("\"" + ${field.name} + "\"")"""
+                            """"${field.name}" to ("\"" + ${field.name}.toString().replace("\"", "\\\"") + "\"")"""
                         }
                     } else {
                         """"${field.name}" to ${field.name}"""

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
@@ -1116,6 +1116,33 @@ class CodeGenTest {
     }
 
     @Test
+    fun generateToInputStringMethodForStringWithQuotes() {
+
+        val schema = """
+            type Query {
+                movies(filter: MovieFilter)
+            }
+
+            input MovieFilter {
+                genre: String
+                id: String!
+            }
+        """.trimIndent()
+
+        val (dataTypes) = CodeGen(
+            CodeGenConfig(
+                schemas = setOf(schema),
+                packageName = basePackageName,
+            )
+        ).generate() as CodeGenResult
+
+        val movieFilter = compileAndGetConstructor(dataTypes, "MovieFilter")
+
+        assertThat(movieFilter.create("quotes\"in\"the\"middle", "quotes\"in\"the\"center").toString())
+            .isEqualTo("""{genre:"quotes\"in\"the\"middle",id:"quotes\"in\"the\"center"}""")
+    }
+
+    @Test
     fun generateToInputStringMethodForListOfString() {
         val schema = """
             type Query {

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
@@ -932,7 +932,7 @@ class KotlinCodeGenTest {
         assertThat(type.funSpecs).extracting("name").contains("toString")
         val expectedInputString = """
             return linkedMapOf(
-            "genre" to (if (genre == null) null else "\"" + genre + "\""),
+            "genre" to (if (genre == null) null else "\"" + genre.toString().replace("\"", "\\\"") + "\""),
             "rating" to rating,
             "views" to views,
             "stars" to stars,
@@ -970,7 +970,7 @@ class KotlinCodeGenTest {
         assertThat(type.funSpecs).extracting("name").contains("toString")
         val expectedInputString = """
             return linkedMapOf(
-            "genre" to ("\"" + genre + "\""),
+            "genre" to ("\"" + genre.toString().replace("\"", "\\\"") + "\""),
             "rating" to rating,
             "views" to views,
             "stars" to stars,
@@ -1008,7 +1008,7 @@ class KotlinCodeGenTest {
         assertThat(type.funSpecs).extracting("name").contains("toString")
         val expectedInputString = """
             return linkedMapOf(
-            "genre" to ("\"" + genre + "\""),
+            "genre" to ("\"" + genre.toString().replace("\"", "\\\"") + "\""),
             "rating" to rating,
             "average" to average,
             "viewed" to viewed,
@@ -1052,11 +1052,44 @@ class KotlinCodeGenTest {
         assertThat(type.funSpecs).extracting("name").contains("toString")
         val expectedInputString = """
             return linkedMapOf(
-            "genre" to (if (genre == null) null else "\"" + genre + "\""),
+            "genre" to (if (genre == null) null else "\"" + genre.toString().replace("\"", "\\\"") + "\""),
             "rating" to rating,
             "average" to average,
             "viewed" to viewed,
-            "identifier" to (if (identifier == null) null else "\"" + identifier + "\""),
+            "identifier" to (if (identifier == null) null else "\"" + identifier.toString().replace("\"", "\\\"") + "\""),
+            ).map { it.key + ":" + it.value }.joinToString(",", "{", "}")
+        """.trimIndent()
+        val generatedInputString = type.funSpecs.single { it.name == "toString" }.body.toString().trimIndent()
+        assertThat(expectedInputString).isEqualTo(generatedInputString)
+    }
+
+    @Test
+    fun generateToStringMethodForStringWithQuotes() {
+        val schema = """
+            type Query {
+                movies(filter: MovieFilter)
+            }
+
+            input MovieFilter {
+                genre: String
+                id: String!
+            }
+        """.trimIndent()
+
+        val (dataTypes) = CodeGen(
+            CodeGenConfig(
+                schemas = setOf(schema),
+                packageName = basePackageName,
+                language = Language.KOTLIN
+            )
+        ).generate() as KotlinCodeGenResult
+
+        val type = dataTypes[0].members[0] as TypeSpec
+        assertThat(type.funSpecs).extracting("name").contains("toString")
+        val expectedInputString = """
+            return linkedMapOf(
+            "genre" to (if (genre == null) null else "\"" + genre.toString().replace("\"", "\\\"") + "\""),
+            "id" to ("\"" + id.toString().replace("\"", "\\\"") + "\""),
             ).map { it.key + ":" + it.value }.joinToString(",", "{", "}")
         """.trimIndent()
         val generatedInputString = type.funSpecs.single { it.name == "toString" }.body.toString().trimIndent()
@@ -1202,10 +1235,10 @@ class KotlinCodeGenTest {
 
         val expectedInputString = """
             return linkedMapOf(
-            "localDateTime" to (if (localDateTime == null) null else "\"" + localDateTime + "\""),
-            "localDate" to (if (localDate == null) null else "\"" + localDate + "\""),
-            "localTime" to (if (localTime == null) null else "\"" + localTime + "\""),
-            "dateTime" to (if (dateTime == null) null else "\"" + dateTime + "\""),
+            "localDateTime" to (if (localDateTime == null) null else "\"" + localDateTime.toString().replace("\"", "\\\"") + "\""),
+            "localDate" to (if (localDate == null) null else "\"" + localDate.toString().replace("\"", "\\\"") + "\""),
+            "localTime" to (if (localTime == null) null else "\"" + localTime.toString().replace("\"", "\\\"") + "\""),
+            "dateTime" to (if (dateTime == null) null else "\"" + dateTime.toString().replace("\"", "\\\"") + "\""),
             ).map { it.key + ":" + it.value }.joinToString(",", "{", "}")
         """.trimIndent()
         val generatedInputString = type.funSpecs.single { it.name == "toString" }.body.toString().trimIndent()
@@ -1270,7 +1303,7 @@ class KotlinCodeGenTest {
 
         val expectedInputString = """
             return linkedMapOf(
-            "time" to (if (time == null) null else "\"" + time + "\""),
+            "time" to (if (time == null) null else "\"" + time.toString().replace("\"", "\\\"") + "\""),
             "date" to date,
             ).map { it.key + ":" + it.value }.joinToString(",", "{", "}")
         """.trimIndent()


### PR DESCRIPTION
If an Input object has double quotes in a String field, escape them when toString() is called.

resolves #123 