### PR TITLE
Bug fixes when using config option to generateInterfaces for data classes.

### DIFF
--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/DataTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/DataTypeGenerator.kt
@@ -56,7 +56,8 @@ class DataTypeGenerator(private val config: CodeGenConfig, private val document:
                 .plus(extensions.flatMap { it.fieldDefinitions }.filterSkipped().map { Field(it.name, typeUtils.findReturnType(it.type, useInterfaceType, true)) })
             val interfaceName = "I$name"
             implements = listOf(interfaceName) + implements
-            interfaceCodeGenResult = generateInterface(interfaceName, fieldDefinitions)
+            val superInterfaces = definition.implements
+            interfaceCodeGenResult = generateInterface(interfaceName, superInterfaces, fieldDefinitions)
         }
 
         val fieldDefinitions = definition.fieldDefinitions
@@ -147,9 +148,13 @@ abstract class BaseDataTypeGenerator(internal val packageName: String, private v
         return CodeGenResult(dataTypes = listOf(javaFile))
     }
 
-    internal fun generateInterface(name: String, fields: List<Field>): CodeGenResult {
+    internal fun generateInterface(name: String, superInterfaces: List<Type<*>>, fields: List<Field>): CodeGenResult {
         val javaType = TypeSpec.interfaceBuilder(name)
             .addModifiers(Modifier.PUBLIC)
+
+        superInterfaces.forEach {
+            javaType.addSuperinterface(ClassName.get(packageName, (it as TypeName).name))
+        }
 
         fields.forEach {
             addAbstractGetter(it.type, it, javaType)

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/TypeUtils.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/TypeUtils.kt
@@ -140,7 +140,8 @@ class TypeUtils(private val packageName: String, private val config: CodeGenConf
                 var simpleName = name
                 if (useInterfaceType &&
                     !document.definitions.filterIsInstance<EnumTypeDefinition>().any { e -> e.name == name } &&
-                    !document.definitions.filterIsInstance<UnionTypeDefinition>().any { e -> e.name == name }
+                    !document.definitions.filterIsInstance<UnionTypeDefinition>().any { e -> e.name == name } &&
+                    !isFieldTypeAnInterface(this)
                 ) {
                     simpleName = "I$name"
                 }
@@ -207,4 +208,10 @@ class TypeUtils(private val packageName: String, private val config: CodeGenConf
                 it.name to (value as StringValue).value
             }.toMap()
         }
+
+    fun isFieldTypeAnInterface(fieldDefinitionType: TypeName): Boolean {
+        return document.getDefinitionsOfType(InterfaceTypeDefinition::class.java).asSequence()
+            .filter { node -> node.name == findInnerType(fieldDefinitionType).name }
+            .toList().isNotEmpty()
+    }
 }


### PR DESCRIPTION
1) Ensure data classes that have interface fields return the appropriate interface type in getters.
2) Also ensure generated interface classes for corresponding data classes contain the original super interfaces .

For this schema,
```
interface Fruit {
    name: String
}
        
type Apple implements Fruit {
    name: String
}
        
type Basket {
  fruit: Fruit
}
```
 the generated `IApple` interface did not extend `Fruit` . Also in `Basket`, the return type of `getFruit` was `IFruit` instead of `Fruit` where `IFruit` is not generated because it is already an interface.

This PR fixes both these issues.
