### PR TITLE
Input types should not be generated when typeMapped

### DIFF
--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
@@ -413,6 +413,10 @@ fun ObjectTypeDefinition.shouldSkip(config: CodeGenConfig): Boolean {
     return this.directives.any { it.name == "skipcodegen" } || config.typeMapping.containsKey(this.name)
 }
 
+fun InputObjectTypeDefinition.shouldSkip(config: CodeGenConfig): Boolean {
+    return this.directives.any { it.name == "skipcodegen" } || config.typeMapping.containsKey(this.name)
+}
+
 fun InterfaceTypeDefinition.shouldSkip(config: CodeGenConfig): Boolean {
     return this.directives.any { it.name == "skipcodegen" } || config.typeMapping.containsKey(this.name)
 }

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/DataTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/DataTypeGenerator.kt
@@ -72,8 +72,12 @@ class DataTypeGenerator(private val config: CodeGenConfig, private val document:
     }
 }
 
-class InputTypeGenerator(config: CodeGenConfig, document: Document) : BaseDataTypeGenerator(config.packageNameTypes, config, document) {
+class InputTypeGenerator(private val config: CodeGenConfig, document: Document) : BaseDataTypeGenerator(config.packageNameTypes, config, document) {
     fun generate(definition: InputObjectTypeDefinition, extensions: List<InputObjectTypeExtensionDefinition>): CodeGenResult {
+        if (definition.shouldSkip(config)) {
+            return CodeGenResult()
+        }
+
         val name = definition.name
 
         val fieldDefinitions = definition.inputValueDefinitions.map { it ->

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinDataTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinDataTypeGenerator.kt
@@ -52,6 +52,9 @@ class KotlinDataTypeGenerator(private val config: CodeGenConfig, private val doc
 
 class KotlinInputTypeGenerator(private val config: CodeGenConfig, private val document: Document) : AbstractKotlinDataTypeGenerator(config.packageNameTypes, config) {
     fun generate(definition: InputObjectTypeDefinition, extensions: List<InputObjectTypeExtensionDefinition>): CodeGenResult {
+        if (definition.shouldSkip(config)) {
+            return CodeGenResult()
+        }
 
         val fields = definition.inputValueDefinitions
             .filter(ReservedKeywordFilter.filterInvalidNames)

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
@@ -1013,6 +1013,32 @@ class CodeGenTest {
     }
 
     @Test
+    fun `Use mapped type name for input type`() {
+
+        val schema = """
+            type Query {                
+                search(input: SearchInput): String
+            }
+            
+           input SearchInput {
+            title: String
+           }
+        """.trimIndent()
+
+        val (dataTypes) = CodeGen(
+            CodeGenConfig(
+                schemas = setOf(schema),
+                packageName = basePackageName,
+                typeMapping = mapOf(
+                    Pair("SearchInput", "mypackage.SearchInput"),
+                ),
+            )
+        ).generate()
+
+        assertThat(dataTypes).hasSize(0)
+    }
+
+    @Test
     fun generateInputTypes() {
 
         val schema = """


### PR DESCRIPTION
The same as #180 but for input types. 
Probably related to https://github.com/Netflix/dgs-framework/issues/310, although I don't fully understand the reported issue.