### PR TITLE
Users can define the configuration/scope the graphql-dgs-codegen-client-core will have.

### DIFF
--- a/graphql-dgs-codegen-gradle/src/main/java/com/netflix/graphql/dgs/codegen/gradle/CodegenPluginExtension.java
+++ b/graphql-dgs-codegen-gradle/src/main/java/com/netflix/graphql/dgs/codegen/gradle/CodegenPluginExtension.java
@@ -30,4 +30,10 @@ public abstract class CodegenPluginExtension {
     public abstract Property<Boolean> getClientCoreConventionsEnabled();
 
     public abstract Property<String> getClientCoreVersion();
+
+    /**
+     * Describes the configuration/scope that the client-core library is going to be added to.
+     * It defaults to {@link ClientUtilsConventions#GRADLE_CLASSPATH_CONFIGURATION}
+     */
+    public abstract Property<String> getClientCoreScope();
 }

--- a/graphql-dgs-codegen-gradle/src/main/kotlin/com/netflix/graphql/dgs/codegen/gradle/ClientUtilsConventions.kt
+++ b/graphql-dgs-codegen-gradle/src/main/kotlin/com/netflix/graphql/dgs/codegen/gradle/ClientUtilsConventions.kt
@@ -23,18 +23,23 @@ import org.gradle.api.logging.Logging
 import java.util.*
 
 object ClientUtilsConventions {
+    const val GRADLE_CLASSPATH_CONFIGURATION = "implementation"
 
     private const val CLIENT_UTILS_ARTIFACT_GROUP = "com.netflix.graphql.dgs.codegen"
     private const val CLIENT_UTILS_ARTIFACT_NAME = "graphql-dgs-codegen-client-core"
-    private const val GRADLE_CLASSPATH_CONFIGURATION = "implementation"
 
     private val logger = Logging.getLogger(ClientUtilsConventions::class.java)
 
-    fun apply(project: Project, optionalCodeUtilsVersion: Optional<String> = Optional.empty()) {
+    fun apply(
+        project: Project,
+        optionalCodeUtilsVersion: Optional<String> = Optional.empty(),
+        optionalCodeClientDependencyScope: Optional<String> = Optional.empty()
+    ) {
         clientCoreArtifact(optionalCodeUtilsVersion).ifPresent { dependencyString ->
-            val implementationClasspath = project.configurations.getByName(GRADLE_CLASSPATH_CONFIGURATION).dependencies
-            implementationClasspath.add(project.dependencies.create(dependencyString))
-            logger.lifecycle("DGS CodeGen added [$dependencyString] to the $GRADLE_CLASSPATH_CONFIGURATION classpath.")
+            val dependencyConfiguration = optionalCodeClientDependencyScope.orElse(GRADLE_CLASSPATH_CONFIGURATION)
+            val configurationDependencies = project.configurations.getByName(dependencyConfiguration).dependencies
+            configurationDependencies.add(project.dependencies.create(dependencyString))
+            logger.lifecycle("DGS CodeGen added [$dependencyString] to the $dependencyConfiguration dependencies.")
         }
     }
 

--- a/graphql-dgs-codegen-gradle/src/main/kotlin/com/netflix/graphql/dgs/codegen/gradle/CodegenPlugin.kt
+++ b/graphql-dgs-codegen-gradle/src/main/kotlin/com/netflix/graphql/dgs/codegen/gradle/CodegenPlugin.kt
@@ -57,7 +57,11 @@ class CodegenPlugin : Plugin<Project> {
         project.afterEvaluate { p ->
             if (extensions.clientCoreConventionsEnabled.getOrElse(true)) {
                 logger.info("Applying CodegenPlugin Client Utils conventions.")
-                ClientUtilsConventions.apply(p, Optional.ofNullable(extensions.clientCoreVersion.orNull))
+                ClientUtilsConventions.apply(
+                    p,
+                    Optional.ofNullable(extensions.clientCoreVersion.orNull),
+                    Optional.ofNullable(extensions.clientCoreScope.orNull)
+                )
             }
         }
     }

--- a/graphql-dgs-codegen-gradle/src/test/kotlin/com/netflix/graphql/dgs/CodegenGradlePluginClientUtilsConventionsTest.kt
+++ b/graphql-dgs-codegen-gradle/src/test/kotlin/com/netflix/graphql/dgs/CodegenGradlePluginClientUtilsConventionsTest.kt
@@ -97,6 +97,41 @@ dependencies { }
     }
 
     @Test
+    fun `Can define the cofiguration the graphql-dgs-codegen-client-core module will be added to`() {
+        // configuration
+        val configuration = "api"
+        // and a build file that configures the client core version to use such version
+        prepareBuildGradleFile(
+            """
+            plugins {
+                id 'java-library'
+                id 'com.netflix.dgs.codegen'
+            }
+            
+            repositories { mavenCentral() }
+            
+            dependencies { }
+            
+            codegen {
+                clientCoreScope = "$configuration"
+            }
+            """.trimMargin()
+        )
+        // when the build is executed
+        val runner = GradleRunner.create()
+            .withProjectDir(projectDir)
+            .withPluginClasspath()
+            .withPluginClasspath(emptyList())
+            .withDebug(true)
+            .withArguments("-q", "--info", "--stacktrace", "dependencies", "--configuration=compileClasspath")
+
+        val result = runner.build()
+        // then we assert that the dependency was resolved to the higher version.
+        assertThat(result.output)
+            .contains("DGS CodeGen added [com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-client-core:${inferredVersion.get()}] to the $configuration dependencies.")
+    }
+
+    @Test
     fun `Can define the specific version for the graphql-dgs-codegen-client-core`() {
         // given a higher version
         val higherVersion = "123456"


### PR DESCRIPTION
Rationale
=========

Users might require the artifacts contained in the `graphql-dgs-codegen-client-core` module to be exposed as part of the
API of the module that contains the code generated by this plugin. An example of this will be a GraphQL JAR client
module with the generated codegen code. In such a module the developer will require the artifacts included in the `graphql-dgs-codegen-client-core` as well.

A developer can manually add the dependency to the `graphql-dgs-codegen-client-core`, see example below, but
this will require a prior knowledge on the specific version of the plugin. This version might be obscured if the developer is defining such a version using either `latest.release` or `latest.candidate` as version.

Example of how the dependency can be defined explicitly.

```
dependencies {
    api 'com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-client-core:123'
}
```

Feature Description
===============

With this change a developer can define the configuration/scope the dependency will be added to. Let's say, a developer want to add the `graphql-dgs-codegen-client-core` to the `api` configuration/scope. To do so they will define the following
configuration:

```
codegen {
    clientCoreScope = "api"
}
```