### PR TITLE
Java Projection Classes express an explicit Schema Type

### DIFF
--- a/graphql-dgs-codegen-core/dependencies.lock
+++ b/graphql-dgs-codegen-core/dependencies.lock
@@ -9,31 +9,31 @@
             "locked": "2.12.3"
         },
         "com.github.ajalt.clikt:clikt": {
-            "locked": "3.1.0"
+            "locked": "3.2.0"
         },
         "com.graphql-java:graphql-java": {
             "locked": "16.2"
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
-            "locked": "4.0.1"
+            "locked": "4.3.1"
         },
         "com.netflix.graphql.dgs:graphql-dgs-client": {
-            "locked": "4.0.1"
+            "locked": "4.3.1"
         },
         "com.netflix.graphql.dgs:graphql-dgs-platform-dependencies": {
-            "locked": "4.0.1"
+            "locked": "4.3.1"
         },
         "com.squareup:javapoet": {
             "locked": "1.13.0"
         },
         "com.squareup:kotlinpoet": {
-            "locked": "1.7.2"
+            "locked": "1.8.0"
         },
         "commons-lang:commons-lang": {
             "locked": "2.6"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
-            "locked": "1.4.32"
+            "locked": "1.5.0"
         }
     },
     "implementationDependenciesMetadata": {
@@ -41,25 +41,25 @@
             "locked": "2.12.3"
         },
         "com.github.ajalt.clikt:clikt": {
-            "locked": "3.1.0"
+            "locked": "3.2.0"
         },
         "com.graphql-java:graphql-java": {
             "locked": "16.2"
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
-            "locked": "4.0.1"
+            "locked": "4.3.1"
         },
         "com.netflix.graphql.dgs:graphql-dgs-client": {
-            "locked": "4.0.1"
+            "locked": "4.3.1"
         },
         "com.netflix.graphql.dgs:graphql-dgs-platform-dependencies": {
-            "locked": "4.0.1"
+            "locked": "4.3.1"
         },
         "com.squareup:javapoet": {
             "locked": "1.13.0"
         },
         "com.squareup:kotlinpoet": {
-            "locked": "1.7.2"
+            "locked": "1.8.0"
         },
         "commons-lang:commons-lang": {
             "locked": "2.6"
@@ -93,31 +93,31 @@
             "locked": "2.12.3"
         },
         "com.github.ajalt.clikt:clikt": {
-            "locked": "3.1.0"
+            "locked": "3.2.0"
         },
         "com.graphql-java:graphql-java": {
             "locked": "16.2"
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
-            "locked": "4.0.1"
+            "locked": "4.3.1"
         },
         "com.netflix.graphql.dgs:graphql-dgs-client": {
-            "locked": "4.0.1"
+            "locked": "4.3.1"
         },
         "com.netflix.graphql.dgs:graphql-dgs-platform-dependencies": {
-            "locked": "4.0.1"
+            "locked": "4.3.1"
         },
         "com.squareup:javapoet": {
             "locked": "1.13.0"
         },
         "com.squareup:kotlinpoet": {
-            "locked": "1.7.2"
+            "locked": "1.8.0"
         },
         "commons-lang:commons-lang": {
             "locked": "2.6"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
-            "locked": "1.4.32"
+            "locked": "1.5.0"
         }
     },
     "testCompileClasspath": {
@@ -125,7 +125,7 @@
             "locked": "2.12.3"
         },
         "com.github.ajalt.clikt:clikt": {
-            "locked": "3.1.0"
+            "locked": "3.2.0"
         },
         "com.google.jimfs:jimfs": {
             "locked": "1.2"
@@ -134,37 +134,37 @@
             "locked": "0.19"
         },
         "com.google.truth:truth": {
-            "locked": "1.1.2"
+            "locked": "1.1.3"
         },
         "com.graphql-java:graphql-java": {
             "locked": "16.2"
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
-            "locked": "4.0.1"
+            "locked": "4.3.1"
         },
         "com.netflix.graphql.dgs:graphql-dgs-client": {
-            "locked": "4.0.1"
+            "locked": "4.3.1"
         },
         "com.netflix.graphql.dgs:graphql-dgs-platform-dependencies": {
-            "locked": "4.0.1"
+            "locked": "4.3.1"
         },
         "com.squareup:javapoet": {
             "locked": "1.13.0"
         },
         "com.squareup:kotlinpoet": {
-            "locked": "1.7.2"
+            "locked": "1.8.0"
         },
         "commons-lang:commons-lang": {
             "locked": "2.6"
         },
         "org.assertj:assertj-core": {
-            "locked": "3.11.1"
+            "locked": "3.19.0"
         },
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
             "locked": "1.4.31"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
-            "locked": "1.4.32"
+            "locked": "1.5.0"
         },
         "org.junit.jupiter:junit-jupiter": {
             "locked": "5.7.2"
@@ -181,7 +181,7 @@
             "locked": "2.12.3"
         },
         "com.github.ajalt.clikt:clikt": {
-            "locked": "3.1.0"
+            "locked": "3.2.0"
         },
         "com.google.jimfs:jimfs": {
             "locked": "1.2"
@@ -190,31 +190,31 @@
             "locked": "0.19"
         },
         "com.google.truth:truth": {
-            "locked": "1.1.2"
+            "locked": "1.1.3"
         },
         "com.graphql-java:graphql-java": {
             "locked": "16.2"
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
-            "locked": "4.0.1"
+            "locked": "4.3.1"
         },
         "com.netflix.graphql.dgs:graphql-dgs-client": {
-            "locked": "4.0.1"
+            "locked": "4.3.1"
         },
         "com.netflix.graphql.dgs:graphql-dgs-platform-dependencies": {
-            "locked": "4.0.1"
+            "locked": "4.3.1"
         },
         "com.squareup:javapoet": {
             "locked": "1.13.0"
         },
         "com.squareup:kotlinpoet": {
-            "locked": "1.7.2"
+            "locked": "1.8.0"
         },
         "commons-lang:commons-lang": {
             "locked": "2.6"
         },
         "org.assertj:assertj-core": {
-            "locked": "3.11.1"
+            "locked": "3.19.0"
         },
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
             "locked": "1.4.31"
@@ -237,7 +237,7 @@
             "locked": "2.12.3"
         },
         "com.github.ajalt.clikt:clikt": {
-            "locked": "3.1.0"
+            "locked": "3.2.0"
         },
         "com.google.jimfs:jimfs": {
             "locked": "1.2"
@@ -246,37 +246,37 @@
             "locked": "0.19"
         },
         "com.google.truth:truth": {
-            "locked": "1.1.2"
+            "locked": "1.1.3"
         },
         "com.graphql-java:graphql-java": {
             "locked": "16.2"
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
-            "locked": "4.0.1"
+            "locked": "4.3.1"
         },
         "com.netflix.graphql.dgs:graphql-dgs-client": {
-            "locked": "4.0.1"
+            "locked": "4.3.1"
         },
         "com.netflix.graphql.dgs:graphql-dgs-platform-dependencies": {
-            "locked": "4.0.1"
+            "locked": "4.3.1"
         },
         "com.squareup:javapoet": {
             "locked": "1.13.0"
         },
         "com.squareup:kotlinpoet": {
-            "locked": "1.7.2"
+            "locked": "1.8.0"
         },
         "commons-lang:commons-lang": {
             "locked": "2.6"
         },
         "org.assertj:assertj-core": {
-            "locked": "3.11.1"
+            "locked": "3.19.0"
         },
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
             "locked": "1.4.31"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
-            "locked": "1.4.32"
+            "locked": "1.5.0"
         },
         "org.junit.jupiter:junit-jupiter": {
             "locked": "5.7.2"

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ClientApiGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ClientApiGenerator.kt
@@ -392,12 +392,14 @@ class ClientApiGenerator(private val config: CodeGenConfig, private val document
         val clazzName = "${prefix}Projection"
         if (generatedClasses.contains(clazzName)) return null else generatedClasses.add(clazzName)
         val javaType = TypeSpec.classBuilder(clazzName)
-            .addModifiers(Modifier.PUBLIC).superclass(ParameterizedTypeName.get(className, ClassName.get(getPackageName(), parent.name), ClassName.get(getPackageName(), root.name)))
+            .addModifiers(Modifier.PUBLIC)
+            .superclass(ParameterizedTypeName.get(className, ClassName.get(getPackageName(), parent.name), ClassName.get(getPackageName(), root.name)))
             .addMethod(
                 MethodSpec.constructorBuilder()
                     .addModifiers(Modifier.PUBLIC)
                     .addParameter(ParameterSpec.builder(ClassName.get(getPackageName(), parent.name), "parent").build())
-                    .addParameter(ParameterSpec.builder(ClassName.get(getPackageName(), root.name), "root").build()).addCode("super(parent, root);")
+                    .addParameter(ParameterSpec.builder(ClassName.get(getPackageName(), root.name), "root").build())
+                    .addCode("""super(parent, root, java.util.Optional.of("${type.name}"));""")
                     .build()
             )
 

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
@@ -1953,18 +1953,18 @@ class CodeGenTest {
         val team = interfaces[0]
         assertThat(team.typeSpec.name).isEqualTo("ITeam")
         assertThat(team.typeSpec.methodSpecs).extracting("name").containsExactly("getName")
-        assertThat(team.typeSpec.methodSpecs[0].returnType).extracting("simpleName").containsExactly("String")
+        assertThat(team.typeSpec.methodSpecs[0].returnType).extracting("simpleName").isEqualTo("String")
 
         val player = interfaces[1]
         assertThat(player.typeSpec.name).isEqualTo("IPlayer")
         assertThat(player.typeSpec.methodSpecs).extracting("name").containsExactly("getName")
-        assertThat(player.typeSpec.methodSpecs[0].returnType).extracting("simpleName").containsExactly("String")
+        assertThat(player.typeSpec.methodSpecs[0].returnType).extracting("simpleName").isEqualTo("String")
 
         val standing = interfaces[2]
         assertThat(standing.typeSpec.name).isEqualTo("Standing")
         assertThat(standing.typeSpec.methodSpecs).extracting("name").containsExactly("getPosition", "getTeam")
         assertThat(standing.typeSpec.methodSpecs[0].returnType.toString()).contains("int")
-        assertThat(standing.typeSpec.methodSpecs[1].returnType).extracting("simpleName").containsExactly("ITeam")
+        assertThat(standing.typeSpec.methodSpecs[1].returnType).extracting("simpleName").isEqualTo("ITeam")
 
         assertCompilesJava(dataTypes.plus(interfaces))
     }
@@ -2034,22 +2034,22 @@ class CodeGenTest {
         val iMovie = interfaces[0]
         assertThat(iMovie.typeSpec.name).isEqualTo("IMovie")
         assertThat(iMovie.typeSpec.methodSpecs).extracting("name").containsExactly("getId", "getTitle", "getGenre", "getLanguage", "getTags", "getRating")
-        assertThat(iMovie.typeSpec.methodSpecs[0].returnType).extracting("simpleName").containsExactly("String")
-        assertThat(iMovie.typeSpec.methodSpecs[1].returnType).extracting("simpleName").containsExactly("String")
-        assertThat(iMovie.typeSpec.methodSpecs[2].returnType).extracting("simpleName").containsExactly("IGenre")
-        assertThat(iMovie.typeSpec.methodSpecs[3].returnType).extracting("simpleName").containsExactly("Language")
+        assertThat(iMovie.typeSpec.methodSpecs[0].returnType).extracting("simpleName").isEqualTo("String")
+        assertThat(iMovie.typeSpec.methodSpecs[1].returnType).extracting("simpleName").isEqualTo("String")
+        assertThat(iMovie.typeSpec.methodSpecs[2].returnType).extracting("simpleName").isEqualTo("IGenre")
+        assertThat(iMovie.typeSpec.methodSpecs[3].returnType).extracting("simpleName").isEqualTo("Language")
         var parameterizedTypeName = iMovie.typeSpec.methodSpecs[4].returnType as ParameterizedTypeName
-        assertThat(parameterizedTypeName.rawType).extracting("simpleName").containsExactly("List")
-        assertThat(parameterizedTypeName.typeArguments[0]).extracting("simpleName").containsExactly("String")
-        assertThat(iMovie.typeSpec.methodSpecs[5].returnType).extracting("simpleName").containsExactly("IRating")
+        assertThat(parameterizedTypeName.rawType).extracting("simpleName").isEqualTo("List")
+        assertThat(parameterizedTypeName.typeArguments[0]).extracting("simpleName").isEqualTo("String")
+        assertThat(iMovie.typeSpec.methodSpecs[5].returnType).extracting("simpleName").isEqualTo("IRating")
 
         val iMoviePage = interfaces[1]
         assertThat(iMoviePage.typeSpec.name).isEqualTo("IMoviePage")
         assertThat(iMoviePage.typeSpec.methodSpecs).extracting("name").containsExactly("getItems")
         parameterizedTypeName = iMoviePage.typeSpec.methodSpecs[0].returnType as ParameterizedTypeName
-        assertThat(parameterizedTypeName.rawType).extracting("simpleName").containsExactly("List")
+        assertThat(parameterizedTypeName.rawType).extracting("simpleName").isEqualTo("List")
         val wildcardTypeName = parameterizedTypeName.typeArguments[0] as WildcardTypeName
-        assertThat(wildcardTypeName.upperBounds[0]).extracting("simpleName").containsExactly("IMovie")
+        assertThat(wildcardTypeName.upperBounds[0]).extracting("simpleName").isEqualTo("IMovie")
 
         val iGenre = interfaces[2]
         assertThat(iGenre.typeSpec.name).isEqualTo("IGenre")
@@ -2063,22 +2063,22 @@ class CodeGenTest {
         assertThat(movie.typeSpec.name).isEqualTo("Movie")
         assertThat(movie.typeSpec.superinterfaces).extracting("simpleName").containsExactly("IMovie")
         assertThat(movie.typeSpec.fieldSpecs).extracting("name").containsExactly("id", "title", "genre", "language", "tags", "rating")
-        assertThat(movie.typeSpec.fieldSpecs[0].type).extracting("simpleName").containsExactly("String")
-        assertThat(movie.typeSpec.fieldSpecs[1].type).extracting("simpleName").containsExactly("String")
-        assertThat(movie.typeSpec.fieldSpecs[2].type).extracting("simpleName").containsExactly("IGenre")
-        assertThat(movie.typeSpec.fieldSpecs[3].type).extracting("simpleName").containsExactly("Language")
+        assertThat(movie.typeSpec.fieldSpecs[0].type).extracting("simpleName").isEqualTo("String")
+        assertThat(movie.typeSpec.fieldSpecs[1].type).extracting("simpleName").isEqualTo("String")
+        assertThat(movie.typeSpec.fieldSpecs[2].type).extracting("simpleName").isEqualTo("IGenre")
+        assertThat(movie.typeSpec.fieldSpecs[3].type).extracting("simpleName").isEqualTo("Language")
         parameterizedTypeName = movie.typeSpec.fieldSpecs[4].type as ParameterizedTypeName
-        assertThat(parameterizedTypeName.rawType).extracting("simpleName").containsExactly("List")
-        assertThat(parameterizedTypeName.typeArguments[0]).extracting("simpleName").containsExactly("String")
-        assertThat(movie.typeSpec.fieldSpecs[5].type).extracting("simpleName").containsExactly("IRating")
+        assertThat(parameterizedTypeName.rawType).extracting("simpleName").isEqualTo("List")
+        assertThat(parameterizedTypeName.typeArguments[0]).extracting("simpleName").isEqualTo("String")
+        assertThat(movie.typeSpec.fieldSpecs[5].type).extracting("simpleName").isEqualTo("IRating")
 
         val moviePage = dataTypes[1]
         assertThat(moviePage.typeSpec.name).isEqualTo("MoviePage")
         assertThat(moviePage.typeSpec.superinterfaces).extracting("simpleName").containsExactly("IMoviePage")
         assertThat(moviePage.typeSpec.fieldSpecs).extracting("name").containsExactly("items")
         parameterizedTypeName = moviePage.typeSpec.fieldSpecs[0].type as ParameterizedTypeName
-        assertThat(parameterizedTypeName.rawType).extracting("simpleName").containsExactly("List")
-        assertThat(parameterizedTypeName.typeArguments[0]).extracting("simpleName").containsExactly("IMovie")
+        assertThat(parameterizedTypeName.rawType).extracting("simpleName").isEqualTo("List")
+        assertThat(parameterizedTypeName.typeArguments[0]).extracting("simpleName").isEqualTo("IMovie")
 
         val genre = dataTypes[2]
         assertThat(genre.typeSpec.name).isEqualTo("Genre")
@@ -2094,13 +2094,13 @@ class CodeGenTest {
         assertThat(movieFilter.typeSpec.name).isEqualTo("MovieFilter")
         assertThat(movieFilter.typeSpec.superinterfaces.size).isEqualTo(0)
         assertThat(movieFilter.typeSpec.fieldSpecs).extracting("name").containsExactly("title", "genre", "language", "tags", "rating")
-        assertThat(movieFilter.typeSpec.fieldSpecs[0].type).extracting("simpleName").containsExactly("String")
-        assertThat(movieFilter.typeSpec.fieldSpecs[1].type).extracting("simpleName").containsExactly("Genre")
-        assertThat(movieFilter.typeSpec.fieldSpecs[2].type).extracting("simpleName").containsExactly("Language")
+        assertThat(movieFilter.typeSpec.fieldSpecs[0].type).extracting("simpleName").isEqualTo("String")
+        assertThat(movieFilter.typeSpec.fieldSpecs[1].type).extracting("simpleName").isEqualTo("Genre")
+        assertThat(movieFilter.typeSpec.fieldSpecs[2].type).extracting("simpleName").isEqualTo("Language")
         parameterizedTypeName = movieFilter.typeSpec.fieldSpecs[3].type as ParameterizedTypeName
-        assertThat(parameterizedTypeName.rawType).extracting("simpleName").containsExactly("List")
-        assertThat(parameterizedTypeName.typeArguments[0]).extracting("simpleName").containsExactly("String")
-        assertThat(movieFilter.typeSpec.fieldSpecs[4].type).extracting("simpleName").containsExactly("Rating")
+        assertThat(parameterizedTypeName.rawType).extracting("simpleName").isEqualTo("List")
+        assertThat(parameterizedTypeName.typeArguments[0]).extracting("simpleName").isEqualTo("String")
+        assertThat(movieFilter.typeSpec.fieldSpecs[4].type).extracting("simpleName").isEqualTo("Rating")
 
         assertCompilesJava(dataTypes.plus(interfaces).plus(result.javaEnumTypes))
     }
@@ -2158,8 +2158,8 @@ class CodeGenTest {
         assertThat(iSearchResultPage.typeSpec.name).isEqualTo("ISearchResultPage")
         assertThat(iSearchResultPage.typeSpec.methodSpecs).extracting("name").containsExactly("getItems")
         var parameterizedTypeName = iSearchResultPage.typeSpec.methodSpecs[0].returnType as ParameterizedTypeName
-        assertThat(parameterizedTypeName.rawType).extracting("simpleName").containsExactly("List")
-        assertThat(parameterizedTypeName.typeArguments[0]).extracting("simpleName").containsExactly("SearchResult")
+        assertThat(parameterizedTypeName.rawType).extracting("simpleName").isEqualTo("List")
+        assertThat(parameterizedTypeName.typeArguments[0]).extracting("simpleName").isEqualTo("SearchResult")
 
         assertThat(interfaces[3].typeSpec.name).isEqualTo("SearchResult")
         assertThat(interfaces[4].typeSpec.name).isEqualTo("Character")
@@ -2174,8 +2174,8 @@ class CodeGenTest {
         assertThat(searchResultPage.typeSpec.superinterfaces).extracting("simpleName").containsExactly("ISearchResultPage")
         assertThat(searchResultPage.typeSpec.fieldSpecs).extracting("name").containsExactly("items")
         parameterizedTypeName = searchResultPage.typeSpec.fieldSpecs[0].type as ParameterizedTypeName
-        assertThat(parameterizedTypeName.rawType).extracting("simpleName").containsExactly("List")
-        assertThat(parameterizedTypeName.typeArguments[0]).extracting("simpleName").containsExactly("SearchResult")
+        assertThat(parameterizedTypeName.rawType).extracting("simpleName").isEqualTo("List")
+        assertThat(parameterizedTypeName.typeArguments[0]).extracting("simpleName").isEqualTo("SearchResult")
 
         assertCompilesJava(dataTypes.plus(interfaces).plus(result.javaEnumTypes))
     }

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodegenTestClassLoader.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodegenTestClassLoader.kt
@@ -1,0 +1,50 @@
+/*
+ *
+ *  Copyright 2020 Netflix, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package com.netflix.graphql.dgs.codegen
+
+import com.google.testing.compile.Compilation
+import java.io.ByteArrayOutputStream
+import java.util.*
+import javax.tools.JavaFileObject
+
+internal class CodegenTestClassLoader(private val compilation: Compilation, parent: ClassLoader?) : ClassLoader(parent) {
+
+    @Throws(ClassNotFoundException::class)
+    override fun loadClass(name: String): Class<*>? {
+        val packageNameAsUnixPath = name.replace(".", "/")
+        val normalizedName = "/CLASS_OUTPUT/$packageNameAsUnixPath.class"
+
+        return Optional.ofNullable(
+            compilation
+                .generatedFiles()
+                .find { it.kind == JavaFileObject.Kind.CLASS && it.name == normalizedName }
+        ).map { fileObject ->
+            val input = fileObject.openInputStream()
+            val buffer = ByteArrayOutputStream()
+            var data: Int = input.read()
+            while (data != -1) {
+                buffer.write(data)
+                data = input.read()
+            }
+            input.close()
+            val classData: ByteArray = buffer.toByteArray()
+            defineClass(name, classData, 0, classData.size)
+        }.orElse(super.loadClass(name))
+    }
+}

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/testUtils.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/testUtils.kt
@@ -30,12 +30,15 @@ import org.jetbrains.kotlin.cli.common.messages.MessageRenderer
 import org.jetbrains.kotlin.cli.common.messages.PrintingMessageCollector
 import org.jetbrains.kotlin.cli.jvm.K2JVMCompiler
 import org.jetbrains.kotlin.config.Services
+import org.junit.platform.commons.util.ReflectionUtils
 import java.io.File
+import java.lang.reflect.Method
 import java.nio.file.Files
 import java.nio.file.Path
 
 fun assertCompilesJava(javaFiles: Collection<JavaFile>): Compilation {
     val result = javac().compile(javaFiles.map(JavaFile::toJavaFileObject))
+    result.generatedFiles()
     CompilationSubject.assertThat(result).succeededWithoutWarnings()
     return result
 }
@@ -70,4 +73,14 @@ fun assertCompilesKotlin(files: List<FileSpec>): Path {
     }
 
     return buildDir
+}
+
+fun codegenTestClassLoader(compilation: Compilation, parent: ClassLoader? = null): ClassLoader {
+    return CodegenTestClassLoader(compilation, parent)
+}
+
+@Suppress("UNCHECKED_CAST")
+fun <T> invokeMethod(method: Method, target: Any, vararg args: Any): T {
+    val result = ReflectionUtils.invokeMethod(method, target, *args)
+    return result as T
 }

--- a/graphql-dgs-codegen-gradle/dependencies.lock
+++ b/graphql-dgs-codegen-gradle/dependencies.lock
@@ -71,7 +71,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
-            "locked": "3.1.0"
+            "locked": "3.2.0"
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -86,19 +86,19 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
-            "locked": "4.0.1"
+            "locked": "4.3.1"
         },
         "com.netflix.graphql.dgs:graphql-dgs-client": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
-            "locked": "4.0.1"
+            "locked": "4.3.1"
         },
         "com.netflix.graphql.dgs:graphql-dgs-platform-dependencies": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
-            "locked": "4.0.1"
+            "locked": "4.3.1"
         },
         "com.squareup:javapoet": {
             "firstLevelTransitive": [
@@ -110,7 +110,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
-            "locked": "1.7.2"
+            "locked": "1.8.0"
         },
         "commons-lang:commons-lang": {
             "firstLevelTransitive": [
@@ -122,18 +122,18 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
-            "locked": "1.4.32"
+            "locked": "1.5.0"
         }
     },
     "testCompileClasspath": {
         "com.google.guava:guava": {
-            "locked": "30.1-jre"
+            "locked": "30.1.1-jre"
         },
         "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core": {
             "project": true
         },
         "org.assertj:assertj-core": {
-            "locked": "3.11.1"
+            "locked": "3.19.0"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
@@ -150,13 +150,13 @@
     },
     "testImplementationDependenciesMetadata": {
         "com.google.guava:guava": {
-            "locked": "30.1-jre"
+            "locked": "30.1.1-jre"
         },
         "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core": {
             "project": true
         },
         "org.assertj:assertj-core": {
-            "locked": "3.11.1"
+            "locked": "3.19.0"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
@@ -182,10 +182,10 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
-            "locked": "3.1.0"
+            "locked": "3.2.0"
         },
         "com.google.guava:guava": {
-            "locked": "30.1-jre"
+            "locked": "30.1.1-jre"
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -200,19 +200,19 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
-            "locked": "4.0.1"
+            "locked": "4.3.1"
         },
         "com.netflix.graphql.dgs:graphql-dgs-client": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
-            "locked": "4.0.1"
+            "locked": "4.3.1"
         },
         "com.netflix.graphql.dgs:graphql-dgs-platform-dependencies": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
-            "locked": "4.0.1"
+            "locked": "4.3.1"
         },
         "com.squareup:javapoet": {
             "firstLevelTransitive": [
@@ -224,7 +224,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
-            "locked": "1.7.2"
+            "locked": "1.8.0"
         },
         "commons-lang:commons-lang": {
             "firstLevelTransitive": [
@@ -233,13 +233,13 @@
             "locked": "2.6"
         },
         "org.assertj:assertj-core": {
-            "locked": "3.11.1"
+            "locked": "3.19.0"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
-            "locked": "1.4.32"
+            "locked": "1.5.0"
         },
         "org.junit.jupiter:junit-jupiter": {
             "locked": "5.7.2"


### PR DESCRIPTION
The Java Projection classes will now reflect an explicit GraphQL Schema
Type via their optional `getSchemaType` method. This is used to help
the DGS GraphQL Client resolve the Schema Type required to express the
projection in the GraphQL Query.