### PR TITLE
Fields with basic types should support projections

### DIFF
--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
@@ -438,20 +438,73 @@ fun TypeDefinition<*>.fieldDefinitions(): List<FieldDefinition> {
     }
 }
 
-fun Type<*>.findTypeDefinition(document: Document, excludeExtensions: Boolean = false): TypeDefinition<*>? {
+fun Type<*>.findTypeDefinition(
+    document: Document,
+    excludeExtensions: Boolean = false,
+    includeBaseTypes: Boolean = false
+): TypeDefinition<*>? {
     return when (this) {
         is NonNullType -> {
-            this.type.findTypeDefinition(document, excludeExtensions)
+            this.type.findTypeDefinition(document, excludeExtensions, includeBaseTypes)
         }
         is ListType -> {
-            this.type.findTypeDefinition(document, excludeExtensions)
+            this.type.findTypeDefinition(document, excludeExtensions, includeBaseTypes)
         }
-        else -> document.definitions.asSequence().filterIsInstance<TypeDefinition<*>>().find {
-            if (it is ScalarTypeDefinition) {
-                false
+        else -> {
+            if (includeBaseTypes && this.isBaseType()) {
+                this.findBaseTypeDefinition()
             } else {
-                it.name == (this as TypeName).name && (!excludeExtensions || it !is ObjectTypeExtensionDefinition)
+                document.definitions.asSequence().filterIsInstance<TypeDefinition<*>>().find {
+                    if (it is ScalarTypeDefinition) {
+                        false
+                    } else {
+                        it.name == (this as TypeName).name && (!excludeExtensions || it !is ObjectTypeExtensionDefinition)
+                    }
+                }
             }
+        }
+    }
+}
+
+fun Type<*>.isBaseType(): Boolean {
+    return when (this) {
+        is NonNullType -> {
+            this.type.isBaseType()
+        }
+        is ListType -> {
+            this.type.isBaseType()
+        }
+        is TypeName -> {
+            when (this.name) {
+                "String", "Boolean", "Float", "Int" -> true
+                else -> false
+            }
+        }
+        else -> {
+            false
+        }
+    }
+}
+
+fun Type<*>.findBaseTypeDefinition(): TypeDefinition<*>? {
+    return when (this) {
+        is NonNullType -> {
+            this.type.findBaseTypeDefinition()
+        }
+        is ListType -> {
+            this.type.findBaseTypeDefinition()
+        }
+        is TypeName -> {
+            when (this.name) {
+                "String" -> ScalarTypeDefinition.newScalarTypeDefinition().name("String").build()
+                "Boolean" -> ScalarTypeDefinition.newScalarTypeDefinition().name("Boolean").build()
+                "Float" -> ScalarTypeDefinition.newScalarTypeDefinition().name("Float").build()
+                "Int" -> ScalarTypeDefinition.newScalarTypeDefinition().name("Int").build()
+                else -> null
+            }
+        }
+        else -> {
+            null
         }
     }
 }

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ClientApiGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ClientApiGenerator.kt
@@ -181,31 +181,40 @@ class ClientApiGenerator(private val config: CodeGenConfig, private val document
 
         val fieldDefinitions = type.fieldDefinitions() + document.definitions.filterIsInstance<ObjectTypeExtensionDefinition>().filter { it.name == type.name }.flatMap { it.fieldDefinitions }
 
-        val codeGenResult = fieldDefinitions.filterSkipped()
-            .mapNotNull { if (it.type.findTypeDefinition(document, true) != null) Pair(it, it.type.findTypeDefinition(document, true)) else null }
-            .map {
-                val projectionName = "${prefix}_${it.first.name.capitalize()}Projection"
+        val codeGenResult = fieldDefinitions
+            .filterSkipped()
+            .mapNotNull {
+                val typeDefinition = it.type.findTypeDefinition(
+                    document,
+                    excludeExtensions = true,
+                    includeBaseTypes = it.inputValueDefinitions.isNotEmpty().and(it.type.isBaseType())
+                )
+                if (typeDefinition != null) it to typeDefinition else null
+            }
+            .map { (fieldDef, typeDef) ->
+                val projectionName = "${prefix}_${fieldDef.name.capitalize()}Projection"
 
-                val noArgMethodBuilder = MethodSpec.methodBuilder(ReservedKeywordSanitizer.sanitize(it.first.name))
-                    .returns(ClassName.get(getPackageName(), projectionName))
-                    .addCode(
-                        """
+                if (!fieldDef.type.isBaseType()) {
+                    val noArgMethodBuilder = MethodSpec.methodBuilder(ReservedKeywordSanitizer.sanitize(fieldDef.name))
+                        .returns(ClassName.get(getPackageName(), projectionName))
+                        .addCode(
+                            """
                         $projectionName projection = new $projectionName(this, this);    
-                        getFields().put("${it.first.name}", projection);
+                        getFields().put("${fieldDef.name}", projection);
                         return projection;
-                        """.trimIndent()
-                    )
-                    .addModifiers(Modifier.PUBLIC)
+                            """.trimIndent()
+                        )
+                        .addModifiers(Modifier.PUBLIC)
+                    javaType.addMethod(noArgMethodBuilder.build())
+                }
 
-                javaType.addMethod(noArgMethodBuilder.build())
-
-                if (it.first.inputValueDefinitions.isNotEmpty()) {
-                    addFieldSelectionMethodWithArguments(it.first, projectionName, javaType)
+                if (fieldDef.inputValueDefinitions.isNotEmpty()) {
+                    addFieldSelectionMethodWithArguments(fieldDef, projectionName, javaType)
                 }
 
                 val processedEdges = mutableSetOf<Pair<String, String>>()
-                processedEdges.add(Pair(it.second!!.name, type.name))
-                createSubProjection(it.second!!, javaType.build(), javaType.build(), "${prefix}_${it.first.name.capitalize()}", processedEdges, 1)
+                processedEdges.add(Pair(typeDef.name, type.name))
+                createSubProjection(typeDef, javaType.build(), javaType.build(), "${prefix}_${fieldDef.name.capitalize()}", processedEdges, 1)
             }
             .fold(CodeGenResult()) { total, current -> total.merge(current) }
 
@@ -257,7 +266,6 @@ class ClientApiGenerator(private val config: CodeGenConfig, private val document
             .addModifiers(Modifier.PUBLIC)
 
         fieldDefinition.inputValueDefinitions.forEach { input ->
-            println("addFieldSelectionMethodWithArguments: $fieldDefinition")
             methodBuilder.addParameter(ParameterSpec.builder(typeUtils.findReturnType(input.type), input.name).build())
         }
         return javaType.addMethod(methodBuilder.build())

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/testUtils.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/testUtils.kt
@@ -37,7 +37,7 @@ import java.nio.file.Files
 import java.nio.file.Path
 
 fun assertCompilesJava(javaFiles: Collection<JavaFile>): Compilation {
-    val result = javac().compile(javaFiles.map(JavaFile::toJavaFileObject))
+    val result = javac().withOptions("-parameters").compile(javaFiles.map(JavaFile::toJavaFileObject))
     result.generatedFiles()
     CompilationSubject.assertThat(result).succeededWithoutWarnings()
     return result


### PR DESCRIPTION
## Current Behavior

The _Client API codegen_ will not generate projection types for _basic type fields_, such as Strings, Booleans, Integers, or Floats, or arrays of any of these types. Let's say we have the following schema:

```
type Query {
    someField: Foo
}

type Foo {
    stringField(arg: Boolean): String
}
```

According to the schema we should expect a _stringField projection_ on the `someField` field, but currently this is not the case.

## Suggested Improvement 

When generating the root projections, as well as sub-projections, we
need to consider the _fields_ with basic types that present input arguments.

To be more specific, and leveraging the schema mentioned above, the `SomeFieldProjectionRoot` _projection type_
should include a `stringField(Boolean arg)` method definition.

The changes on this PR will generate the following `stringField(Boolean arg)` method...

```
public SomeField_StringFieldProjection stringField(Boolean arg) {
    SomeField_StringFieldProjection projection = new SomeField_StringFieldProjection(this, this);
    getFields().put("stringField", projection);
    getInputArguments().computeIfAbsent("stringField", k -> new ArrayList<>());
    InputArgument argArg = new InputArgument("arg", arg);
    getInputArguments().get("stringField").add(argArg);
    return projection;
}
```

In addition to the `stringFeild()` method that will already exist in the `SomeFieldProjectionRoot`, such as the one
below.

```
public SomeFieldProjectionRoot stringField() {
    getFields().put("stringField", null);
    return this;
}
```

### Backwards Compatibility 

Note that the empty argument method will still return the _root projection_ class, in this case `SomeFieldProjectionRoot` while the new field, the one with the argument, will return a different type, in this case `SomeField_StringFieldProjection`.
This is the same behavior for complex types and although arguably both could return the new type, `SomeField_StringFieldProjection`, this will be backwards incompatible.