### PR TITLE
Types that are type mapped should never be generated.

### DIFF
--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
@@ -409,8 +409,16 @@ fun List<FieldDefinition>.filterIncludedInConfig(definitionName: String, config:
     }
 }
 
-fun ObjectTypeDefinition.shouldSkip(): Boolean {
-    return this.directives.any { it.name == "skipcodegen" }
+fun ObjectTypeDefinition.shouldSkip(config: CodeGenConfig): Boolean {
+    return this.directives.any { it.name == "skipcodegen" } || config.typeMapping.containsKey(this.name)
+}
+
+fun InterfaceTypeDefinition.shouldSkip(config: CodeGenConfig): Boolean {
+    return this.directives.any { it.name == "skipcodegen" } || config.typeMapping.containsKey(this.name)
+}
+
+fun UnionTypeDefinition.shouldSkip(config: CodeGenConfig): Boolean {
+    return this.directives.any { it.name == "skipcodegen" } || config.typeMapping.containsKey(this.name)
 }
 
 fun TypeDefinition<*>.fieldDefinitions(): List<FieldDefinition> {

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/DataTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/DataTypeGenerator.kt
@@ -29,7 +29,7 @@ import javax.lang.model.element.Modifier
 
 class DataTypeGenerator(private val config: CodeGenConfig, private val document: Document) : BaseDataTypeGenerator(config.packageNameTypes, config, document) {
     fun generate(definition: ObjectTypeDefinition, extensions: List<ObjectTypeExtensionDefinition>): CodeGenResult {
-        if (definition.shouldSkip()) {
+        if (definition.shouldSkip(config)) {
             return CodeGenResult()
         }
 

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/InterfaceGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/InterfaceGenerator.kt
@@ -20,6 +20,8 @@ package com.netflix.graphql.dgs.codegen.generators.java
 
 import com.netflix.graphql.dgs.codegen.CodeGenConfig
 import com.netflix.graphql.dgs.codegen.CodeGenResult
+import com.netflix.graphql.dgs.codegen.filterSkipped
+import com.netflix.graphql.dgs.codegen.shouldSkip
 import com.squareup.javapoet.ClassName
 import com.squareup.javapoet.JavaFile
 import com.squareup.javapoet.MethodSpec
@@ -27,13 +29,18 @@ import com.squareup.javapoet.TypeSpec
 import graphql.language.*
 import javax.lang.model.element.Modifier
 
-class InterfaceGenerator(config: CodeGenConfig, private val document: Document) {
+class InterfaceGenerator(private val config: CodeGenConfig, private val document: Document) {
 
     private val packageName = config.packageNameTypes
     private val typeUtils = TypeUtils(packageName, config, document)
     private val useInterfaceType = config.generateInterfaces
 
     fun generate(definition: InterfaceTypeDefinition, extensions: List<InterfaceTypeExtensionDefinition>): CodeGenResult {
+
+        if (definition.shouldSkip(config)) {
+            return CodeGenResult()
+        }
+
         val javaType = TypeSpec.interfaceBuilder(definition.name)
             .addModifiers(Modifier.PUBLIC)
 
@@ -43,7 +50,7 @@ class InterfaceGenerator(config: CodeGenConfig, private val document: Document) 
 
         val mergedFieldDefinitions = definition.fieldDefinitions + extensions.flatMap { it.fieldDefinitions }
 
-        mergedFieldDefinitions.forEach {
+        mergedFieldDefinitions.filterSkipped().forEach {
             // Only generate getters/setters for fields that are not interfaces.
             //
             // interface Pet {

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/UnionTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/UnionTypeGenerator.kt
@@ -20,6 +20,7 @@ package com.netflix.graphql.dgs.codegen.generators.java
 
 import com.netflix.graphql.dgs.codegen.CodeGenConfig
 import com.netflix.graphql.dgs.codegen.CodeGenResult
+import com.netflix.graphql.dgs.codegen.shouldSkip
 import com.squareup.javapoet.ClassName
 import com.squareup.javapoet.JavaFile
 import com.squareup.javapoet.TypeSpec
@@ -30,6 +31,10 @@ import javax.lang.model.element.Modifier
 
 class UnionTypeGenerator(private val config: CodeGenConfig) {
     fun generate(definition: UnionTypeDefinition, extensions: List<UnionTypeExtensionDefinition>): CodeGenResult {
+        if (definition.shouldSkip(config)) {
+            return CodeGenResult()
+        }
+
         val javaType = TypeSpec.interfaceBuilder(definition.name)
             .addModifiers(Modifier.PUBLIC)
 

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinDataTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinDataTypeGenerator.kt
@@ -28,7 +28,7 @@ import graphql.language.*
 
 class KotlinDataTypeGenerator(private val config: CodeGenConfig, private val document: Document) : AbstractKotlinDataTypeGenerator(config.packageNameTypes, config) {
     fun generate(definition: ObjectTypeDefinition, extensions: List<ObjectTypeExtensionDefinition>): CodeGenResult {
-        if (definition.shouldSkip()) {
+        if (definition.shouldSkip(config)) {
             return CodeGenResult()
         }
 

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinInterfaceTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinInterfaceTypeGenerator.kt
@@ -20,13 +20,14 @@ package com.netflix.graphql.dgs.codegen.generators.kotlin
 
 import com.netflix.graphql.dgs.codegen.CodeGenConfig
 import com.netflix.graphql.dgs.codegen.CodeGenResult
+import com.netflix.graphql.dgs.codegen.shouldSkip
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.TypeSpec
 import graphql.language.*
 
-class KotlinInterfaceTypeGenerator(config: CodeGenConfig) {
+class KotlinInterfaceTypeGenerator(private val config: CodeGenConfig) {
 
     private val packageName = config.packageNameTypes
     private val typeUtils = KotlinTypeUtils(packageName, config)
@@ -36,6 +37,10 @@ class KotlinInterfaceTypeGenerator(config: CodeGenConfig) {
         document: Document,
         extensions: List<InterfaceTypeExtensionDefinition>
     ): CodeGenResult {
+        if (definition.shouldSkip(config)) {
+            return CodeGenResult()
+        }
+
         val interfaceBuilder = TypeSpec.interfaceBuilder(definition.name)
         if (definition.description != null) {
             interfaceBuilder.addKdoc(definition.description.content.lines().joinToString("\n"))

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinUnionTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinUnionTypeGenerator.kt
@@ -20,6 +20,7 @@ package com.netflix.graphql.dgs.codegen.generators.kotlin
 
 import com.netflix.graphql.dgs.codegen.CodeGenConfig
 import com.netflix.graphql.dgs.codegen.CodeGenResult
+import com.netflix.graphql.dgs.codegen.shouldSkip
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.TypeSpec
@@ -27,11 +28,15 @@ import graphql.language.TypeName
 import graphql.language.UnionTypeDefinition
 import graphql.language.UnionTypeExtensionDefinition
 
-class KotlinUnionTypeGenerator(config: CodeGenConfig) {
+class KotlinUnionTypeGenerator(private val config: CodeGenConfig) {
 
     private val packageName = config.packageNameTypes
 
     fun generate(definition: UnionTypeDefinition, extensions: List<UnionTypeExtensionDefinition>): CodeGenResult {
+        if (definition.shouldSkip(config)) {
+            return CodeGenResult()
+        }
+
         val interfaceBuilder = TypeSpec.interfaceBuilder(definition.name)
 
         val memberTypes = definition.memberTypes.plus(extensions.flatMap { it.memberTypes }).asSequence()


### PR DESCRIPTION
Also includes a fix for skipping interface fields marked as `@skipcodegen`