### PR TITLE
Support Projections on complex Entity fields

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ install-py-libs: ## Installs the Python Modules required by the scripts.
 	 pip3 install -r scripts/requirements.txt
 
 
-all: test-examples ## Cleans, checks/tests, publishes the plugin locally and runs the examples.
+all: format test-examples ## Cleans, checks/tests, publishes the plugin locally and runs the examples.
 
 
 help:

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/ClientApiGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/ClientApiGenTest.kt
@@ -20,6 +20,7 @@ package com.netflix.graphql.dgs.codegen
 
 import com.google.common.truth.Truth
 import com.netflix.graphql.dgs.client.codegen.GraphQLQuery
+import com.squareup.javapoet.ClassName
 import com.squareup.javapoet.JavaFile
 import com.squareup.javapoet.ParameterizedTypeName
 import org.apache.commons.lang.ClassUtils.getPublicMethod
@@ -1668,13 +1669,18 @@ class ClientApiGenTest {
             type Query {
                 movies: [Movie]
             }
-            
+
             type Movie {
                 actors: [Actor]
+                awards(oscarsOnly: Boolean): [Award!]
             }
-            
+
             type Actor {
-                awards(oscarsOnly: Boolean): String
+                awards(oscarsOnly: Boolean): [Award!]
+            }
+
+            type Award {
+                name: String
             }
         """.trimIndent()
 
@@ -1689,8 +1695,9 @@ class ClientApiGenTest {
 
         val methodSpecs = codeGenResult.clientProjections[1].typeSpec.methodSpecs
         val methodWithArgs = methodSpecs.filter { !it.isConstructor }.find { it.parameters.size > 0 }
-        assertThat(methodWithArgs).isNotNull
-        assertThat(methodWithArgs!!.parameters[0].name).isEqualTo("oscarsOnly")
+        assertThat(methodWithArgs!!).isNotNull
+        assertThat(methodWithArgs.returnType).extracting { (it as ClassName).simpleName() }.isEqualTo("Movies_ActorsProjection")
+        assertThat(methodWithArgs.parameters[0].name).isEqualTo("oscarsOnly")
         assertThat(methodWithArgs.parameters[0].type.toString()).isEqualTo("java.lang.Boolean")
     }
 

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/EntitiesClientApiGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/EntitiesClientApiGenTest.kt
@@ -361,4 +361,32 @@ class EntitiesClientApiGenTest {
         val projections = codeGenResult.clientProjections.filter { it.typeSpec.name.contains("Entities") }
         assertThat(projections).isEmpty()
     }
+
+    @Test
+    fun generateProjectionsForEntitiesKey() {
+        val schema = """
+            type Foo @key(fields:"id") {
+              id: ID
+              stringField: String
+              barField: Bar
+              mStringField(arg: [String!]): [String!]
+              mBarField(arg: [String!]): [Bar!]
+            }
+
+            type Bar {
+              id: ID
+              name: String
+            }
+        """.trimIndent()
+
+        val codeGenResult = CodeGen(
+            CodeGenConfig(
+                schemas = setOf(schema),
+                packageName = basePackageName,
+                generateClientApi = true,
+            )
+        ).generate()
+        // then
+        val testClassLoader = assertCompilesJava(codeGenResult).toClassLoader()
+    }
 }


### PR DESCRIPTION
This commit will resolve projection on _Entity_ fields with complex
types. For example, let's say we have a `Foo` entity with a field
projection that returns a `Bar`.

```
type Foo @key(fields:"id") {
    id: ID
    bar(arg: [String!]): Bar
}

type Bar {
    name: String
}
```

In the past the root projection for the entity will only generate a
`bar` method with no arguments. With this change it will have, in
addition, the `bar` method that supports the arguments for the
projection.