### PR TITLE
Add more reserved keywords to the sanitizer list

### DIFF
--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ReservedKeywordSanitizer.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ReservedKeywordSanitizer.kt
@@ -21,7 +21,7 @@ package com.netflix.graphql.dgs.codegen.generators.java
 class ReservedKeywordSanitizer {
 
     companion object {
-        private val reservedKeywords = setOf("import", "_", "root", "parent", "interface", "boolean", "enum")
+        private val reservedKeywords = setOf("import", "_", "root", "parent", "interface", "boolean", "enum", "volatile", "protected")
         private const val prefix = "_"
 
         fun sanitize(originalName: String): String {


### PR DESCRIPTION
Similar to #210 - add a few reserved keywords found during working with a _very large composed schema_ that unfortunately can't change the names on. 

Added a test to make sure the generated code with the new keywords works as expected. 