### PR TITLE
Fix generation or projections for schemas with type extensions.

### DIFF
--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ClientApiGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ClientApiGenerator.kt
@@ -322,7 +322,7 @@ class ClientApiGenerator(private val config: CodeGenConfig, private val document
 
     private fun createUnionTypes(type: TypeDefinition<*>, javaType: TypeSpec.Builder, rootType: TypeSpec, prefix: String, processedEdges: Set<Pair<String, String>>, queryDepth: Int): CodeGenResult {
         return if (type is UnionTypeDefinition) {
-            val memberTypes = type.memberTypes.mapNotNull { it.findTypeDefinition(document) }.toList()
+            val memberTypes = type.memberTypes.mapNotNull { it.findTypeDefinition(document, true) }.toList()
             memberTypes.map {
                 addFragmentProjectionMethod(javaType, rootType, prefix, it, processedEdges, queryDepth)
             }.fold(CodeGenResult()) { total, current -> total.merge(current) }
@@ -431,7 +431,7 @@ class ClientApiGenerator(private val config: CodeGenConfig, private val document
             fieldDefinitions
                 .filterSkipped()
                 .mapNotNull {
-                    val typeDefinition = it.type.findTypeDefinition(document)
+                    val typeDefinition = it.type.findTypeDefinition(document, true)
                     if (typeDefinition != null) Pair(it, typeDefinition) else null
                 }
                 .filter { (_, typeDef) -> !processedEdges.contains(Pair(typeDef.name, type.name)) }


### PR DESCRIPTION
For schemas that contain type extensions, the generated projections in some cases would add the same method for a field multiple times. This is because the type extensions were not being filtered out when finding the original type to match against. The existing code adds fields from the matched type definition and the type extensions, so if the matched type definition is already the extended type, we end up with the same field accounted for multiple times.

The test case shows the problematic schema use case.
The code that adds the fields from the original type definition with the extension is here: https://github.com/Netflix/dgs-codegen/blob/b91ed0e07b279eca7227ea3227a55121a54048e8/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ClientApiGenerator.kt#L424

Fixes the root cause of the issue for #223, i.e. it should not matter which order the files are processed in.