### PR TITLE
Adding the graphql-dgs-codegen-client-core module

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,33 +16,65 @@
  *
  */
 
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+    dependencies {
+        classpath 'nl.javadude.gradle.plugins:license-gradle-plugin:0.10.0'
+    }
+}
+
 plugins {
     id 'org.jetbrains.kotlin.jvm' version '1.4.31' apply false
     id 'nebula.netflixoss' version '9.4.2'
     id 'org.jlleitschuh.gradle.ktlint' version '10.0.0'
 }
 
+description = 'Netflix GraphQL DGS Code Generation'
+
 allprojects {
     repositories {
         mavenCentral()
     }
+
+    apply plugin: 'nebula.netflixoss'
+    apply plugin: 'nebula.info'
+    apply plugin: 'org.jetbrains.kotlin.jvm'
+    apply plugin: 'license'
+
     group = 'com.netflix.graphql.dgs.codegen'
+
+    dependencies {
+        testImplementation platform('org.junit:junit-bom:5.7.+')
+        testImplementation 'org.assertj:assertj-core:3.19.+'
+        testImplementation 'org.junit.jupiter:junit-jupiter'
+        testImplementation 'org.junit.jupiter:junit-jupiter-params'
+    }
 
     tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
       kotlinOptions {
         jvmTarget = "1.8"
       }
     }
+
+    license {
+        exclude('**/*.bin')
+        exclude('**/test-project/*')
+    }
+
+    test {
+        useJUnitPlatform()
+    }
+
+    sourceCompatibility = 1.8
 }
 
 subprojects {
     apply {
         plugin("org.jlleitschuh.gradle.ktlint")
     }
-
     ktlint {
         disabledRules = ["no-wildcard-imports"]
     }
 }
-
-description = 'Netflix GraphQL DGS Code Generation'

--- a/dependencies.lock
+++ b/dependencies.lock
@@ -1,7 +1,93 @@
 {
+    "apiDependenciesMetadata": {
+        "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
+            "locked": "1.4.31"
+        }
+    },
+    "compileClasspath": {
+        "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
+            "locked": "1.4.31"
+        }
+    },
+    "implementationDependenciesMetadata": {
+        "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
+            "locked": "1.4.31"
+        }
+    },
+    "kotlinCompilerClasspath": {
+        "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
+            "locked": "1.4.31"
+        }
+    },
+    "kotlinCompilerPluginClasspath": {
+        "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
+            "locked": "1.4.31"
+        }
+    },
+    "kotlinKlibCommonizerClasspath": {
+        "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable": {
+            "locked": "1.4.31"
+        }
+    },
     "ktlint": {
         "com.pinterest:ktlint": {
             "locked": "0.40.0"
+        }
+    },
+    "runtimeClasspath": {
+        "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
+            "locked": "1.4.31"
+        }
+    },
+    "testCompileClasspath": {
+        "org.assertj:assertj-core": {
+            "locked": "3.19.0"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
+            "locked": "1.4.31"
+        },
+        "org.junit.jupiter:junit-jupiter": {
+            "locked": "5.7.2"
+        },
+        "org.junit.jupiter:junit-jupiter-params": {
+            "locked": "5.7.2"
+        },
+        "org.junit:junit-bom": {
+            "locked": "5.7.2"
+        }
+    },
+    "testImplementationDependenciesMetadata": {
+        "org.assertj:assertj-core": {
+            "locked": "3.19.0"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
+            "locked": "1.4.31"
+        },
+        "org.junit.jupiter:junit-jupiter": {
+            "locked": "5.7.2"
+        },
+        "org.junit.jupiter:junit-jupiter-params": {
+            "locked": "5.7.2"
+        },
+        "org.junit:junit-bom": {
+            "locked": "5.7.2"
+        }
+    },
+    "testRuntimeClasspath": {
+        "org.assertj:assertj-core": {
+            "locked": "3.19.0"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
+            "locked": "1.4.31"
+        },
+        "org.junit.jupiter:junit-jupiter": {
+            "locked": "5.7.2"
+        },
+        "org.junit.jupiter:junit-jupiter-params": {
+            "locked": "5.7.2"
+        },
+        "org.junit:junit-bom": {
+            "locked": "5.7.2"
         }
     }
 }

--- a/graphql-dgs-codegen-client-core/build.gradle
+++ b/graphql-dgs-codegen-client-core/build.gradle
@@ -1,0 +1,36 @@
+/*
+ *
+ *  Copyright 2020 Netflix, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+plugins {
+    id 'java-library'
+}
+
+dependencies {
+    implementation platform('com.netflix.graphql.dgs:graphql-dgs-platform-dependencies:latest.release')
+    compileOnly platform('com.netflix.graphql.dgs:graphql-dgs-platform-dependencies:latest.release')
+
+    compileOnly 'com.netflix.graphql.dgs:graphql-dgs-client'
+    compileOnly 'com.graphql-java:graphql-java'
+    compileOnly 'com.fasterxml.jackson.core:jackson-databind'
+    compileOnly 'org.springframework:spring-core'
+
+    testImplementation 'com.netflix.graphql.dgs:graphql-dgs-client'
+    testImplementation 'com.netflix.graphql.dgs:graphql-dgs-extended-scalars'
+    testImplementation 'com.graphql-java:graphql-java'
+    testImplementation 'org.springframework:spring-core'
+}

--- a/graphql-dgs-codegen-client-core/dependencies.lock
+++ b/graphql-dgs-codegen-client-core/dependencies.lock
@@ -1,0 +1,176 @@
+{
+    "apiDependenciesMetadata": {
+        "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
+            "locked": "1.4.31"
+        }
+    },
+    "compileClasspath": {
+        "com.fasterxml.jackson.core:jackson-databind": {
+            "locked": "2.12.3"
+        },
+        "com.graphql-java:graphql-java": {
+            "locked": "16.2"
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-client": {
+            "locked": "4.3.1"
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform-dependencies": {
+            "locked": "4.3.1"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
+            "locked": "1.4.32"
+        },
+        "org.springframework:spring-core": {
+            "locked": "5.2.13.RELEASE"
+        }
+    },
+    "compileOnlyDependenciesMetadata": {
+        "com.fasterxml.jackson.core:jackson-databind": {
+            "locked": "2.12.3"
+        },
+        "com.graphql-java:graphql-java": {
+            "locked": "16.2"
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-client": {
+            "locked": "4.3.1"
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform-dependencies": {
+            "locked": "4.3.1"
+        },
+        "org.springframework:spring-core": {
+            "locked": "5.2.13.RELEASE"
+        }
+    },
+    "implementationDependenciesMetadata": {
+        "com.netflix.graphql.dgs:graphql-dgs-platform-dependencies": {
+            "locked": "4.3.1"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
+            "locked": "1.4.31"
+        }
+    },
+    "kotlinCompilerClasspath": {
+        "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
+            "locked": "1.4.31"
+        }
+    },
+    "kotlinCompilerPluginClasspath": {
+        "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
+            "locked": "1.4.31"
+        }
+    },
+    "kotlinKlibCommonizerClasspath": {
+        "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable": {
+            "locked": "1.4.31"
+        }
+    },
+    "ktlint": {
+        "com.pinterest:ktlint": {
+            "locked": "0.40.0"
+        }
+    },
+    "runtimeClasspath": {
+        "com.netflix.graphql.dgs:graphql-dgs-platform-dependencies": {
+            "locked": "4.3.1"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
+            "locked": "1.4.31"
+        }
+    },
+    "testCompileClasspath": {
+        "com.graphql-java:graphql-java": {
+            "locked": "16.2"
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-client": {
+            "locked": "4.3.1"
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-extended-scalars": {
+            "locked": "4.3.1"
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform-dependencies": {
+            "locked": "4.3.1"
+        },
+        "org.assertj:assertj-core": {
+            "locked": "3.19.0"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
+            "locked": "1.4.32"
+        },
+        "org.junit.jupiter:junit-jupiter": {
+            "locked": "5.7.2"
+        },
+        "org.junit.jupiter:junit-jupiter-params": {
+            "locked": "5.7.2"
+        },
+        "org.junit:junit-bom": {
+            "locked": "5.7.2"
+        },
+        "org.springframework:spring-core": {
+            "locked": "5.2.13.RELEASE"
+        }
+    },
+    "testImplementationDependenciesMetadata": {
+        "com.graphql-java:graphql-java": {
+            "locked": "16.2"
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-client": {
+            "locked": "4.3.1"
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-extended-scalars": {
+            "locked": "4.3.1"
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform-dependencies": {
+            "locked": "4.3.1"
+        },
+        "org.assertj:assertj-core": {
+            "locked": "3.19.0"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
+            "locked": "1.4.32"
+        },
+        "org.junit.jupiter:junit-jupiter": {
+            "locked": "5.7.2"
+        },
+        "org.junit.jupiter:junit-jupiter-params": {
+            "locked": "5.7.2"
+        },
+        "org.junit:junit-bom": {
+            "locked": "5.7.2"
+        },
+        "org.springframework:spring-core": {
+            "locked": "5.2.13.RELEASE"
+        }
+    },
+    "testRuntimeClasspath": {
+        "com.graphql-java:graphql-java": {
+            "locked": "16.2"
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-client": {
+            "locked": "4.3.1"
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-extended-scalars": {
+            "locked": "4.3.1"
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform-dependencies": {
+            "locked": "4.3.1"
+        },
+        "org.assertj:assertj-core": {
+            "locked": "3.19.0"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
+            "locked": "1.4.32"
+        },
+        "org.junit.jupiter:junit-jupiter": {
+            "locked": "5.7.2"
+        },
+        "org.junit.jupiter:junit-jupiter-params": {
+            "locked": "5.7.2"
+        },
+        "org.junit:junit-bom": {
+            "locked": "5.7.2"
+        },
+        "org.springframework:spring-core": {
+            "locked": "5.2.13.RELEASE"
+        }
+    }
+}

--- a/graphql-dgs-codegen-client-core/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/BaseProjectionNode.kt
+++ b/graphql-dgs-codegen-client-core/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/BaseProjectionNode.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.client.codegen
+
+import java.util.*
+import kotlin.collections.LinkedHashMap
+
+abstract class BaseProjectionNode(
+    /**
+     * Explicit GraphQL Schema type. This, for example, is used to define the GraphQL Type when resolving a _fragment_.
+     * For example, let's say the `schemaType` is `"Movie"`, then  the _Entity fragment_ associated to
+     * this node will be:
+     *
+     * ```
+     *  ... on Movie {
+     * ```
+     */
+    val schemaType: Optional<String> = Optional.empty()
+) {
+
+    val fields: MutableMap<String, Any?> = LinkedHashMap()
+    val fragments: MutableList<BaseSubProjectionNode<*, *>> = LinkedList()
+    val inputArguments: MutableMap<String, List<InputArgument>> = LinkedHashMap()
+
+    data class InputArgument(val name: String, val value: Any)
+}

--- a/graphql-dgs-codegen-client-core/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/BaseSubProjectionNode.kt
+++ b/graphql-dgs-codegen-client-core/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/BaseSubProjectionNode.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.client.codegen
+
+import java.util.*
+
+abstract class BaseSubProjectionNode<T, R>(
+    val parent: T,
+    val root: R,
+    schemaType: Optional<String> = Optional.empty()
+) : BaseProjectionNode(schemaType) {
+
+    constructor(parent: T, root: R) : this(parent, root, schemaType = Optional.empty())
+
+    fun parent(): T {
+        return parent
+    }
+
+    fun root(): R {
+        return root
+    }
+}

--- a/graphql-dgs-codegen-client-core/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/EntitiesGraphQLQuery.kt
+++ b/graphql-dgs-codegen-client-core/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/EntitiesGraphQLQuery.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.client.codegen
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import java.util.*
+
+class EntitiesGraphQLQuery : GraphQLQuery {
+    val variables: MutableMap<String, Any> = LinkedHashMap()
+
+    constructor(representations: List<Any>?) {
+        variables["representations"] = representations!!
+    }
+
+    constructor()
+
+    override fun getOperationType(): String {
+        return "query(\$representations: [_Any!]!)"
+    }
+
+    override fun getOperationName(): String {
+        return "_entities(representations: \$representations)"
+    }
+
+    class Builder {
+        private val representations: MutableList<Any> = ArrayList()
+        val mapper = ObjectMapper()
+
+        fun build(): EntitiesGraphQLQuery {
+            return EntitiesGraphQLQuery(representations)
+        }
+
+        fun addRepresentationAsVariable(representation: Any): Builder {
+            representations.add(mapper.convertValue(representation, HashMap::class.java))
+            return this
+        }
+    }
+
+    companion object {
+        fun newRequest(): Builder {
+            return Builder()
+        }
+    }
+}

--- a/graphql-dgs-codegen-client-core/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/GraphQLQuery.kt
+++ b/graphql-dgs-codegen-client-core/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/GraphQLQuery.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.client.codegen
+
+import java.util.*
+
+abstract class GraphQLQuery(val operation: String, val name: String?) {
+    val input: MutableMap<String, Any> = LinkedHashMap()
+
+    constructor(operation: String) : this(operation, null)
+    constructor() : this("query")
+
+    open fun getOperationType(): String? {
+        return operation
+    }
+
+    abstract fun getOperationName(): String
+}

--- a/graphql-dgs-codegen-client-core/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/GraphQLQueryRequest.kt
+++ b/graphql-dgs-codegen-client-core/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/GraphQLQueryRequest.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.client.codegen
+
+import graphql.schema.Coercing
+
+class GraphQLQueryRequest(
+    private val query: GraphQLQuery,
+    private val projection: BaseProjectionNode?,
+    scalars: Map<Class<*>, Coercing<*, *>>?
+) {
+
+    constructor(query: GraphQLQuery) : this(query, null, null)
+    constructor(query: GraphQLQuery, projection: BaseProjectionNode?) : this(query, projection, null)
+    private val inputValueSerializer = InputValueSerializer(scalars ?: emptyMap())
+    private val projectionSerializer = ProjectionSerializer(inputValueSerializer)
+
+    fun serialize(): String {
+        val builder = StringBuilder()
+        builder.append(query.getOperationType())
+        if (query.name != null) {
+            builder.append(" ").append(query.name)
+        }
+        builder.append(" {").append(query.getOperationName())
+        val input: Map<String, Any?> = query.input
+        if (input.isNotEmpty()) {
+            builder.append("(")
+            val inputEntryIterator = input.entries.iterator()
+            while (inputEntryIterator.hasNext()) {
+                val (key, value) = inputEntryIterator.next()
+                builder.append(key)
+                builder.append(": ")
+                builder.append(inputValueSerializer.serialize(value))
+                if (inputEntryIterator.hasNext()) {
+                    builder.append(", ")
+                }
+            }
+            builder.append(")")
+        }
+
+        if (projection is BaseSubProjectionNode<*, *>) {
+            builder.append(projectionSerializer.serialize(projection.root() as BaseProjectionNode))
+        } else if (projection != null) {
+            builder.append(projectionSerializer.serialize(projection))
+        }
+
+        builder.append(" }")
+        return builder.toString()
+    }
+}

--- a/graphql-dgs-codegen-client-core/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/InputValueSerializer.kt
+++ b/graphql-dgs-codegen-client-core/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/InputValueSerializer.kt
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.client.codegen
+
+import graphql.schema.Coercing
+import org.springframework.util.ReflectionUtils
+import java.lang.reflect.Field
+import java.time.*
+import java.util.*
+
+class InputValueSerializer(private val scalars: Map<Class<*>, Coercing<*, *>> = emptyMap()) {
+    companion object {
+        val toStringClasses = setOf(
+            String::class.java,
+            LocalDateTime::class.java,
+            LocalDate::class.java,
+            LocalTime::class.java,
+            TimeZone::class.java,
+            Date::class.java,
+            OffsetDateTime::class.java,
+            Currency::class.java,
+            Instant::class.java
+        )
+    }
+
+    fun serialize(input: Any?): String? {
+        if (input == null) {
+            return "null"
+        }
+
+        val type = input::class.java
+
+        return if (scalars.contains(type)) {
+            """"${scalars[type]!!.serialize(input)}""""
+        } else if (type.isPrimitive || type.isAssignableFrom(java.lang.Integer::class.java) || type.isAssignableFrom(java.lang.Long::class.java) || type.isAssignableFrom(java.lang.Double::class.java) || type.isAssignableFrom(java.lang.Float::class.java) || type.isAssignableFrom(java.lang.Boolean::class.java) || type.isAssignableFrom(java.lang.Short::class.java) || type.isAssignableFrom(java.lang.Byte::class.java) || type.isEnum) {
+            input.toString()
+        } else if (toStringClasses.contains(type)) {
+            // Call toString for known types, in case no scalar is found. This is for backward compatibility.
+            """"${input.toString().replace("\\", "\\\\").replace("\"", "\\\"")}""""
+        } else if (input is List<*>) {
+            """[${input.filterNotNull().joinToString(", ") { listItem -> serialize(listItem) ?: "" }}]"""
+        } else if (input is Map<*, *>) {
+            input.map {
+                entry ->
+                if (entry.value != null) {
+                    """${entry.key}: ${serialize(entry.value)}"""
+                } else {
+                    """${entry.key}: null"""
+                }
+            }.joinToString(", ", "{ ", " }")
+        } else {
+            val fields = LinkedList<Field>()
+            ReflectionUtils.doWithFields(input.javaClass) {
+                if (!it.isSynthetic) {
+                    ReflectionUtils.makeAccessible(it)
+                    fields.add(it)
+                }
+            }
+
+            fields.filter { !it.type::class.isCompanion }.mapNotNull {
+                val nestedValue = it.get(input)
+                if (nestedValue != null && nestedValue::class.java == input::class.java) {
+                    """${it.name}:$nestedValue"""
+                } else if (nestedValue != null && !nestedValue::class.isCompanion) {
+                    """${it.name}:${serialize(nestedValue)}"""
+                } else {
+                    null
+                }
+            }.joinToString(", ", "{", " }")
+        }
+    }
+}

--- a/graphql-dgs-codegen-client-core/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/ProjectionSerializer.kt
+++ b/graphql-dgs-codegen-client-core/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/ProjectionSerializer.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.client.codegen
+
+import java.util.*
+
+class ProjectionSerializer(private val inputValueSerializer: InputValueSerializer) {
+
+    fun serialize(projection: BaseProjectionNode, isFragment: Boolean = false): String {
+        if (projection.fields.isEmpty() && projection.fragments.isEmpty()) {
+            return ""
+        }
+
+        val prefix = if (isFragment) {
+            val schemaType = projection.schemaType.orElse(
+                projection::class.java.name
+                    .substringAfterLast(".")
+                    .substringAfterLast("_")
+                    .substringBefore("Projection")
+            )
+            "... on $schemaType { "
+        } else {
+            "{ "
+        }
+
+        val joiner = StringJoiner(" ", prefix, " }")
+        projection.fields.forEach { (key, value) ->
+            val field = if (projection.inputArguments[key] != null) {
+                val inputArgsJoiner = StringJoiner(", ", "(", ")")
+                projection.inputArguments[key]?.forEach {
+                    inputArgsJoiner.add("${it.name}: ${inputValueSerializer.serialize(it.value)}")
+                }
+
+                key + inputArgsJoiner.toString()
+            } else {
+                key
+            }
+
+            joiner.add(field)
+            if (value != null) {
+                if (value is BaseProjectionNode) {
+                    joiner.add(" ").add(serialize(value))
+                } else {
+                    joiner.add(" ").add(value.toString())
+                }
+            }
+        }
+
+        projection.fragments.forEach { joiner.add(serialize(it, true)) }
+
+        return joiner.toString()
+    }
+}

--- a/graphql-dgs-codegen-client-core/src/test/java/com/netflix/graphql/dgs/client/codegen/MovieInput.java
+++ b/graphql-dgs-codegen-client-core/src/test/java/com/netflix/graphql/dgs/client/codegen/MovieInput.java
@@ -1,0 +1,65 @@
+/*
+ *
+ *  Copyright 2020 Netflix, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package com.netflix.graphql.dgs.client.codegen;
+
+import java.util.List;
+
+public class MovieInput {
+    private int movieId;
+    private String title;
+    private Genre genre;
+    private Director director;
+    private List<Actor> actor;
+    private DateRange releaseWindow;
+
+    public MovieInput(int movieId, String title, Genre genre, Director director, List<Actor> actor, DateRange releaseWindow) {
+        this.movieId = movieId;
+        this.title = title;
+        this.genre = genre;
+        this.director = director;
+        this.actor = actor;
+        this.releaseWindow = releaseWindow;
+    }
+
+    public MovieInput(int movieId) {
+        this.movieId = movieId;
+    }
+
+    public enum Genre {
+        ACTION,DRAMA
+    }
+
+    public static class Director {
+        private String name;
+
+        Director(String name) {
+            this.name = name;
+        }
+    }
+
+    public static class Actor {
+        private String name;
+        private String roleName;
+
+        Actor(String name, String roleName) {
+            this.name = name;
+            this.roleName = roleName;
+        }
+    }
+}

--- a/graphql-dgs-codegen-client-core/src/test/java/com/netflix/graphql/dgs/client/codegen/exampleprojection/ShowsProjectionRoot.java
+++ b/graphql-dgs-codegen-client-core/src/test/java/com/netflix/graphql/dgs/client/codegen/exampleprojection/ShowsProjectionRoot.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.client.codegen.exampleprojection;
+
+import com.netflix.graphql.dgs.client.codegen.BaseProjectionNode;
+import com.netflix.graphql.dgs.client.codegen.BaseSubProjectionNode;
+
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+
+public class ShowsProjectionRoot extends BaseProjectionNode {
+
+    public Shows_ReviewsProjection reviews() {
+        Shows_ReviewsProjection projection = new Shows_ReviewsProjection(this, this);
+        getFields().put("reviews", projection);
+        return projection;
+    }
+
+    public Shows_ReviewsProjection reviews(Integer minScore, OffsetDateTime since) {
+        Shows_ReviewsProjection projection = new Shows_ReviewsProjection(this, this);
+        getFields().put("reviews", projection);
+        getInputArguments().computeIfAbsent("reviews", k -> new ArrayList<>());
+        InputArgument minScoreArg = new InputArgument("minScore", minScore);
+        getInputArguments().get("reviews").add(minScoreArg);
+        InputArgument sinceArg = new InputArgument("since", since);
+        getInputArguments().get("reviews").add(sinceArg);
+        return projection;
+    }
+
+
+    public ShowsProjectionRoot id() {
+        getFields().put("id", null);
+        return this;
+    }
+
+    public ShowsProjectionRoot title() {
+        getFields().put("title", null);
+        return this;
+    }
+
+    public ShowsProjectionRoot releaseYear() {
+        getFields().put("releaseYear", null);
+        return this;
+    }
+
+    public static class Shows_ReviewsProjection extends BaseSubProjectionNode<ShowsProjectionRoot, ShowsProjectionRoot> {
+      public Shows_ReviewsProjection(ShowsProjectionRoot parent, ShowsProjectionRoot root) {
+        super(parent, root);
+      }
+
+      public Shows_ReviewsProjection username() {
+        getFields().put("username", null);
+        return this;
+      }
+
+      public Shows_ReviewsProjection starScore() {
+        getFields().put("starScore", null);
+        return this;
+      }
+
+      public Shows_ReviewsProjection submittedDate() {
+        getFields().put("submittedDate", null);
+        return this;
+      }
+    }
+}

--- a/graphql-dgs-codegen-client-core/src/test/kotlin/com/netflix/graphql/dgs/client/codegen/DateRangeScalar.kt
+++ b/graphql-dgs-codegen-client-core/src/test/kotlin/com/netflix/graphql/dgs/client/codegen/DateRangeScalar.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.client.codegen
+
+import graphql.language.StringValue
+import graphql.schema.Coercing
+import graphql.schema.CoercingParseLiteralException
+import graphql.schema.CoercingParseValueException
+import graphql.schema.CoercingSerializeException
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+
+class DateRangeScalar : Coercing<DateRange, String> {
+    private var formatter = DateTimeFormatter.ofPattern("MM/dd/yyyy")
+
+    @Throws(CoercingSerializeException::class)
+    override fun serialize(dataFetcherResult: Any): String {
+        val range: DateRange = dataFetcherResult as DateRange
+        return range.from.format(formatter) + "-" + range.to.format(formatter)
+    }
+
+    @Throws(CoercingParseValueException::class)
+    override fun parseValue(input: Any): DateRange {
+        val split = (input as String).split("-").toTypedArray()
+        val from = LocalDate.parse(split[0], formatter)
+        val to = LocalDate.parse(split[0], formatter)
+        return DateRange(from, to)
+    }
+
+    @Throws(CoercingParseLiteralException::class)
+    override fun parseLiteral(input: Any): DateRange {
+        val split = (input as StringValue).value.split("-").toTypedArray()
+        val from = LocalDate.parse(split[0], formatter)
+        val to = LocalDate.parse(split[0], formatter)
+        return DateRange(from, to)
+    }
+}
+
+class DateRange(val from: LocalDate, val to: LocalDate)

--- a/graphql-dgs-codegen-client-core/src/test/kotlin/com/netflix/graphql/dgs/client/codegen/GraphQLQueryRequestTest.kt
+++ b/graphql-dgs-codegen-client-core/src/test/kotlin/com/netflix/graphql/dgs/client/codegen/GraphQLQueryRequestTest.kt
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.client.codegen
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+class GraphQLQueryRequestTest {
+    @Test
+    fun testSerializeListOfStringsAsInput() {
+        val query = TestGraphQLQuery().apply {
+            input["actors"] = "actorA"
+            input["movies"] = listOf("movie1", "movie2")
+        }
+        val request = GraphQLQueryRequest(query)
+        val result = request.serialize()
+        assertThat(result).isEqualTo("query {test(actors: \"actorA\", movies: [\"movie1\", \"movie2\"]) }")
+    }
+
+    @Test
+    fun testSerializeListOfIntegersAsInput() {
+        val query = TestGraphQLQuery().apply {
+            input["movies"] = listOf(1234, 5678)
+        }
+        val request = GraphQLQueryRequest(query)
+        val result = request.serialize()
+        assertThat(result).isEqualTo("query {test(movies: [1234, 5678]) }")
+    }
+
+    @Test
+    fun testSerializeInputWithMultipleParameters() {
+        val query = TestGraphQLQuery().apply {
+            input["name"] = "noname"
+            input["age"] = 30
+        }
+        val request = GraphQLQueryRequest(query)
+        val result = request.serialize()
+        assertThat(result).isEqualTo("query {test(name: \"noname\", age: 30) }")
+    }
+
+    @Test
+    fun testSerializeInputClass() {
+        val query = TestGraphQLQuery().apply {
+            input["movie"] = Movie(1234, "testMovie")
+        }
+        val request = GraphQLQueryRequest(query)
+        val result = request.serialize()
+        assertThat(result).isEqualTo("query {test(movie: {movieId:1234, name:\"testMovie\" }) }")
+    }
+
+    @Test
+    fun testSerializeInputClassWithProjection() {
+        val query = TestGraphQLQuery().apply {
+            input["movie"] = Movie(1234, "testMovie")
+        }
+        val request = GraphQLQueryRequest(query, MovieProjection().name().movieId())
+        val result = request.serialize()
+        assertThat(result).isEqualTo("query {test(movie: {movieId:1234, name:\"testMovie\" }){ name movieId } }")
+    }
+
+    @Test
+    fun testSerializeMutation() {
+        val query = TestGraphQLMutation().apply {
+            input["movie"] = Movie(1234, "testMovie")
+        }
+        val request = GraphQLQueryRequest(query, MovieProjection().name().movieId())
+        val result = request.serialize()
+        assertThat(result).isEqualTo("mutation {testMutation(movie: {movieId:1234, name:\"testMovie\" }){ name movieId } }")
+    }
+
+    @Test
+    fun serializeWithName() {
+        val query = TestNamedGraphQLQuery().apply {
+            input["movie"] = Movie(123, "greatMovie")
+        }
+        val request = GraphQLQueryRequest(query, MovieProjection().name().movieId())
+        val result = request.serialize()
+        assertThat(result).isEqualTo("query TestNamedQuery {test(movie: {movieId:123, name:\"greatMovie\" }){ name movieId } }")
+    }
+
+    @Test
+    fun serializeWithScalar() {
+        val query = TestNamedGraphQLQuery().apply {
+            input["movie"] = Movie(123, "greatMovie")
+            input["dateRange"] = DateRange(LocalDate.of(2020, 1, 1), LocalDate.of(2021, 5, 11))
+        }
+        val request =
+            GraphQLQueryRequest(query, MovieProjection(), mapOf(DateRange::class.java to DateRangeScalar()))
+
+        val result = request.serialize()
+        assertThat(result).isEqualTo("query TestNamedQuery {test(movie: {movieId:123, name:\"greatMovie\" }, dateRange: \"01/01/2020-05/11/2021\") }")
+    }
+
+    @Test
+    fun serializeWithNestedScalar() {
+        val query = TestNamedGraphQLQuery().apply {
+            input["movie"] = Movie(123, "greatMovie", DateRange(LocalDate.of(2020, 1, 1), LocalDate.of(2021, 5, 11)))
+        }
+        val request =
+            GraphQLQueryRequest(query, MovieProjection(), mapOf(DateRange::class.java to DateRangeScalar()))
+
+        val result = request.serialize()
+        assertThat(result).isEqualTo("query TestNamedQuery {test(movie: {movieId:123, name:\"greatMovie\", window:\"01/01/2020-05/11/2021\" }) }")
+    }
+
+    @Test
+    fun testSerializeMapAsInput() {
+        val query = TestGraphQLQuery().apply {
+            input["actors"] = mapOf("name" to "actorA", "movies" to listOf("movie1", "movie2"))
+            input["movie"] = Movie(123, "greatMovie", DateRange(LocalDate.of(2020, 1, 1), LocalDate.of(2021, 5, 11)))
+        }
+        val request = GraphQLQueryRequest(query, MovieProjection(), mapOf(DateRange::class.java to DateRangeScalar()))
+        val result = request.serialize()
+        assertThat(result).isEqualTo("query {test(actors: { name: \"actorA\", movies: [\"movie1\", \"movie2\"] }, movie: {movieId:123, name:\"greatMovie\", window:\"01/01/2020-05/11/2021\" }) }")
+    }
+}
+
+class TestGraphQLQuery : GraphQLQuery() {
+    override fun getOperationName(): String {
+        return "test"
+    }
+}
+
+class TestNamedGraphQLQuery : GraphQLQuery("query", "TestNamedQuery") {
+    override fun getOperationName(): String {
+        return "test"
+    }
+}
+
+class TestGraphQLMutation : GraphQLQuery("mutation") {
+    override fun getOperationName(): String {
+        return "testMutation"
+    }
+}
+
+data class Movie(val movieId: Int, val name: String, val window: DateRange? = null)
+
+class MovieProjection : BaseProjectionNode() {
+    fun movieId(): MovieProjection {
+        fields["movieId"] = null
+        return this
+    }
+
+    fun name(): MovieProjection {
+        fields["name"] = null
+        return this
+    }
+}

--- a/graphql-dgs-codegen-client-core/src/test/kotlin/com/netflix/graphql/dgs/client/codegen/InputValueSerializerTest.kt
+++ b/graphql-dgs-codegen-client-core/src/test/kotlin/com/netflix/graphql/dgs/client/codegen/InputValueSerializerTest.kt
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.client.codegen
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+class InputValueSerializerTest {
+
+    @Test
+    fun `Serialize a complex object`() {
+
+        val movieInput = MovieInput(
+            1,
+            "Some movie",
+            MovieInput.Genre.ACTION,
+            MovieInput.Director("The Director"),
+            listOf(
+                MovieInput.Actor("Actor 1", "Role 1"),
+                MovieInput.Actor("Actor 2", "Role 2"),
+            ),
+            DateRange(LocalDate.of(2020, 1, 1), LocalDate.of(2021, 1, 1))
+        )
+
+        val serialize = InputValueSerializer(mapOf(DateRange::class.java to DateRangeScalar())).serialize(movieInput)
+        assertThat(serialize).isEqualTo("{movieId:1, title:\"Some movie\", genre:ACTION, director:{name:\"The Director\" }, actor:[{name:\"Actor 1\", roleName:\"Role 1\" }, {name:\"Actor 2\", roleName:\"Role 2\" }], releaseWindow:\"01/01/2020-01/01/2021\" }")
+    }
+
+    @Test
+    fun `List of a complex object`() {
+
+        val movieInput = MovieInput(
+            1,
+            "Some movie",
+            MovieInput.Genre.ACTION,
+            MovieInput.Director("The Director"),
+            listOf(
+                MovieInput.Actor("Actor 1", "Role 1"),
+                MovieInput.Actor("Actor 2", "Role 2"),
+            ),
+            DateRange(LocalDate.of(2020, 1, 1), LocalDate.of(2021, 1, 1))
+        )
+
+        val serialize = InputValueSerializer(mapOf(DateRange::class.java to DateRangeScalar())).serialize(listOf(movieInput))
+        assertThat(serialize).isEqualTo("[{movieId:1, title:\"Some movie\", genre:ACTION, director:{name:\"The Director\" }, actor:[{name:\"Actor 1\", roleName:\"Role 1\" }, {name:\"Actor 2\", roleName:\"Role 2\" }], releaseWindow:\"01/01/2020-01/01/2021\" }]")
+    }
+
+    @Test
+    fun `Null values should be skipped`() {
+
+        val movieInput = MovieInput(1)
+
+        val serialize = InputValueSerializer(mapOf(DateRange::class.java to DateRangeScalar())).serialize(movieInput)
+        assertThat(serialize).isEqualTo("{movieId:1 }")
+    }
+
+    @Test
+    fun `String value`() {
+        val serialize = InputValueSerializer().serialize("some string")
+        assertThat(serialize).isEqualTo("\"some string\"")
+    }
+
+    @Test
+    fun `String with slashes`() {
+        val serialize = InputValueSerializer().serialize("some \\ \"string\"")
+        assertThat(serialize).isEqualTo("\"some \\\\ \\\"string\\\"\"")
+    }
+
+    @Test
+    fun `int value`() {
+        val serialize = InputValueSerializer().serialize(1)
+        assertThat(serialize).isEqualTo("1")
+    }
+
+    @Test
+    fun `long value`() {
+        val serialize = InputValueSerializer().serialize(1L)
+        assertThat(serialize).isEqualTo("1")
+    }
+
+    @Test
+    fun `boolean value`() {
+        val serialize = InputValueSerializer().serialize(true)
+        assertThat(serialize).isEqualTo("true")
+    }
+
+    @Test
+    fun `double value`() {
+        val serialize = InputValueSerializer().serialize(1.1)
+        assertThat(serialize).isEqualTo("1.1")
+    }
+
+    @Test
+    fun `Companion objects should be ignored`() {
+        val serialize = InputValueSerializer().serialize(MyDataWithCompanion("some title"))
+        assertThat(serialize).isEqualTo("{title:\"some title\" }")
+    }
+
+    @Test
+    fun `List of Integer`() {
+        val serialize = InputValueSerializer().serialize(listOf(1, 2, 3))
+        assertThat(serialize).isEqualTo("[1, 2, 3]")
+    }
+
+    @Test
+    fun `Base class properties should be found`() {
+        val serialize = InputValueSerializer().serialize(MySubClass("DGS", 1500))
+        assertThat(serialize).isEqualTo("{stars:1500, name:\"DGS\" }")
+    }
+
+    @Test
+    fun `Date without scalar`() {
+        val input = WithLocalDateTime(LocalDateTime.of(2021, 5, 13, 4, 34))
+        val serialize = InputValueSerializer().serialize(input)
+        assertThat(serialize).isEqualTo("""{date:"2021-05-13T04:34" }""")
+    }
+
+    data class MyDataWithCompanion(val title: String) {
+        public companion object {}
+    }
+
+    open class MyBaseClass(private val name: String)
+
+    class MySubClass(name: String, val stars: Int) : MyBaseClass(name)
+
+    class WithLocalDateTime(val date: LocalDateTime)
+}

--- a/graphql-dgs-codegen-client-core/src/test/kotlin/com/netflix/graphql/dgs/client/codegen/ProjectionSerializerTest.kt
+++ b/graphql-dgs-codegen-client-core/src/test/kotlin/com/netflix/graphql/dgs/client/codegen/ProjectionSerializerTest.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.client.codegen
+
+import com.netflix.graphql.dgs.client.codegen.exampleprojection.EntitiesProjectionRoot
+import com.netflix.graphql.dgs.client.codegen.exampleprojection.ShowsProjectionRoot
+import graphql.scalars.ExtendedScalars
+import graphql.schema.Coercing
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import java.util.*
+
+internal class ProjectionSerializerTest {
+
+    @Test
+    fun `Projection with argument that requires a scalar`() {
+        val scalars: Map<Class<*>, Coercing<*, *>> =
+            mapOf(OffsetDateTime::class.java to ExtendedScalars.DateTime.coercing)
+        val projectionSerializer = ProjectionSerializer(InputValueSerializer(scalars))
+
+        val projection = ShowsProjectionRoot()
+            .reviews(3, OffsetDateTime.of(2021, 6, 16, 15, 20, 0, 0, ZoneOffset.UTC)).starScore().root
+        val serialize = projectionSerializer.serialize(projection)
+        assertThat(serialize).isEqualTo("{ reviews(minScore: 3, since: \"2021-06-16T15:20:00Z\")   { starScore } }")
+    }
+
+    @Test
+    fun `Projection for entity with explicit schema type`() {
+        // given
+        val root = EntitiesProjectionRoot()
+        root.onMovie(Optional.of("Movie"))
+            .moveId().title().releaseYear()
+            .reviews(username = "Foo", score = 10).username().score()
+        // when
+        val serialize = ProjectionSerializer(InputValueSerializer()).serialize(root, isFragment = true)
+        // then
+        assertThat(serialize).isEqualTo("""... on Entities { ... on Movie { __typename moveId title releaseYear reviews(username: "Foo", score: 10)   { username score } } }""")
+    }
+
+    @Test
+    fun `Projection for entity with no explicit schema type`() {
+        // given
+        val root = EntitiesProjectionRoot()
+        root.onMovie(Optional.empty())
+            .moveId().title().releaseYear()
+            .reviews(username = "Foo", score = 10).username().score()
+        // when
+        val serialize = ProjectionSerializer(InputValueSerializer()).serialize(root, isFragment = true)
+        // then
+        assertThat(serialize).isEqualTo("""... on Entities { ... on EntitiesMovieKey { __typename moveId title releaseYear reviews(username: "Foo", score: 10)   { username score } } }""")
+    }
+}

--- a/graphql-dgs-codegen-client-core/src/test/kotlin/com/netflix/graphql/dgs/client/codegen/exampleprojection/EntitiesMovieKeyProjection.kt
+++ b/graphql-dgs-codegen-client-core/src/test/kotlin/com/netflix/graphql/dgs/client/codegen/exampleprojection/EntitiesMovieKeyProjection.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.client.codegen.exampleprojection
+
+import com.netflix.graphql.dgs.client.codegen.BaseSubProjectionNode
+import java.util.*
+
+class EntitiesMovieKeyProjection(
+    parent: EntitiesProjectionRoot,
+    root: EntitiesProjectionRoot,
+    schemaType: Optional<String>
+) : BaseSubProjectionNode<EntitiesProjectionRoot, EntitiesProjectionRoot>(
+    parent,
+    root,
+    schemaType = schemaType
+) {
+
+    fun moveId(): EntitiesMovieKeyProjection {
+        fields["moveId"] = null
+        return this
+    }
+
+    fun title(): EntitiesMovieKeyProjection {
+        fields["title"] = null
+        return this
+    }
+
+    fun releaseYear(): EntitiesMovieKeyProjection {
+        fields["releaseYear"] = null
+        return this
+    }
+
+    fun reviews(username: String, score: Int): Movies_ReviewsProjection {
+        val projection = Movies_ReviewsProjection(this, root)
+        fields["reviews"] = projection
+        inputArguments.computeIfAbsent("reviews") { mutableListOf() }
+        (inputArguments["reviews"] as MutableList).add(InputArgument("username", username))
+        (inputArguments["reviews"] as MutableList).add(InputArgument("score", score))
+        return projection
+    }
+
+    init {
+        fields["__typename"] = null
+    }
+}

--- a/graphql-dgs-codegen-client-core/src/test/kotlin/com/netflix/graphql/dgs/client/codegen/exampleprojection/EntitiesProjectionRoot.kt
+++ b/graphql-dgs-codegen-client-core/src/test/kotlin/com/netflix/graphql/dgs/client/codegen/exampleprojection/EntitiesProjectionRoot.kt
@@ -16,7 +16,15 @@
  *
  */
 
-rootProject.name = 'graphql-dgs-codegen'
-include 'graphql-dgs-codegen-gradle'
-include 'graphql-dgs-codegen-core'
-include 'graphql-dgs-codegen-client-core'
+package com.netflix.graphql.dgs.client.codegen.exampleprojection
+
+import com.netflix.graphql.dgs.client.codegen.BaseProjectionNode
+import java.util.*
+
+class EntitiesProjectionRoot : BaseProjectionNode() {
+    fun onMovie(schemaType: Optional<String>): EntitiesMovieKeyProjection {
+        val fragment = EntitiesMovieKeyProjection(this, this, schemaType)
+        fragments.add(fragment)
+        return fragment
+    }
+}

--- a/graphql-dgs-codegen-client-core/src/test/kotlin/com/netflix/graphql/dgs/client/codegen/exampleprojection/Movies_ReviewsProjection.kt
+++ b/graphql-dgs-codegen-client-core/src/test/kotlin/com/netflix/graphql/dgs/client/codegen/exampleprojection/Movies_ReviewsProjection.kt
@@ -16,7 +16,19 @@
  *
  */
 
-rootProject.name = 'graphql-dgs-codegen'
-include 'graphql-dgs-codegen-gradle'
-include 'graphql-dgs-codegen-core'
-include 'graphql-dgs-codegen-client-core'
+package com.netflix.graphql.dgs.client.codegen.exampleprojection
+
+import com.netflix.graphql.dgs.client.codegen.BaseSubProjectionNode
+
+class Movies_ReviewsProjection(parent: EntitiesMovieKeyProjection, root: EntitiesProjectionRoot) :
+    BaseSubProjectionNode<EntitiesMovieKeyProjection, EntitiesProjectionRoot>(parent, root) {
+    fun username(): Movies_ReviewsProjection {
+        fields["username"] = null
+        return this
+    }
+
+    fun score(): Movies_ReviewsProjection {
+        fields["score"] = null
+        return this
+    }
+}

--- a/graphql-dgs-codegen-core/build.gradle
+++ b/graphql-dgs-codegen-core/build.gradle
@@ -16,58 +16,32 @@
  *
  */
 
-
-buildscript {
-    repositories {
-        mavenCentral()
-    }
-
-    dependencies {
-        classpath 'nl.javadude.gradle.plugins:license-gradle-plugin:0.10.0'
-    }
-}
-
 plugins {
     id 'java-library'
     id 'application'
 }
 
-apply plugin: 'nebula.netflixoss'
-apply plugin: 'org.jetbrains.kotlin.jvm'
-apply plugin: 'license'
-
-sourceCompatibility = 1.8
 
 dependencies {
-    implementation(platform("com.netflix.graphql.dgs:graphql-dgs-platform-dependencies:latest.release"))
-    implementation("com.netflix.graphql.dgs:graphql-dgs") { transitive = false }
-    implementation "com.netflix.graphql.dgs:graphql-dgs-client"
-    implementation "com.graphql-java:graphql-java"
-    implementation "com.fasterxml.jackson.core:jackson-annotations"
+    implementation platform("com.netflix.graphql.dgs:graphql-dgs-platform-dependencies:latest.release")
 
-    implementation "com.squareup:javapoet:1.13.+"
-    implementation "com.squareup:kotlinpoet:1.8.+"
-    implementation "com.github.ajalt.clikt:clikt:3.2.+"
-    implementation "commons-lang:commons-lang:2.6"
+    implementation('com.netflix.graphql.dgs:graphql-dgs') { transitive = false }
+    implementation 'com.netflix.graphql.dgs:graphql-dgs-client'
+    implementation 'com.graphql-java:graphql-java'
+    implementation 'com.fasterxml.jackson.core:jackson-annotations'
 
-    testImplementation "com.google.jimfs:jimfs:1.2"
-    testImplementation "com.google.testing.compile:compile-testing:0.+"
-    testImplementation "com.google.truth:truth:1.+"
-    testImplementation "org.assertj:assertj-core:3.19.+"
-    testImplementation "org.jetbrains.kotlin:kotlin-compiler-embeddable:1.4.31"
+    implementation 'com.squareup:javapoet:1.13.+'
+    implementation 'com.squareup:kotlinpoet:1.8.+'
+    implementation 'com.github.ajalt.clikt:clikt:3.2.+'
+    implementation 'commons-lang:commons-lang:2.6'
 
-    testImplementation(platform("org.junit:junit-bom:5.7.+"))
-    testImplementation("org.junit.jupiter:junit-jupiter")
-    testImplementation("org.junit.jupiter:junit-jupiter-params")
-}
-
-
-license {
-    exclude('**/*.bin')
-}
-
-test {
-    useJUnitPlatform()
+    testImplementation 'com.google.jimfs:jimfs:1.2'
+    testImplementation 'com.google.testing.compile:compile-testing:0.+'
+    testImplementation 'com.google.truth:truth:1.+'
+    testImplementation 'org.jetbrains.kotlin:kotlin-compiler-embeddable:1.4.31'
+    // The plugin will add the "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-client-core" to the Project test classpath.
+    // We are adding it explicitly so we can write tests against it.
+    testImplementation project(":graphql-dgs-codegen-client-core")
 }
 
 application {

--- a/graphql-dgs-codegen-core/dependencies.lock
+++ b/graphql-dgs-codegen-core/dependencies.lock
@@ -139,6 +139,9 @@
         "com.graphql-java:graphql-java": {
             "locked": "16.2"
         },
+        "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-client-core": {
+            "project": true
+        },
         "com.netflix.graphql.dgs:graphql-dgs": {
             "locked": "4.3.1"
         },
@@ -164,6 +167,9 @@
             "locked": "1.4.31"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-client-core"
+            ],
             "locked": "1.5.0"
         },
         "org.junit.jupiter:junit-jupiter": {
@@ -195,6 +201,9 @@
         "com.graphql-java:graphql-java": {
             "locked": "16.2"
         },
+        "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-client-core": {
+            "project": true
+        },
         "com.netflix.graphql.dgs:graphql-dgs": {
             "locked": "4.3.1"
         },
@@ -220,6 +229,9 @@
             "locked": "1.4.31"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-client-core"
+            ],
             "locked": "1.4.32"
         },
         "org.junit.jupiter:junit-jupiter": {
@@ -251,6 +263,9 @@
         "com.graphql-java:graphql-java": {
             "locked": "16.2"
         },
+        "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-client-core": {
+            "project": true
+        },
         "com.netflix.graphql.dgs:graphql-dgs": {
             "locked": "4.3.1"
         },
@@ -258,6 +273,9 @@
             "locked": "4.3.1"
         },
         "com.netflix.graphql.dgs:graphql-dgs-platform-dependencies": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-client-core"
+            ],
             "locked": "4.3.1"
         },
         "com.squareup:javapoet": {
@@ -276,6 +294,9 @@
             "locked": "1.4.31"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-client-core"
+            ],
             "locked": "1.5.0"
         },
         "org.junit.jupiter:junit-jupiter": {

--- a/graphql-dgs-codegen-gradle/build.gradle
+++ b/graphql-dgs-codegen-gradle/build.gradle
@@ -16,24 +16,11 @@
  *
  */
 
-buildscript {
-    repositories {
-        mavenCentral()
-    }
-
-    dependencies {
-        classpath 'nl.javadude.gradle.plugins:license-gradle-plugin:0.10.0'
-    }
-}
-
 plugins {
     id 'com.gradle.plugin-publish' version '0.15.0'
 }
 
-apply plugin: 'org.jetbrains.kotlin.jvm'
 apply plugin: 'java-gradle-plugin'
-apply plugin: 'nebula.netflixoss'
-apply plugin: 'license'
 
 dependencies {
     api project(":graphql-dgs-codegen-core")
@@ -41,9 +28,6 @@ dependencies {
 
     testApi gradleTestKit()
     testImplementation("com.google.guava:guava:30.1.1-jre")
-    testImplementation("org.assertj:assertj-core:3.19.+")
-    testImplementation(platform("org.junit:junit-bom:5.7.+"))
-    testImplementation("org.junit.jupiter:junit-jupiter")
 }
 
 description = 'Netflix GraphQL DGS Code Generation Plugin'
@@ -74,14 +58,6 @@ gradlePlugin {
     }
 }
 
-license {
-    exclude('**/*.bin')
-    exclude('**/test-project/*')
-}
-
-test {
-    useJUnitPlatform()
-}
 
 task createClasspathManifest {
     File outputDir = file("$buildDir/$name")

--- a/graphql-dgs-codegen-gradle/dependencies.lock
+++ b/graphql-dgs-codegen-gradle/dependencies.lock
@@ -144,6 +144,9 @@
         "org.junit.jupiter:junit-jupiter": {
             "locked": "5.7.2"
         },
+        "org.junit.jupiter:junit-jupiter-params": {
+            "locked": "5.7.2"
+        },
         "org.junit:junit-bom": {
             "locked": "5.7.2"
         }
@@ -165,6 +168,9 @@
             "locked": "1.4.31"
         },
         "org.junit.jupiter:junit-jupiter": {
+            "locked": "5.7.2"
+        },
+        "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.7.2"
         },
         "org.junit:junit-bom": {
@@ -242,6 +248,9 @@
             "locked": "1.5.0"
         },
         "org.junit.jupiter:junit-jupiter": {
+            "locked": "5.7.2"
+        },
+        "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.7.2"
         },
         "org.junit:junit-bom": {

--- a/graphql-dgs-codegen-gradle/src/main/java/com/netflix/graphql/dgs/codegen/gradle/CodegenPluginExtension.java
+++ b/graphql-dgs-codegen-gradle/src/main/java/com/netflix/graphql/dgs/codegen/gradle/CodegenPluginExtension.java
@@ -16,7 +16,18 @@
  *
  */
 
-rootProject.name = 'graphql-dgs-codegen'
-include 'graphql-dgs-codegen-gradle'
-include 'graphql-dgs-codegen-core'
-include 'graphql-dgs-codegen-client-core'
+package com.netflix.graphql.dgs.codegen.gradle;
+
+import org.gradle.api.provider.Property;
+
+public abstract class CodegenPluginExtension {
+
+    @SuppressWarnings("UnstableApiUsage")
+    public CodegenPluginExtension() {
+        getClientCoreConventionsEnabled().convention(true);
+    }
+
+    public abstract Property<Boolean> getClientCoreConventionsEnabled();
+
+    public abstract Property<String> getClientCoreVersion();
+}

--- a/graphql-dgs-codegen-gradle/src/main/kotlin/com/netflix/graphql/dgs/codegen/gradle/ClientUtilsConventions.kt
+++ b/graphql-dgs-codegen-gradle/src/main/kotlin/com/netflix/graphql/dgs/codegen/gradle/ClientUtilsConventions.kt
@@ -1,0 +1,57 @@
+/*
+ *
+ *  Copyright 2020 Netflix, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package com.netflix.graphql.dgs.codegen.gradle
+
+import org.gradle.api.Project
+import org.gradle.api.logging.Logging
+import java.util.*
+
+object ClientUtilsConventions {
+
+    private const val CLIENT_UTILS_ARTIFACT_GROUP = "com.netflix.graphql.dgs.codegen"
+    private const val CLIENT_UTILS_ARTIFACT_NAME = "graphql-dgs-codegen-client-core"
+    private const val GRADLE_CLASSPATH_CONFIGURATION = "implementation"
+
+    private val logger = Logging.getLogger(ClientUtilsConventions::class.java)
+
+    fun apply(project: Project, optionalCodeUtilsVersion: Optional<String> = Optional.empty()) {
+        clientCoreArtifact(optionalCodeUtilsVersion).ifPresent { dependencyString ->
+            val implementationClasspath = project.configurations.getByName(GRADLE_CLASSPATH_CONFIGURATION).dependencies
+            implementationClasspath.add(project.dependencies.create(dependencyString))
+            logger.lifecycle("DGS CodeGen added [$dependencyString] to the $GRADLE_CLASSPATH_CONFIGURATION classpath.")
+        }
+    }
+
+    private val pluginProperties: Optional<Properties> = try {
+        val props = Properties()
+        props.load(this.javaClass.classLoader.getResourceAsStream("META-INF/graphql-dgs-codegen-core.properties"))
+        Optional.of(props)
+    } catch (e: Exception) {
+        logger.error("Unable to resolve the graphql-dgs-codegen-gradle.properties properties.")
+        Optional.empty()
+    }
+
+    internal val pluginMetaInfVersion: Optional<String> =
+        pluginProperties.flatMap { Optional.ofNullable(it.getProperty("Implementation-Version")) }
+
+    private fun clientCoreArtifact(optionalVersion: Optional<String>): Optional<String> {
+        val version = if (optionalVersion.isPresent) optionalVersion else pluginMetaInfVersion
+        return version.map { "$CLIENT_UTILS_ARTIFACT_GROUP:$CLIENT_UTILS_ARTIFACT_NAME:$it" }
+    }
+}

--- a/graphql-dgs-codegen-gradle/src/main/kotlin/com/netflix/graphql/dgs/codegen/gradle/CodegenPlugin.kt
+++ b/graphql-dgs-codegen-gradle/src/main/kotlin/com/netflix/graphql/dgs/codegen/gradle/CodegenPlugin.kt
@@ -20,27 +20,45 @@ package com.netflix.graphql.dgs.codegen.gradle
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.logging.Logging
 import org.gradle.api.plugins.JavaPlugin
 import org.gradle.api.plugins.JavaPluginConvention
 import org.gradle.api.tasks.SourceSet
+import java.util.*
 
 class CodegenPlugin : Plugin<Project> {
-    override fun apply(project: Project) {
-        project.plugins.apply(JavaPlugin::class.java)
-        val taskProvider = project.tasks.register("generateJava", GenerateJavaTask::class.java)
-        project.getTasksByName("compileJava", false).forEach {
-            it.dependsOn(taskProvider.get())
-        }
 
+    companion object {
+        const val GRADLE_GROUP = "DGS GraphQL Codegen"
+        private val logger = Logging.getLogger(CodegenPlugin::class.java)
+    }
+
+    override fun apply(project: Project) {
+        val extensions = project.extensions.create("codegen", CodegenPluginExtension::class.java)
+
+        project.plugins.apply(JavaPlugin::class.java)
+
+        val generateJavaTaskProvider = project.tasks.register("generateJava", GenerateJavaTask::class.java)
+        generateJavaTaskProvider.configure { it.group = GRADLE_GROUP }
+
+        project.getTasksByName("compileJava", false).forEach {
+            it.dependsOn(generateJavaTaskProvider.get())
+        }
         project.getTasksByName("compileKotlin", false).forEach {
-            it.dependsOn(taskProvider.get())
+            it.dependsOn(generateJavaTaskProvider.get())
         }
 
         val javaConvention = project.convention.getPlugin(JavaPluginConvention::class.java)
         val sourceSets = javaConvention.sourceSets
         val mainSourceSet = sourceSets.getByName(SourceSet.MAIN_SOURCE_SET_NAME)
-        val outputDir = taskProvider.get().getOutputDir()
-
+        val outputDir = generateJavaTaskProvider.get().getOutputDir()
         mainSourceSet.java.srcDirs(outputDir)
+
+        project.afterEvaluate { p ->
+            if (extensions.clientCoreConventionsEnabled.getOrElse(true)) {
+                logger.info("Applying CodegenPlugin Client Utils conventions.")
+                ClientUtilsConventions.apply(p, Optional.ofNullable(extensions.clientCoreVersion.orNull))
+            }
+        }
     }
 }

--- a/graphql-dgs-codegen-gradle/src/main/kotlin/com/netflix/graphql/dgs/codegen/gradle/GenerateJavaTask.kt
+++ b/graphql-dgs-codegen-gradle/src/main/kotlin/com/netflix/graphql/dgs/codegen/gradle/GenerateJavaTask.kt
@@ -27,14 +27,10 @@ import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
 import org.jetbrains.kotlin.gradle.plugin.KotlinPluginWrapper
-import org.slf4j.LoggerFactory
 import java.io.File
 import java.nio.file.Paths
 
 open class GenerateJavaTask : DefaultTask() {
-
-    private val LOGGER = LoggerFactory.getLogger("DgsCodegenPlugin")
-
     @Input
     var generatedSourcesDir: String = project.buildDir.absolutePath
 
@@ -116,7 +112,7 @@ open class GenerateJavaTask : DefaultTask() {
     fun generate() {
         val schemaPaths = schemaPaths.map { Paths.get(it.toString()).toFile() }.toSet()
         schemaPaths.filter { !it.exists() }.forEach {
-            LOGGER.warn("Schema location ${it.absolutePath} does not exist")
+            logger.warn("Schema location ${it.absolutePath} does not exist")
         }
 
         val config = CodeGenConfig(
@@ -145,7 +141,7 @@ open class GenerateJavaTask : DefaultTask() {
             snakeCaseConstantNames = snakeCaseConstantNames
         )
 
-        LOGGER.info("Codegen config: {}", config)
+        logger.info("Codegen config: {}", config)
 
         val codegen = CodeGen(config)
         codegen.generate()

--- a/graphql-dgs-codegen-gradle/src/test/kotlin/com/netflix/graphql/dgs/CodegenGradlePluginClientUtilsConventionsTest.kt
+++ b/graphql-dgs-codegen-gradle/src/test/kotlin/com/netflix/graphql/dgs/CodegenGradlePluginClientUtilsConventionsTest.kt
@@ -1,0 +1,180 @@
+/*
+ *
+ *  Copyright 2020 Netflix, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package com.netflix.graphql.dgs
+
+import com.netflix.graphql.dgs.codegen.gradle.ClientUtilsConventions
+import org.assertj.core.api.Assertions.assertThat
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+class CodegenGradlePluginClientUtilsConventionsTest {
+
+    @TempDir
+    lateinit var projectDir: File
+
+    private val inferredVersion = ClientUtilsConventions.pluginMetaInfVersion
+
+    @Test
+    fun `If disabled, will not add the graphql-dgs-codegen-client-core`() {
+        prepareBuildGradleFile(
+            """
+plugins {
+    id 'java'
+    id 'com.netflix.dgs.codegen'
+}
+
+repositories { mavenCentral() }
+
+dependencies { }
+
+codegen.clientCoreConventionsEnabled = false
+""".trimMargin()
+        )
+
+        val runner = GradleRunner.create()
+            .withProjectDir(projectDir)
+            .withPluginClasspath()
+            .withPluginClasspath(emptyList())
+            .withDebug(true)
+            .withArguments("--info", "--stacktrace", "dependencies", "--configuration=compileClasspath")
+
+        val result = runner.build()
+
+        assertThat(result.output)
+            .doesNotContain("DGS CodeGen added [com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-client-core")
+        assertThat(result.output)
+            .doesNotContain("com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-client-core")
+    }
+
+    @Test
+    fun `Adds the graphql-dgs-codegen-client-core to the classpath`() {
+        // given a build file with the plugin.
+        prepareBuildGradleFile(
+            """
+plugins {
+    id 'java'
+    id 'com.netflix.dgs.codegen'
+}
+
+repositories { mavenCentral() }
+
+dependencies { }
+
+""".trimMargin()
+        )
+        // when the build is executed
+        val runner = GradleRunner.create()
+            .withProjectDir(projectDir)
+            .withPluginClasspath()
+            .withPluginClasspath(emptyList())
+            .withDebug(true)
+            .withArguments("--info", "--stacktrace", "dependencies", "--configuration=compileClasspath")
+
+        val result = runner.build()
+        // then we assert that the dependency was resolved to the proper version
+        assertThat(result.output)
+            .contains("DGS CodeGen added [com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-client-core:${inferredVersion.get()}")
+        assertThat(result.output)
+            .contains("- com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-client-core:${inferredVersion.get()}")
+    }
+
+    @Test
+    fun `Can define the specific version for the graphql-dgs-codegen-client-core`() {
+        // given a higher version
+        val higherVersion = "123456"
+        // and a build file that configures the client core version to use such version
+        prepareBuildGradleFile(
+            """
+plugins {
+    id 'java'
+    id 'com.netflix.dgs.codegen'
+}
+
+repositories { mavenCentral() }
+
+dependencies { }
+
+codegen {
+    clientCoreVersion = "$higherVersion"
+}
+""".trimMargin()
+        )
+        // when the build is executed
+        val runner = GradleRunner.create()
+            .withProjectDir(projectDir)
+            .withPluginClasspath()
+            .withPluginClasspath(emptyList())
+            .withDebug(true)
+            .withArguments("--info", "--stacktrace", "dependencies", "--configuration=compileClasspath")
+
+        val result = runner.build()
+        // then we assert that the dependency was resolved to the higher version.
+        assertThat(result.output)
+            .contains("DGS CodeGen added [com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-client-core:$higherVersion")
+        assertThat(result.output)
+            .contains("- com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-client-core:$higherVersion FAILED")
+    }
+
+    @Test
+    fun `Can be overridden by an explicit dependency to graphql-dgs-codegen-client-core`() {
+        // given a higher version
+        val higherVersion = "123456"
+        // and a build file that depends on it.
+        prepareBuildGradleFile(
+            """
+plugins {
+    id 'java'
+    id 'com.netflix.dgs.codegen'
+}
+
+repositories { mavenCentral() }
+
+dependencies { 
+    implementation 'com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-client-core:$higherVersion'
+}
+""".trimMargin()
+        )
+        // when the build is executed
+        val runner = GradleRunner.create()
+            .withProjectDir(projectDir)
+            .withPluginClasspath()
+            .withPluginClasspath(emptyList())
+            .withDebug(true)
+            .withArguments("--info", "--stacktrace", "dependencies", "--configuration=compileClasspath")
+
+        val result = runner.build()
+        // then we assert that the dependency was resolved to the higher version.
+        assertThat(result.output)
+            .contains("DGS CodeGen added [com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-client-core")
+        assertThat(result.output)
+            .contains("- com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-client-core:${inferredVersion.get()} -> $higherVersion FAILED")
+    }
+
+    private fun prepareBuildGradleFile(content: String) {
+        writeProjectFile("build.gradle", content)
+    }
+
+    private fun writeProjectFile(relativePath: String, content: String) {
+        val file = File(projectDir, relativePath)
+        file.parentFile.mkdirs()
+        file.writeText(content)
+    }
+}

--- a/graphql-dgs-codegen-gradle/src/test/kotlin/com/netflix/graphql/dgs/CodegenGradlePluginSpringBootSmokeTest.kt
+++ b/graphql-dgs-codegen-gradle/src/test/kotlin/com/netflix/graphql/dgs/CodegenGradlePluginSpringBootSmokeTest.kt
@@ -116,6 +116,8 @@ plugins {
 test {
     useJUnitPlatform()
 }
+// Need to disable the core conventions since the artifacts are not yet visible.
+codegen.clientCoreConventionsEnabled = false
 """.trimMargin()
         )
 
@@ -207,6 +209,8 @@ plugins {
 test {
     useJUnitPlatform()
 }
+// Need to disable the core conventions since the artifacts are not yet visible.
+codegen.clientCoreConventionsEnabled = false
 """.trimMargin()
         )
 

--- a/graphql-dgs-codegen-gradle/src/test/resources/test-project/build.gradle
+++ b/graphql-dgs-codegen-gradle/src/test/resources/test-project/build.gradle
@@ -32,3 +32,5 @@ generateJava {
     generatedSourcesDir = "${projectDir}/build/graphql"
     typeMapping = [Date:"java.time.LocalDateTime"]
 }
+
+codegen.clientCoreConventionsEnabled = false

--- a/graphql-dgs-codegen-gradle/src/test/resources/test-project/build_omit_null_input_fields.gradle
+++ b/graphql-dgs-codegen-gradle/src/test/resources/test-project/build_omit_null_input_fields.gradle
@@ -34,3 +34,5 @@ generateJava {
     generateClient = true
     generateDataTypes = true
 }
+
+codegen.clientCoreConventionsEnabled = false

--- a/graphql-dgs-codegen-gradle/src/test/resources/test-project/build_with_default_dir.gradle
+++ b/graphql-dgs-codegen-gradle/src/test/resources/test-project/build_with_default_dir.gradle
@@ -32,3 +32,5 @@ generateJava {
     typeMapping = [Date:"java.time.LocalDateTime"]
     // no generated sources dir specified
 }
+
+codegen.clientCoreConventionsEnabled = false


### PR DESCRIPTION
What
====

This commit adds a new module, the `graphql-dgs-codegen-client-core`, that offers classes, and other artifacts, that complement the code generated by _DGS Codegen_.
The plugin, by default, will add the artifact automatically to the _implementation_ scope.

As a Developer
=============

As a Developer you will be able to leverage the `graphql-dgs-codegen-client-core`.
Optionally you have the option to disable  the inclusion of such dependency by setting the `codegen.clientCoreConventionsEnabled` flag to `false` as follows.

```
codegen.clientCoreConventionsEnabled = true
```

or

```
codegen {
    clientCoreConventionsEnabled = true
}
```