### PR TITLE
Remove logic to automatically add __typename in field selection for unions.

### DIFF
--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ClientApiGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ClientApiGenerator.kt
@@ -24,7 +24,6 @@ import com.netflix.graphql.dgs.client.codegen.GraphQLQuery
 import com.netflix.graphql.dgs.codegen.*
 import com.netflix.graphql.dgs.codegen.generators.shared.ClassnameShortener
 import com.squareup.javapoet.*
-import graphql.introspection.Introspection.TypeNameMetaFieldDef
 import graphql.language.*
 import javax.lang.model.element.Modifier
 
@@ -346,7 +345,6 @@ class ClientApiGenerator(private val config: CodeGenConfig, private val document
 
         javaType.addInitializerBlock(
             CodeBlock.builder()
-                .addStatement("getFields().put(\$S, null)", TypeNameMetaFieldDef.name)
                 .build()
         )
 


### PR DESCRIPTION
When creating a query with fragments (usually for union types), avoid adding the __typename to the field selection in the graphql response. The snippet below shows the behavior without the change in this PR:
```
 query ($representations: [_Any!]!) {
     _entities(representations: $representations) {
                ... on Fruit { 
                    __typename // This is not needed, but is added to the generated code currently
                    name 
                } 
    }
} 
```

This is not required and interferes with deserialization of the response into objects.  For example, the following does not work if __typename is in the query's field selection because `Fruit` would not be generated with a `__typename` field.
```
Fruit  apple =
        response.extractValueAsObject("data._entities[0]", Fruit.class);
```