### PR TITLE
Generates data fetcher interface for query types

### DIFF
--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
@@ -230,13 +230,19 @@ class CodeGen(private val config: CodeGenConfig) {
             .map { KotlinEnumTypeGenerator(config).generate(it) }
             .fold(KotlinCodeGenResult()) { t: KotlinCodeGenResult, u: KotlinCodeGenResult -> t.merge(u) }
 
+        val dataFetchersResult = definitions.asSequence()
+            .filterIsInstance<ObjectTypeDefinition>()
+            .filter { it.name == "Query" }
+            .map { KotlinDataFetcherGenerator(config).generate(it) }
+            .fold(KotlinCodeGenResult()) { t: KotlinCodeGenResult, u: KotlinCodeGenResult -> t.merge(u) }
+
         val constantsClass = KotlinConstantsGenerator(config, document).generate()
 
         val client = generateKotlinClientApi(definitions)
         val entitiesClient = generateKotlinClientEntitiesApi(definitions)
         val entitiesRepresentationsTypes = generateKotlinClientEntitiesRepresentations(definitions)
 
-        return datatypesResult.merge(inputTypes).merge(interfacesResult).merge(unionResult).merge(enumsResult).merge(client).merge(entitiesClient).merge(entitiesRepresentationsTypes).merge(constantsClass)
+        return datatypesResult.merge(inputTypes).merge(interfacesResult).merge(unionResult).merge(enumsResult).merge(client).merge(entitiesClient).merge(entitiesRepresentationsTypes).merge(dataFetchersResult).merge(constantsClass)
     }
 
     private fun generateKotlinClientApi(definitions: Collection<Definition<Definition<*>>>): KotlinCodeGenResult {

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinDataFetcherGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinDataFetcherGenerator.kt
@@ -1,0 +1,53 @@
+package com.netflix.graphql.dgs.codegen.generators.kotlin
+
+import com.netflix.graphql.dgs.DgsData
+import com.netflix.graphql.dgs.codegen.CodeGenConfig
+import com.netflix.graphql.dgs.codegen.KotlinCodeGenResult
+import com.squareup.kotlinpoet.AnnotationSpec
+import com.squareup.kotlinpoet.FileSpec
+import com.squareup.kotlinpoet.TypeSpec
+import com.squareup.kotlinpoet.FunSpec
+import com.squareup.kotlinpoet.KModifier
+import com.squareup.kotlinpoet.TypeName
+import graphql.language.FieldDefinition
+import graphql.language.ObjectTypeDefinition
+import graphql.schema.DataFetchingEnvironment
+
+class KotlinDataFetcherGenerator(private val config: CodeGenConfig) {
+
+    private val packageName = config.packageNameDatafetchers
+    private val typeUtils = KotlinTypeUtils(config.packageNameTypes, config)
+
+    fun generate(query: ObjectTypeDefinition): KotlinCodeGenResult =
+        query.fieldDefinitions
+            .map { generateField(it) }
+            .fold(KotlinCodeGenResult()) { left, right -> left.merge(right) }
+
+    private fun generateField(field: FieldDefinition): KotlinCodeGenResult {
+        val fieldName = field.name.substring(0, 1).toUpperCase() + field.name.substring(1)
+        val className = fieldName + "Datafetcher"
+
+        val returnType = typeUtils.findReturnType(field.type)
+
+        val methodSpec = FunSpec.builder("get$fieldName")
+            .addAnnotation(AnnotationSpec.builder(DgsData::class).addMember("parentType", "\$S", "Query").addMember("field", "\$S", field.name).build())
+            .addModifiers(KModifier.ABSTRACT)
+            .also { builder ->
+                field.inputValueDefinitions.forEach {
+                    val inputType: TypeName = typeUtils.findReturnType(it.type)
+                    builder.addParameter(it.name, inputType)
+                }
+            }
+            .addParameter("dataFetchingEnvironment", DataFetchingEnvironment::class)
+            .returns(returnType)
+            .build()
+
+        val interfaceBuilder = TypeSpec.interfaceBuilder(className)
+            .addFunction(methodSpec)
+            .build()
+
+        val fileSpec = FileSpec.get(packageName, interfaceBuilder)
+
+        return KotlinCodeGenResult(dataFetchers = listOf(fileSpec))
+    }
+}

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
@@ -21,6 +21,7 @@ package com.netflix.graphql.dgs.codegen
 import com.google.common.truth.Truth
 import com.squareup.kotlinpoet.*
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
+import graphql.schema.DataFetchingEnvironment
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
@@ -33,6 +34,7 @@ class KotlinCodeGenTest {
 
     val basePackageName = "com.netflix.graphql.dgs.codegen.tests.generated"
     val typesPackageName = "$basePackageName.types"
+    val datafetchersPackageName = "$basePackageName.datafetchers"
 
     @Test
     fun generateDataClassWithStringProperties() {
@@ -64,6 +66,101 @@ class KotlinCodeGenTest {
         assertThat(type.modifiers).contains(KModifier.DATA)
         assertThat(type.propertySpecs.size).isEqualTo(2)
         assertThat(type.propertySpecs).extracting("name").contains("firstname", "lastname")
+    }
+
+    @Test
+    fun generateDataFetcherInterfaceWithFunction() {
+
+        val schema = """
+            type Query {
+                people: [Person]
+            }
+            
+            type Person {
+                firstname: String
+                lastname: String
+            }
+        """.trimIndent()
+
+        val dataFetchers = (CodeGen(
+            CodeGenConfig(
+                schemas = setOf(schema),
+                packageName = basePackageName,
+                language = Language.KOTLIN
+            )
+        ).generate() as KotlinCodeGenResult).dataFetchers
+
+        assertThat(dataFetchers.size).isEqualTo(1)
+        assertThat(dataFetchers[0].name).isEqualTo("PeopleDatafetcher")
+        assertThat(dataFetchers[0].packageName).isEqualTo(datafetchersPackageName)
+        val type = dataFetchers[0].members[0] as TypeSpec
+
+        assertThat(type.kind).isEqualTo(TypeSpec.Kind.INTERFACE)
+        assertThat(type.funSpecs).hasSize(1)
+            .anySatisfy { fn ->
+                assertThat(fn.name).isEqualTo("getPeople")
+                assertThat(fn.returnType)
+                    .satisfies { returnType ->
+                        returnType as ParameterizedTypeName
+                        assertThat(returnType.rawType.canonicalName).isEqualTo(List::class.qualifiedName)
+                        assertThat(returnType.typeArguments).hasSize(1)
+                            .allMatch { (it as ClassName).canonicalName == "$typesPackageName.Person" }
+                    }
+                assertThat(fn.parameters).hasSize(1)
+                    .allSatisfy {
+                        assertThat(it.name).isEqualTo("dataFetchingEnvironment")
+                        assertThat((it.type as ClassName).canonicalName).isEqualTo(DataFetchingEnvironment::class.qualifiedName)
+                    }
+            }
+    }
+
+
+    @Test
+    fun generateDataFetcherInterfaceWithArgument() {
+
+        val schema = """
+            type Query {
+                person(name: String): Person
+            }
+            
+            type Person {
+                firstname: String
+                lastname: String
+            }
+        """.trimIndent()
+
+        val dataFetchers = (CodeGen(
+            CodeGenConfig(
+                schemas = setOf(schema),
+                packageName = basePackageName,
+                language = Language.KOTLIN
+            )
+        ).generate() as KotlinCodeGenResult).dataFetchers
+
+        assertThat(dataFetchers.size).isEqualTo(1)
+        assertThat(dataFetchers[0].name).isEqualTo("PersonDatafetcher")
+        assertThat(dataFetchers[0].packageName).isEqualTo(datafetchersPackageName)
+        val type = dataFetchers[0].members[0] as TypeSpec
+
+        assertThat(type.kind).isEqualTo(TypeSpec.Kind.INTERFACE)
+        assertThat(type.funSpecs).hasSize(1)
+            .anySatisfy { fn ->
+                assertThat(fn.name).isEqualTo("getPerson")
+                assertThat(fn.returnType)
+                    .satisfies { returnType ->
+                        returnType as ClassName
+                        assertThat(returnType.canonicalName).isEqualTo("$typesPackageName.Person")
+                    }
+                assertThat(fn.parameters).hasSize(2);
+                assertThat(fn.parameters[0]).satisfies {
+                    assertThat(it.name).isEqualTo("name")
+                    assertThat((it.type as ClassName).canonicalName).isEqualTo(String::class.qualifiedName)
+                }
+                assertThat(fn.parameters[1]).satisfies {
+                    assertThat(it.name).isEqualTo("dataFetchingEnvironment")
+                    assertThat((it.type as ClassName).canonicalName).isEqualTo(DataFetchingEnvironment::class.qualifiedName)
+                }
+            }
     }
 
     @Test


### PR DESCRIPTION
The Java generator has an option to generate example data fetchers that can be copied into the codebase and extended as needed, but the kotlin generator has no such option.

This PR implements example data fetcher generator for kotlin with a twist: instead of generating a a class with TODO bodies, it generates an interface, for now.

This is the first in a series of PRs that would add an option similar to [OpenAPI kotlin-spring generator](https://openapi-generator.tech/docs/generators/kotlin-spring/) `interfaceOnly` option.

The final solution would enable the development of schemas in a separate repository. Automation would use this generator to generate data classes for types and interfaces for data fetchers and mutations that server component must implement. The generated sources would be packaged and published as a jar.
