### PR TITLE
Generate nested input types when required

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,2 @@
+[{*.kt,*.kts}]
+ij_kotlin_code_style_defaults = KOTLIN_OFFICIAL

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
@@ -91,7 +91,16 @@ class CodeGen(private val config: CodeGenConfig) {
         val entitiesRepresentationsTypes = generateJavaClientEntitiesRepresentations(definitions)
         val constantsClass = ConstantsGenerator(config, document).generate()
 
-        return dataTypesResult.merge(dataFetchersResult).merge(inputTypesResult).merge(unionsResult).merge(enumsResult).merge(interfacesResult).merge(client).merge(entitiesClient).merge(entitiesRepresentationsTypes).merge(constantsClass)
+        return dataTypesResult
+            .merge(dataFetchersResult)
+            .merge(inputTypesResult)
+            .merge(unionsResult)
+            .merge(enumsResult)
+            .merge(interfacesResult)
+            .merge(client)
+            .merge(entitiesClient)
+            .merge(entitiesRepresentationsTypes)
+            .merge(constantsClass)
     }
 
     private fun generateJavaEnums(definitions: Collection<Definition<*>>): CodeGenResult {
@@ -107,7 +116,6 @@ class CodeGen(private val config: CodeGenConfig) {
         if (!config.generateDataTypes) {
             return CodeGenResult()
         }
-
         return definitions.asSequence()
             .filterIsInstance<UnionTypeDefinition>()
             .excludeSchemaTypeExtension()
@@ -171,14 +179,11 @@ class CodeGen(private val config: CodeGenConfig) {
     }
 
     private fun generateJavaDataType(definitions: Collection<Definition<*>>): CodeGenResult {
-        if (!config.generateDataTypes) {
-            return CodeGenResult()
-        }
-
         return definitions.asSequence()
             .filterIsInstance<ObjectTypeDefinition>()
             .excludeSchemaTypeExtension()
             .filter { it.name != "Query" && it.name != "Mutation" && it.name != "RelayPageInfo" }
+            .filter { config.generateDataTypes || it.name in requiredTypeCollector.requiredTypes }
             .map {
                 DataTypeGenerator(config, document).generate(it, findTypeExtensions(it.name, definitions))
             }.fold(CodeGenResult()) { t: CodeGenResult, u: CodeGenResult -> t.merge(u) }

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/RequiredTypeCollector.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/RequiredTypeCollector.kt
@@ -28,6 +28,7 @@ import graphql.language.NodeTraverser
 import graphql.language.NodeVisitorStub
 import graphql.language.ObjectTypeDefinition
 import graphql.language.TypeName
+import graphql.language.UnionTypeDefinition
 import graphql.util.TraversalControl
 import graphql.util.TraverserContext
 
@@ -69,6 +70,16 @@ class RequiredTypeCollector(
                             visitedTypes.add("${node.name}.${it.name}")
                             it.type.findTypeDefinition(document)?.accept(context, this)
                         }
+                    return TraversalControl.CONTINUE
+                }
+
+                override fun visitUnionTypeDefinition(
+                    node: UnionTypeDefinition,
+                    context: TraverserContext<Node<*>>
+                ): TraversalControl {
+                    node.memberTypes.forEach {
+                        it.findTypeDefinition(document)?.accept(context, this)
+                    }
                     return TraversalControl.CONTINUE
                 }
 

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/ClientApiGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/ClientApiGenTest.kt
@@ -1373,8 +1373,20 @@ class ClientApiGenTest {
     fun generateOnlyRequiredDataTypesForQuery() {
         val schema = """
             type Query {
-                shows(showFilter: ShowFilter): [Show]
+                shows(showFilter: ShowFilter): [Video]
                 people(personFilter: PersonFilter): [Person]
+            }
+            
+            union Video = Show | Movie
+            
+            type Movie {
+                title: String
+                duration: Int
+                related: Related
+            }
+            
+            type Related {
+                 video: Video
             }
             
             type Show {
@@ -1432,7 +1444,15 @@ class ClientApiGenTest {
         assertThat(codeGenResult.javaQueryTypes)
             .extracting("typeSpec").extracting("name").containsExactly("ShowsGraphQLQuery")
         assertThat(codeGenResult.clientProjections)
-            .extracting("typeSpec").extracting("name").containsExactly("ShowsProjectionRoot")
+            .extracting("typeSpec").extracting("name").containsExactly(
+                "ShowsProjectionRoot",
+                "Shows_ShowProjection",
+                "Shows_MovieProjection",
+                "Shows_Movie_RelatedProjection",
+                "Shows_Movie_Related_VideoProjection",
+                "Shows_Movie_Related_Video_ShowProjection",
+                "Shows_Movie_Related_Video_MovieProjection"
+            )
 
         assertCompilesJava(codeGenResult.clientProjections + codeGenResult.javaDataTypes + codeGenResult.javaEnumTypes)
     }
@@ -1447,11 +1467,11 @@ class ClientApiGenTest {
             
             type Show {
                 title: String
+                tags(from: Int, to: Int, sourceType: SourceType): [ShowTag]
+                isLive(countryFilter: CountryFilter): Boolean
             }
             
-            enum ShouldNotInclude {
-                YES,NO
-            }
+            enum ShouldNotInclude { YES, NO }
             
             input NotUsed {
                 field: String
@@ -1460,7 +1480,7 @@ class ClientApiGenTest {
             input ShowFilter {
                 title: String
                 showType: ShowType
-                similarTo: SimilarityInput              
+                similarTo: SimilarityInput
             }
             
             input SimilarityInput {
@@ -1471,15 +1491,36 @@ class ClientApiGenTest {
                 MOVIE, SERIES
             }
             
+            input CountryFilter {
+                countriesToExclude: [String]
+            }
+                 
+            enum SourceType { FOO, BAR }
+           
             type Person {
                 name: String
             }
         """.trimIndent()
 
-        val codeGenResult = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, generateClientApi = true, includeMutations = setOf("shows"), generateDataTypes = false, writeToFiles = false)).generate()
-        assertThat(codeGenResult.javaDataTypes.size).isEqualTo(2)
-        assertThat(codeGenResult.javaDataTypes).extracting("typeSpec").extracting("name").containsExactly("ShowFilter", "SimilarityInput")
-        assertThat(codeGenResult.javaEnumTypes).extracting("typeSpec").extracting("name").containsExactly("ShowType")
+        val codeGenResult = CodeGen(
+            CodeGenConfig(
+                schemas = setOf(schema),
+                packageName = basePackageName,
+                generateClientApi = true,
+                includeMutations = setOf("shows"),
+                generateDataTypes = false,
+                writeToFiles = false
+            )
+        ).generate()
+
+        assertThat(codeGenResult.javaDataTypes)
+            .extracting("typeSpec").extracting("name").containsExactly("ShowFilter", "SimilarityInput", "CountryFilter")
+        assertThat(codeGenResult.javaEnumTypes)
+            .extracting("typeSpec").extracting("name").containsExactly("ShowType", "SourceType")
+        assertThat(codeGenResult.javaQueryTypes)
+            .extracting("typeSpec").extracting("name").containsExactly("ShowsGraphQLQuery")
+        assertThat(codeGenResult.clientProjections)
+            .extracting("typeSpec").extracting("name").containsExactly("ShowsProjectionRoot")
 
         assertCompilesJava(codeGenResult.clientProjections + codeGenResult.javaDataTypes + codeGenResult.javaEnumTypes)
     }

--- a/graphql-dgs-codegen-gradle/src/test/kotlin/com/netflix/graphql/dgs/CodegenGradlePluginFooSmokeTest.kt
+++ b/graphql-dgs-codegen-gradle/src/test/kotlin/com/netflix/graphql/dgs/CodegenGradlePluginFooSmokeTest.kt
@@ -1,0 +1,121 @@
+/*
+ *
+ *  Copyright 2020 Netflix, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package com.netflix.graphql.dgs
+
+import org.assertj.core.api.Assertions.assertThat
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome.SUCCESS
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+class CodegenGradlePluginFooSmokeTest {
+
+    @TempDir
+    lateinit var projectDir: File
+
+    @Test
+    fun `Nested input and enum types are generated even if data type generation is disabled explicitly`() {
+        prepareBuildGraphQLSchema(
+            """
+                directive @key(fields: String) on OBJECT
+                 
+                 type Query {
+                     movies(from: Int, to: Int, movieIds: [Int]): [Movie]
+                 }
+                 
+                 type Movie @key(fields : "movieId") {
+                     movieId: Int!
+                     title: String
+                     tags(from: Int, to: Int, sourceType: SourceType): [MovieTag]
+                     isLive(countryFilter: CountryFilter): Boolean
+                 }
+                 
+                 input CountryFilter {
+                    countriesToExclude: [String]
+                 }
+                 
+                type MovieTag {
+                     movieId: Long
+                     tagId: Long
+                     sourceType: SourceType
+                     tagValues(from: Int, to: Int): [String]
+                 } 
+                 
+                 enum SourceType {
+                   FOO
+                   BAR
+                 }
+            """.trimMargin()
+        )
+
+        prepareBuildGradleFile(
+            """
+                plugins {
+                    id 'java'
+                    id 'com.netflix.dgs.codegen'
+                }
+                
+                 repositories {
+                	mavenCentral()
+                }
+                
+                 generateJava {
+                     packageName = 'com.netflix.testproject.graphql'
+                     generateClient = true
+                     generateDataTypes = false
+                     includeQueries = ["movies"]
+                     typeMapping = [
+                        Long:   "java.lang.Long",
+                     ]
+                } 
+                // Need to disable the core conventions since the artifacts are not yet visible.
+                codegen.clientCoreConventionsEnabled = false
+            """.trimMargin()
+        )
+
+        val result = GradleRunner.create()
+            .withProjectDir(projectDir)
+            .withPluginClasspath()
+            .withDebug(true)
+            .withArguments(
+                "--stacktrace",
+                "--info",
+                "generateJava",
+                "build"
+            ).build()
+
+        assertThat(result.task(":generateJava")).extracting { it?.outcome }.isEqualTo(SUCCESS)
+        assertThat(result.task(":build")).extracting { it?.outcome }.isEqualTo(SUCCESS)
+    }
+
+    private fun prepareBuildGradleFile(content: String) {
+        writeProjectFile("build.gradle", content)
+    }
+
+    private fun prepareBuildGraphQLSchema(content: String) {
+        writeProjectFile("src/main/resources/schema/schema.graphql", content)
+    }
+
+    private fun writeProjectFile(relativePath: String, content: String) {
+        val file = File(projectDir, relativePath)
+        file.parentFile.mkdirs()
+        file.writeText(content)
+    }
+}

--- a/graphql-dgs-codegen-gradle/src/test/kotlin/com/netflix/graphql/dgs/CodegenGradlePluginSpringBootSmokeTest.kt
+++ b/graphql-dgs-codegen-gradle/src/test/kotlin/com/netflix/graphql/dgs/CodegenGradlePluginSpringBootSmokeTest.kt
@@ -30,53 +30,53 @@ class CodegenGradlePluginSpringBootSmokeTest {
     @TempDir
     lateinit var projectDir: File
 
-    val graphQLSchema =
+    private val graphQLSchema =
         """
-type Query {
-    result: Result!
-    find(filter: Filter!): Result!
-}
-
-type Result {
-    isSuccessful: Boolean
-    result: String
-}
-
-input Filter {
-    mandatoryString: String!
-    optionalString: String
-    mandatoryNumber: Int!
-    optionalNumber: Int
-}
-
-interface Audited {
-    lastUpdated: DateTime
-    lastUpdatedBy: String
-}
-
-interface MetaData implements Audited {
-    lastUpdated: DateTime
-    lastUpdatedBy: String
-}
-
-type JSONMetaData implements MetaData & Audited {
-    data: JSON
-    url: Url
-    lastUpdated: DateTime
-    lastUpdatedBy: String
-}
-
-type SimpleMetaData implements MetaData & Audited{
-    data: [String]
-    lastUpdated: DateTime
-    lastUpdatedBy: String
-}
-
-scalar Date 
-scalar DateTime
-scalar Time
-scalar JSON
-scalar Url
+            type Query {
+                result: Result!
+                find(filter: Filter!): Result!
+            }
+            
+            type Result {
+                isSuccessful: Boolean
+                result: String
+            }
+            
+            input Filter {
+                mandatoryString: String!
+                optionalString: String
+                mandatoryNumber: Int!
+                optionalNumber: Int
+            }
+            
+            interface Audited {
+                lastUpdated: DateTime
+                lastUpdatedBy: String
+            }
+            
+            interface MetaData implements Audited {
+                lastUpdated: DateTime
+                lastUpdatedBy: String
+            }
+            
+            type JSONMetaData implements MetaData & Audited {
+                data: JSON
+                url: Url
+                lastUpdated: DateTime
+                lastUpdatedBy: String
+            }
+            
+            type SimpleMetaData implements MetaData & Audited{
+                data: [String]
+                lastUpdated: DateTime
+                lastUpdatedBy: String
+            }
+            
+            scalar Date 
+            scalar DateTime
+            scalar Time
+            scalar JSON
+            scalar Url
             """.trimMargin()
 
     @Test
@@ -85,75 +85,75 @@ scalar Url
 
         prepareBuildGradleFile(
             """
-plugins {
-    id 'java'
-    id 'com.netflix.dgs.codegen'
-}
-
- repositories {
-	mavenCentral()
-}
-
- generateJava {
-     packageName = 'com.netflix.testproject.graphql'
-     typeMapping = [
-        DateTime:   "java.time.OffsetTime",
-        Time:       "java.time.OffsetDateTime",
-        Date:       "java.time.LocalDate",
-        JSON:       "java.lang.Object",
-        Url:        "java.net.URL"
-     ]
-     snakeCaseConstantNames = true
- }
- 
- dependencies {
-    implementation(platform("com.netflix.graphql.dgs:graphql-dgs-platform-dependencies:latest.release"))
-	implementation("com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter")
-	implementation("com.netflix.graphql.dgs:graphql-dgs-extended-scalars")
-	testImplementation("org.springframework.boot:spring-boot-starter-test")
-}
-
-test {
-    useJUnitPlatform()
-}
-// Need to disable the core conventions since the artifacts are not yet visible.
-codegen.clientCoreConventionsEnabled = false
-""".trimMargin()
+                plugins {
+                    id 'java'
+                    id 'com.netflix.dgs.codegen'
+                }
+                
+                 repositories {
+                	mavenCentral()
+                }
+                
+                 generateJava {
+                     packageName = 'com.netflix.testproject.graphql'
+                     typeMapping = [
+                        DateTime:   "java.time.OffsetTime",
+                        Time:       "java.time.OffsetDateTime",
+                        Date:       "java.time.LocalDate",
+                        JSON:       "java.lang.Object",
+                        Url:        "java.net.URL"
+                     ]
+                     snakeCaseConstantNames = true
+                 }
+                 
+                 dependencies {
+                    implementation(platform("com.netflix.graphql.dgs:graphql-dgs-platform-dependencies:latest.release"))
+                	implementation("com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter")
+                	implementation("com.netflix.graphql.dgs:graphql-dgs-extended-scalars")
+                	testImplementation("org.springframework.boot:spring-boot-starter-test")
+                }
+                
+                test {
+                    useJUnitPlatform()
+                }
+                // Need to disable the core conventions since the artifacts are not yet visible.
+                codegen.clientCoreConventionsEnabled = false
+            """.trimMargin()
         )
 
         writeProjectFile(
             "src/test/java/AppTest.java",
             """
-import org.springframework.context.annotation.Configuration;
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.junit.jupiter.api.Test;
-
-import com.netflix.testproject.graphql.types.Filter;
-import com.netflix.testproject.graphql.types.Result;
-import com.netflix.testproject.graphql.types.JSONMetaData;
-import com.netflix.testproject.graphql.DgsConstants;
-import com.netflix.testproject.graphql.DgsConstants.QUERY;
-import com.netflix.testproject.graphql.DgsConstants.RESULT;
-import com.netflix.testproject.graphql.DgsConstants.FILTER;
-import com.netflix.testproject.graphql.DgsConstants.JSON_META_DATA;
-import com.netflix.testproject.graphql.DgsConstants.SIMPLE_META_DATA;
-
-
-@SpringBootTest(
-    classes = {AppTest.TestConf.class},
-    properties = { "debug=true" }
-)
-@EnableAutoConfiguration
-public class AppTest {
-
-    @Test
-    public void test(){
-    }
-
-    @Configuration
-    static class TestConf { }
-}
+                import org.springframework.context.annotation.Configuration;
+                import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+                import org.springframework.boot.test.context.SpringBootTest;
+                import org.junit.jupiter.api.Test;
+                
+                import com.netflix.testproject.graphql.types.Filter;
+                import com.netflix.testproject.graphql.types.Result;
+                import com.netflix.testproject.graphql.types.JSONMetaData;
+                import com.netflix.testproject.graphql.DgsConstants;
+                import com.netflix.testproject.graphql.DgsConstants.QUERY;
+                import com.netflix.testproject.graphql.DgsConstants.RESULT;
+                import com.netflix.testproject.graphql.DgsConstants.FILTER;
+                import com.netflix.testproject.graphql.DgsConstants.JSON_META_DATA;
+                import com.netflix.testproject.graphql.DgsConstants.SIMPLE_META_DATA;
+                
+                
+                @SpringBootTest(
+                    classes = {AppTest.TestConf.class},
+                    properties = { "debug=true" }
+                )
+                @EnableAutoConfiguration
+                public class AppTest {
+                
+                    @Test
+                    public void test(){
+                    }
+                
+                    @Configuration
+                    static class TestConf { }
+                }
             """.trimIndent()
         )
 
@@ -176,76 +176,76 @@ public class AppTest {
     fun `A Spring Boot project can generate the generated Kotlin classes and objects`() {
         prepareBuildGradleFile(
             """
-plugins {
-    id 'java'
-    id 'org.jetbrains.kotlin.jvm' version '1.4.10' 
-    id 'com.netflix.dgs.codegen'
-}
-
- repositories {
-	mavenCentral()
-}
-
- generateJava {
-     packageName = 'com.netflix.testproject.graphql'
-     typeMapping = [
-        DateTime:   "java.time.OffsetTime",
-        Time:       "java.time.OffsetDateTime",
-        Date:       "java.time.LocalDate",
-        JSON:       "java.lang.Object",
-        Url:        "java.net.URL"
-     ]
-     language = "KOTLIN"
-     snakeCaseConstantNames = true
- }
- 
- dependencies {
-    implementation(platform("com.netflix.graphql.dgs:graphql-dgs-platform-dependencies:latest.release"))
-	implementation("com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter")
-	implementation("com.netflix.graphql.dgs:graphql-dgs-extended-scalars")
-	testImplementation("org.springframework.boot:spring-boot-starter-test")
-}
-
-test {
-    useJUnitPlatform()
-}
-// Need to disable the core conventions since the artifacts are not yet visible.
-codegen.clientCoreConventionsEnabled = false
-""".trimMargin()
+                plugins {
+                    id 'java'
+                    id 'org.jetbrains.kotlin.jvm' version '1.4.10' 
+                    id 'com.netflix.dgs.codegen'
+                }
+                
+                 repositories {
+                	mavenCentral()
+                }
+                
+                 generateJava {
+                     packageName = 'com.netflix.testproject.graphql'
+                     typeMapping = [
+                        DateTime:   "java.time.OffsetTime",
+                        Time:       "java.time.OffsetDateTime",
+                        Date:       "java.time.LocalDate",
+                        JSON:       "java.lang.Object",
+                        Url:        "java.net.URL"
+                     ]
+                     language = "KOTLIN"
+                     snakeCaseConstantNames = true
+                 }
+                 
+                dependencies {
+                    implementation(platform("com.netflix.graphql.dgs:graphql-dgs-platform-dependencies:latest.release"))
+                	implementation("com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter")
+                	implementation("com.netflix.graphql.dgs:graphql-dgs-extended-scalars")
+                	testImplementation("org.springframework.boot:spring-boot-starter-test")
+                }
+                
+                test {
+                    useJUnitPlatform()
+                }
+                // Need to disable the core conventions since the artifacts are not yet visible.
+                codegen.clientCoreConventionsEnabled = false
+            """.trimMargin()
         )
 
         writeProjectFile(
             "src/test/kotlin/AppTest.kt",
             """
-import org.springframework.context.annotation.Configuration
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration
-import org.springframework.boot.test.context.SpringBootTest
-import org.junit.jupiter.api.Test
-
-import com.netflix.testproject.graphql.types.Filter
-import com.netflix.testproject.graphql.types.Result
-import com.netflix.testproject.graphql.types.JSONMetaData
-import com.netflix.testproject.graphql.DgsConstants
-import com.netflix.testproject.graphql.DgsConstants.QUERY
-import com.netflix.testproject.graphql.DgsConstants.RESULT
-import com.netflix.testproject.graphql.DgsConstants.FILTER
-import com.netflix.testproject.graphql.DgsConstants.JSON_META_DATA
-import com.netflix.testproject.graphql.DgsConstants.SIMPLE_META_DATA
-
-
-@SpringBootTest(
-    classes=[AppTest.TestConf::class],
-    properties=["debug=true"]
-)
-@EnableAutoConfiguration
-internal class AppTest{
-
-    @Test
-    fun test() {}
-
-    @Configuration
-    open class TestConf { }
-}
+                import org.springframework.context.annotation.Configuration
+                import org.springframework.boot.autoconfigure.EnableAutoConfiguration
+                import org.springframework.boot.test.context.SpringBootTest
+                import org.junit.jupiter.api.Test
+                
+                import com.netflix.testproject.graphql.types.Filter
+                import com.netflix.testproject.graphql.types.Result
+                import com.netflix.testproject.graphql.types.JSONMetaData
+                import com.netflix.testproject.graphql.DgsConstants
+                import com.netflix.testproject.graphql.DgsConstants.QUERY
+                import com.netflix.testproject.graphql.DgsConstants.RESULT
+                import com.netflix.testproject.graphql.DgsConstants.FILTER
+                import com.netflix.testproject.graphql.DgsConstants.JSON_META_DATA
+                import com.netflix.testproject.graphql.DgsConstants.SIMPLE_META_DATA
+                
+                
+                @SpringBootTest(
+                    classes=[AppTest.TestConf::class],
+                    properties=["debug=true"]
+                )
+                @EnableAutoConfiguration
+                internal class AppTest{
+                
+                    @Test
+                    fun test() {}
+                
+                    @Configuration
+                    open class TestConf { }
+                }
             """.trimIndent()
         )
 


### PR DESCRIPTION
Sometimes users want to disable the generation of all _data types_, via the `generateDataTypes` flag.
This is convenient when the schema expresses a large number of such types but the user is only interested in a subsection.
In the past we were not generating the Input and Enum types of nested elements of the subsection,
this commit fixes that.