### PR TITLE
Fields with scalars should support projections

### DIFF
--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
@@ -441,14 +441,15 @@ fun TypeDefinition<*>.fieldDefinitions(): List<FieldDefinition> {
 fun Type<*>.findTypeDefinition(
     document: Document,
     excludeExtensions: Boolean = false,
-    includeBaseTypes: Boolean = false
+    includeBaseTypes: Boolean = false,
+    includeScalarTypes: Boolean = false
 ): TypeDefinition<*>? {
     return when (this) {
         is NonNullType -> {
-            this.type.findTypeDefinition(document, excludeExtensions, includeBaseTypes)
+            this.type.findTypeDefinition(document, excludeExtensions, includeBaseTypes, includeScalarTypes)
         }
         is ListType -> {
-            this.type.findTypeDefinition(document, excludeExtensions, includeBaseTypes)
+            this.type.findTypeDefinition(document, excludeExtensions, includeBaseTypes, includeScalarTypes)
         }
         else -> {
             if (includeBaseTypes && this.isBaseType()) {
@@ -456,7 +457,7 @@ fun Type<*>.findTypeDefinition(
             } else {
                 document.definitions.asSequence().filterIsInstance<TypeDefinition<*>>().find {
                     if (it is ScalarTypeDefinition) {
-                        false
+                        includeScalarTypes && it.name == (this as TypeName).name
                     } else {
                         it.name == (this as TypeName).name && (!excludeExtensions || it !is ObjectTypeExtensionDefinition)
                     }

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ClientApiGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ClientApiGenerator.kt
@@ -187,14 +187,15 @@ class ClientApiGenerator(private val config: CodeGenConfig, private val document
                 val typeDefinition = it.type.findTypeDefinition(
                     document,
                     excludeExtensions = true,
-                    includeBaseTypes = it.inputValueDefinitions.isNotEmpty().and(it.type.isBaseType())
+                    includeBaseTypes = it.inputValueDefinitions.isNotEmpty(),
+                    includeScalarTypes = it.inputValueDefinitions.isNotEmpty()
                 )
                 if (typeDefinition != null) it to typeDefinition else null
             }
             .map { (fieldDef, typeDef) ->
                 val projectionName = "${prefix}_${fieldDef.name.capitalize()}Projection"
 
-                if (!fieldDef.type.isBaseType()) {
+                if (typeDef !is ScalarTypeDefinition) {
                     val noArgMethodBuilder = MethodSpec.methodBuilder(ReservedKeywordSanitizer.sanitize(fieldDef.name))
                         .returns(ClassName.get(getPackageName(), projectionName))
                         .addCode(

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/testUtils.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/testUtils.kt
@@ -36,6 +36,16 @@ import java.lang.reflect.Method
 import java.nio.file.Files
 import java.nio.file.Path
 
+fun assertCompilesJava(codeGenResult: CodeGenResult): Compilation {
+    return assertCompilesJava(
+        codeGenResult.clientProjections
+            .plus(codeGenResult.javaQueryTypes)
+            .plus(codeGenResult.javaEnumTypes)
+            .plus(codeGenResult.javaDataTypes)
+            .plus(codeGenResult.javaInterfaces)
+    )
+}
+
 fun assertCompilesJava(javaFiles: Collection<JavaFile>): Compilation {
     val result = javac().withOptions("-parameters").compile(javaFiles.map(JavaFile::toJavaFileObject))
     result.generatedFiles()
@@ -77,6 +87,10 @@ fun assertCompilesKotlin(files: List<FileSpec>): Path {
 
 fun codegenTestClassLoader(compilation: Compilation, parent: ClassLoader? = null): ClassLoader {
     return CodegenTestClassLoader(compilation, parent)
+}
+
+fun Compilation.toClassLoader(): ClassLoader {
+    return codegenTestClassLoader(this, javaClass.classLoader)
 }
 
 @Suppress("UNCHECKED_CAST")


### PR DESCRIPTION
Current Behavior
================

The _Client API codegen_ will not generate projection types for _scalars_. Let's say we have the following schema:

```
type Query {
    ping: Foo
}

type Foo {
    someField(arg: Boolean): Long
}

scalar Long
```

According to the schema we should expect a _someField projection_, but currently this is not the case.

Suggested Improvement
=====================

When generating the root projections, as well as sub-projections, we
need to consider the _fields_ with basic types that present input arguments.

To be more specific, and leveraging the schema mentioned above, the `SomeFieldProjectionRoot` _projection type_
should include a `ping(Boolean arg)` method definition.

The changes on this PR will generate the following `ping(Boolean arg)` method...

```
public SomeField_PingProjection ping(Boolean arg) {
        SomeField_PingProjection projection = new SomeField_PingProjection(this, this);
        getFields().put("ping", projection);
        getInputArguments().computeIfAbsent("ping", k -> new ArrayList<>());
        InputArgument argArg = new InputArgument("arg", arg);
        getInputArguments().get("ping").add(argArg);
        return projection;
}
```

In addition to the `ping()` method that will already exist in the `SomeFieldProjectionRoot`, such as the one
below.

```
public SomeField_PingProjection ping() {
    SomeField_PingProjection projection = new SomeField_PingProjection(this, this);
    getFields().put("ping", projection);
    return projection;
}
```