### PR TITLE
Switch to the DGS Framework BOM to fetch a recommendation for Jackson

### DIFF
--- a/graphql-dgs-codegen-core/build.gradle
+++ b/graphql-dgs-codegen-core/build.gradle
@@ -39,7 +39,7 @@ apply plugin: 'license'
 sourceCompatibility = 1.8
 
 dependencies {
-    implementation(platform("com.netflix.graphql.dgs:graphql-dgs-platform:latest.release"))
+    implementation(platform("com.netflix.graphql.dgs:graphql-dgs-platform-dependencies:latest.release"))
     implementation("com.netflix.graphql.dgs:graphql-dgs") { transitive = false }
     implementation "com.netflix.graphql.dgs:graphql-dgs-client"
     implementation "com.graphql-java:graphql-java"

--- a/graphql-dgs-codegen-core/dependencies.lock
+++ b/graphql-dgs-codegen-core/dependencies.lock
@@ -6,7 +6,7 @@
     },
     "compileClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.12.2"
+            "locked": "2.12.3"
         },
         "com.github.ajalt.clikt:clikt": {
             "locked": "3.1.0"
@@ -15,10 +15,13 @@
             "locked": "16.2"
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
-            "locked": "3.9.3"
+            "locked": "3.12.1"
         },
         "com.netflix.graphql.dgs:graphql-dgs-client": {
-            "locked": "3.9.3"
+            "locked": "3.12.1"
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform-dependencies": {
+            "locked": "3.12.1"
         },
         "com.squareup:javapoet": {
             "locked": "1.13.0"
@@ -26,13 +29,16 @@
         "com.squareup:kotlinpoet": {
             "locked": "1.7.2"
         },
+        "commons-lang:commons-lang": {
+            "locked": "2.6"
+        },
         "org.jetbrains.kotlin:kotlin-stdlib": {
-            "locked": "1.4.31"
+            "locked": "1.4.32"
         }
     },
     "implementationDependenciesMetadata": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.12.2"
+            "locked": "2.12.3"
         },
         "com.github.ajalt.clikt:clikt": {
             "locked": "3.1.0"
@@ -41,10 +47,13 @@
             "locked": "16.2"
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
-            "locked": "3.9.3"
+            "locked": "3.12.1"
         },
         "com.netflix.graphql.dgs:graphql-dgs-client": {
-            "locked": "3.9.3"
+            "locked": "3.12.1"
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform-dependencies": {
+            "locked": "3.12.1"
         },
         "com.squareup:javapoet": {
             "locked": "1.13.0"
@@ -52,8 +61,11 @@
         "com.squareup:kotlinpoet": {
             "locked": "1.7.2"
         },
+        "commons-lang:commons-lang": {
+            "locked": "2.6"
+        },
         "org.jetbrains.kotlin:kotlin-stdlib": {
-            "locked": "1.4.31"
+            "locked": "1.4.32"
         }
     },
     "kotlinCompilerClasspath": {
@@ -78,7 +90,7 @@
     },
     "runtimeClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.12.2"
+            "locked": "2.12.3"
         },
         "com.github.ajalt.clikt:clikt": {
             "locked": "3.1.0"
@@ -87,10 +99,13 @@
             "locked": "16.2"
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
-            "locked": "3.9.3"
+            "locked": "3.12.1"
         },
         "com.netflix.graphql.dgs:graphql-dgs-client": {
-            "locked": "3.9.3"
+            "locked": "3.12.1"
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform-dependencies": {
+            "locked": "3.12.1"
         },
         "com.squareup:javapoet": {
             "locked": "1.13.0"
@@ -98,16 +113,22 @@
         "com.squareup:kotlinpoet": {
             "locked": "1.7.2"
         },
+        "commons-lang:commons-lang": {
+            "locked": "2.6"
+        },
         "org.jetbrains.kotlin:kotlin-stdlib": {
-            "locked": "1.4.31"
+            "locked": "1.4.32"
         }
     },
     "testCompileClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.12.2"
+            "locked": "2.12.3"
         },
         "com.github.ajalt.clikt:clikt": {
             "locked": "3.1.0"
+        },
+        "com.google.jimfs:jimfs": {
+            "locked": "1.2"
         },
         "com.google.testing.compile:compile-testing": {
             "locked": "0.19"
@@ -119,10 +140,13 @@
             "locked": "16.2"
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
-            "locked": "3.9.3"
+            "locked": "3.12.1"
         },
         "com.netflix.graphql.dgs:graphql-dgs-client": {
-            "locked": "3.9.3"
+            "locked": "3.12.1"
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform-dependencies": {
+            "locked": "3.12.1"
         },
         "com.squareup:javapoet": {
             "locked": "1.13.0"
@@ -130,11 +154,17 @@
         "com.squareup:kotlinpoet": {
             "locked": "1.7.2"
         },
+        "commons-lang:commons-lang": {
+            "locked": "2.6"
+        },
         "org.assertj:assertj-core": {
             "locked": "3.11.1"
         },
-        "org.jetbrains.kotlin:kotlin-stdlib": {
+        "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
             "locked": "1.4.31"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.4.32"
         },
         "org.junit.jupiter:junit-jupiter": {
             "locked": "5.7.1"
@@ -148,10 +178,13 @@
     },
     "testImplementationDependenciesMetadata": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.12.2"
+            "locked": "2.12.3"
         },
         "com.github.ajalt.clikt:clikt": {
             "locked": "3.1.0"
+        },
+        "com.google.jimfs:jimfs": {
+            "locked": "1.2"
         },
         "com.google.testing.compile:compile-testing": {
             "locked": "0.19"
@@ -163,10 +196,13 @@
             "locked": "16.2"
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
-            "locked": "3.9.3"
+            "locked": "3.12.1"
         },
         "com.netflix.graphql.dgs:graphql-dgs-client": {
-            "locked": "3.9.3"
+            "locked": "3.12.1"
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform-dependencies": {
+            "locked": "3.12.1"
         },
         "com.squareup:javapoet": {
             "locked": "1.13.0"
@@ -174,11 +210,17 @@
         "com.squareup:kotlinpoet": {
             "locked": "1.7.2"
         },
+        "commons-lang:commons-lang": {
+            "locked": "2.6"
+        },
         "org.assertj:assertj-core": {
             "locked": "3.11.1"
         },
-        "org.jetbrains.kotlin:kotlin-stdlib": {
+        "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
             "locked": "1.4.31"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.4.32"
         },
         "org.junit.jupiter:junit-jupiter": {
             "locked": "5.7.1"
@@ -192,10 +234,13 @@
     },
     "testRuntimeClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.12.2"
+            "locked": "2.12.3"
         },
         "com.github.ajalt.clikt:clikt": {
             "locked": "3.1.0"
+        },
+        "com.google.jimfs:jimfs": {
+            "locked": "1.2"
         },
         "com.google.testing.compile:compile-testing": {
             "locked": "0.19"
@@ -207,10 +252,13 @@
             "locked": "16.2"
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
-            "locked": "3.9.3"
+            "locked": "3.12.1"
         },
         "com.netflix.graphql.dgs:graphql-dgs-client": {
-            "locked": "3.9.3"
+            "locked": "3.12.1"
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform-dependencies": {
+            "locked": "3.12.1"
         },
         "com.squareup:javapoet": {
             "locked": "1.13.0"
@@ -218,11 +266,17 @@
         "com.squareup:kotlinpoet": {
             "locked": "1.7.2"
         },
+        "commons-lang:commons-lang": {
+            "locked": "2.6"
+        },
         "org.assertj:assertj-core": {
             "locked": "3.11.1"
         },
-        "org.jetbrains.kotlin:kotlin-stdlib": {
+        "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
             "locked": "1.4.31"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.4.32"
         },
         "org.junit.jupiter:junit-jupiter": {
             "locked": "5.7.1"

--- a/graphql-dgs-codegen-gradle/dependencies.lock
+++ b/graphql-dgs-codegen-gradle/dependencies.lock
@@ -35,126 +35,6 @@
             "locked": "1.4.31"
         }
     },
-    "functionalTestCompileClasspath": {
-        "com.google.guava:guava": {
-            "locked": "30.1-jre"
-        },
-        "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core": {
-            "project": true
-        },
-        "org.assertj:assertj-core": {
-            "locked": "3.11.1"
-        },
-        "org.jetbrains.kotlin:kotlin-stdlib": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
-            ],
-            "locked": "1.4.31"
-        },
-        "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
-            "locked": "1.4.31"
-        },
-        "org.junit.jupiter:junit-jupiter": {
-            "locked": "5.7.1"
-        },
-        "org.junit:junit-bom": {
-            "locked": "5.7.1"
-        }
-    },
-    "functionalTestImplementationDependenciesMetadata": {
-        "com.google.guava:guava": {
-            "locked": "30.1-jre"
-        },
-        "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core": {
-            "project": true
-        },
-        "org.assertj:assertj-core": {
-            "locked": "3.11.1"
-        },
-        "org.jetbrains.kotlin:kotlin-stdlib": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
-            ],
-            "locked": "1.4.31"
-        },
-        "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
-            "locked": "1.4.31"
-        },
-        "org.junit.jupiter:junit-jupiter": {
-            "locked": "5.7.1"
-        },
-        "org.junit:junit-bom": {
-            "locked": "5.7.1"
-        }
-    },
-    "functionalTestRuntimeClasspath": {
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
-            ],
-            "locked": "2.12.2"
-        },
-        "com.github.ajalt.clikt:clikt": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
-            ],
-            "locked": "3.1.0"
-        },
-        "com.google.guava:guava": {
-            "locked": "30.1-jre"
-        },
-        "com.graphql-java:graphql-java": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
-            ],
-            "locked": "16.2"
-        },
-        "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core": {
-            "project": true
-        },
-        "com.netflix.graphql.dgs:graphql-dgs": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
-            ],
-            "locked": "3.9.3"
-        },
-        "com.netflix.graphql.dgs:graphql-dgs-client": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
-            ],
-            "locked": "3.9.3"
-        },
-        "com.squareup:javapoet": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
-            ],
-            "locked": "1.13.0"
-        },
-        "com.squareup:kotlinpoet": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
-            ],
-            "locked": "1.7.2"
-        },
-        "org.assertj:assertj-core": {
-            "locked": "3.11.1"
-        },
-        "org.jetbrains.kotlin:kotlin-stdlib": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
-            ],
-            "locked": "1.4.31"
-        },
-        "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
-            "locked": "1.4.31"
-        },
-        "org.junit.jupiter:junit-jupiter": {
-            "locked": "5.7.1"
-        },
-        "org.junit:junit-bom": {
-            "locked": "5.7.1"
-        }
-    },
     "implementationDependenciesMetadata": {
         "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core": {
             "project": true
@@ -194,7 +74,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
-            "locked": "2.12.2"
+            "locked": "2.12.3"
         },
         "com.github.ajalt.clikt:clikt": {
             "firstLevelTransitive": [
@@ -215,13 +95,19 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
-            "locked": "3.9.3"
+            "locked": "3.12.1"
         },
         "com.netflix.graphql.dgs:graphql-dgs-client": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
-            "locked": "3.9.3"
+            "locked": "3.12.1"
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform-dependencies": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
+            ],
+            "locked": "3.12.1"
         },
         "com.squareup:javapoet": {
             "firstLevelTransitive": [
@@ -235,14 +121,20 @@
             ],
             "locked": "1.7.2"
         },
+        "commons-lang:commons-lang": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
+            ],
+            "locked": "2.6"
+        },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
-            "locked": "1.4.31"
+            "locked": "1.4.32"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
-            "locked": "1.4.31"
+            "locked": "1.4.32"
         }
     },
     "testCompileClasspath": {
@@ -302,7 +194,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
-            "locked": "2.12.2"
+            "locked": "2.12.3"
         },
         "com.github.ajalt.clikt:clikt": {
             "firstLevelTransitive": [
@@ -326,13 +218,19 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
-            "locked": "3.9.3"
+            "locked": "3.12.1"
         },
         "com.netflix.graphql.dgs:graphql-dgs-client": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
-            "locked": "3.9.3"
+            "locked": "3.12.1"
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform-dependencies": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
+            ],
+            "locked": "3.12.1"
         },
         "com.squareup:javapoet": {
             "firstLevelTransitive": [
@@ -346,6 +244,12 @@
             ],
             "locked": "1.7.2"
         },
+        "commons-lang:commons-lang": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
+            ],
+            "locked": "2.6"
+        },
         "org.assertj:assertj-core": {
             "locked": "3.11.1"
         },
@@ -353,10 +257,10 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
-            "locked": "1.4.31"
+            "locked": "1.4.32"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
-            "locked": "1.4.31"
+            "locked": "1.4.32"
         },
         "org.junit.jupiter:junit-jupiter": {
             "locked": "5.7.1"


### PR DESCRIPTION
This commit switches from the `graphql-dgs-platform` to the `graphql-dgs-platform-dependencies` BOM.
The latter provides recommendations not only for DGS Components but for their dependencies, including Jackson.