### PR TITLE
Disable JUnit Reporting due usage of repo token.

### DIFF
--- a/.github/workflows/ci-beta.yml
+++ b/.github/workflows/ci-beta.yml
@@ -58,11 +58,11 @@ jobs:
         run: |
           ./gradlew --info check publishToMavenLocal --warning-mode all
 
-      - name: Publish Test Report
-        if: ${{ always() }}
-        uses: scacap/action-surefire-report@v1
-        with:
-          report_paths: '**/build/test-results/test/TEST-*.xml'
+      # - name: Publish Test Report
+      #   if: ${{ always() }}
+      #   uses: scacap/action-surefire-report@v1
+      #   with:
+      #     report_paths: '**/build/test-results/test/TEST-*.xml'
 
       - name: Clone dgs-examples-java
         uses: actions/checkout@master
@@ -81,10 +81,10 @@ jobs:
           find /home/runner/.m2/repository/ -type f -name "*graphql-dgs-codegen-gradle*"
           ./scripts/test-examples.py -v -k --path=./build/examples
 
-      - name: Publish Examples Test Report
-        if: ${{ always() }}
-        uses: scacap/action-surefire-report@v1
-        with:
-          check_name: Examples Test Reports
-          report_paths: 'build/examples/**/build/test-results/test/TEST-*.xml'
+      # - name: Publish Examples Test Report
+      #   if: ${{ always() }}
+      #   uses: scacap/action-surefire-report@v1
+      #   with:
+      #     check_name: Examples Test Reports
+      #     report_paths: 'build/examples/**/build/test-results/test/TEST-*.xml'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,10 @@ jobs:
         run: chmod +x gradlew
       - name: Build with Gradle
         run: ./gradlew build
-      - name: Publish Test Report
-        if: ${{ always() }}
-        uses: scacap/action-surefire-report@v1
-        with:
-          report_paths: '**/build/test-results/test/TEST-*.xml'
+
+      # - name: Publish Test Report
+      #   if: ${{ always() }}
+      #   uses: scacap/action-surefire-report@v1
+      #   with:
+      #     report_paths: '**/build/test-results/test/TEST-*.xml'
 


### PR DESCRIPTION
The `scacap/action-surefire-report@v1` GitHub action requests access to the `github_token`. This is problematic when the PR comes from a _Fork_. We will disable it for now until a better option is available.

Ref. https://securitylab.github.com/research/github-actions-preventing-pwn-requests/