### PR TITLE
Add a config setting to disable generation of setters in interfaces.

### DIFF
--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
@@ -309,6 +309,7 @@ data class CodeGenConfig(
     val kotlinAllFieldsOptional: Boolean = false,
     /** If enabled, the names of the classes available via the DgsConstant class will be snake cased.*/
     val snakeCaseConstantNames: Boolean = false,
+    val generateInterfaceSetters: Boolean = true,
 ) {
     val packageNameClient: String
         get() = "$packageName.$subPackageNameClient"

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGenCli.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGenCli.kt
@@ -57,6 +57,7 @@ class CodeGenCli : CliktCommand("Generate Java sources for SCHEMA file(s)") {
     private val skipEntityQueries by option("--skip-entities").flag()
     private val typeMapping: Map<String, String> by option("--type-mapping").associate()
     private val shortProjectionNames by option("--short-projection-names").flag()
+    private val generateInterfaceSetters by option("--generate-interface-setters").flag()
 
     override fun run() {
         val inputSchemas = if (schemas.isEmpty()) {
@@ -73,9 +74,9 @@ class CodeGenCli : CliktCommand("Generate Java sources for SCHEMA file(s)") {
 
         val generate = CodeGen(
             if (packageName != null) {
-                CodeGenConfig(schemaFiles = inputSchemas, writeToFiles = writeFiles, outputDir = output.toPath(), packageName = packageName!!, subPackageNameClient = subPackageNameClient, subPackageNameDatafetchers = subPackageNameDatafetchers, subPackageNameTypes = subPackageNameTypes, language = Language.valueOf(language.toUpperCase()), generateBoxedTypes = generateBoxedTypes, generateClientApi = generateClient, includeQueries = includeQueries, includeMutations = includeMutations, skipEntityQueries = skipEntityQueries, typeMapping = typeMapping, shortProjectionNames = shortProjectionNames, generateDataTypes = generateDataTypes, generateInterfaces = generateInterfaces)
+                CodeGenConfig(schemaFiles = inputSchemas, writeToFiles = writeFiles, outputDir = output.toPath(), packageName = packageName!!, subPackageNameClient = subPackageNameClient, subPackageNameDatafetchers = subPackageNameDatafetchers, subPackageNameTypes = subPackageNameTypes, language = Language.valueOf(language.toUpperCase()), generateBoxedTypes = generateBoxedTypes, generateClientApi = generateClient, includeQueries = includeQueries, includeMutations = includeMutations, skipEntityQueries = skipEntityQueries, typeMapping = typeMapping, shortProjectionNames = shortProjectionNames, generateDataTypes = generateDataTypes, generateInterfaces = generateInterfaces, generateInterfaceSetters = generateInterfaceSetters)
             } else {
-                CodeGenConfig(schemaFiles = inputSchemas, writeToFiles = writeFiles, outputDir = output.toPath(), subPackageNameClient = subPackageNameClient, subPackageNameDatafetchers = subPackageNameDatafetchers, subPackageNameTypes = subPackageNameTypes, language = Language.valueOf(language.toUpperCase()), generateBoxedTypes = generateBoxedTypes, generateClientApi = generateClient, includeQueries = includeQueries, includeMutations = includeMutations, skipEntityQueries = skipEntityQueries, typeMapping = typeMapping, shortProjectionNames = shortProjectionNames, generateDataTypes = generateDataTypes, generateInterfaces = generateInterfaces)
+                CodeGenConfig(schemaFiles = inputSchemas, writeToFiles = writeFiles, outputDir = output.toPath(), subPackageNameClient = subPackageNameClient, subPackageNameDatafetchers = subPackageNameDatafetchers, subPackageNameTypes = subPackageNameTypes, language = Language.valueOf(language.toUpperCase()), generateBoxedTypes = generateBoxedTypes, generateClientApi = generateClient, includeQueries = includeQueries, includeMutations = includeMutations, skipEntityQueries = skipEntityQueries, typeMapping = typeMapping, shortProjectionNames = shortProjectionNames, generateDataTypes = generateDataTypes, generateInterfaces = generateInterfaces, generateInterfaceSetters = generateInterfaceSetters)
             }
         ).generate()
 

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/InterfaceGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/InterfaceGenerator.kt
@@ -101,16 +101,20 @@ class InterfaceGenerator(private val config: CodeGenConfig, private val document
         val getterBuilder = MethodSpec.methodBuilder("get${fieldName.capitalize()}")
             .addModifiers(Modifier.ABSTRACT, Modifier.PUBLIC)
             .returns(returnType)
-
-        val setterBuilder = MethodSpec.methodBuilder("set${fieldName.capitalize()}")
-            .addModifiers(Modifier.ABSTRACT, Modifier.PUBLIC)
-            .addParameter(returnType, fieldName)
         if (fieldDefinition.description != null) {
             getterBuilder.addJavadoc(fieldDefinition.description.content.lines().joinToString("\n"))
-            setterBuilder.addJavadoc(fieldDefinition.description.content.lines().joinToString("\n"))
         }
-
         javaType.addMethod(getterBuilder.build())
-        javaType.addMethod(setterBuilder.build())
+
+        if (config.generateInterfaceSetters) {
+            val setterBuilder = MethodSpec.methodBuilder("set${fieldName.capitalize()}")
+                .addModifiers(Modifier.ABSTRACT, Modifier.PUBLIC)
+                .addParameter(returnType, fieldName)
+
+            if (fieldDefinition.description != null) {
+                setterBuilder.addJavadoc(fieldDefinition.description.content.lines().joinToString("\n"))
+            }
+            javaType.addMethod(setterBuilder.build())
+        }
     }
 }

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
@@ -1870,6 +1870,49 @@ class CodeGenTest {
     }
 
     @Test
+    fun generateInterfacesWithoutSetters() {
+
+        val schema = """
+            type Query {
+                people: [Person]
+            }
+
+            interface Person {
+                firstname: String!
+                lastname: String
+            }
+
+        """.trimIndent()
+
+        val (dataTypes, interfaces) =
+            CodeGen(
+                CodeGenConfig(
+                    schemas = setOf(schema),
+                    packageName = basePackageName,
+                    generateInterfaceSetters = false,
+                )
+            ).generate()
+
+        assertThat(interfaces).hasSize(1)
+
+        val person = interfaces[0]
+        Truth.assertThat(person.toString()).isEqualTo(
+            """
+               |package com.netflix.graphql.dgs.codegen.tests.generated.types;
+               |
+               |import java.lang.String;
+               |
+               |public interface Person {
+               |  String getFirstname();
+               |
+               |  String getLastname();
+               |}
+               |""".trimMargin()
+        )
+        assertCompilesJava(dataTypes + interfaces)
+    }
+
+    @Test
     fun generateConstantsWithExtendedInterface() {
         val schema = """
             type Query {


### PR DESCRIPTION
User would like to generate immutable interfaces when using @Value lombok annotation.