### PR TITLE
Support generation of just interfaces without data types.

### DIFF
--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
@@ -107,7 +107,7 @@ class CodeGen(private val config: CodeGenConfig) {
         return definitions.asSequence()
             .filterIsInstance<EnumTypeDefinition>()
             .excludeSchemaTypeExtension()
-            .filter { config.generateDataTypes || it.name in requiredTypeCollector.requiredTypes }
+            .filter { config.generateDataTypes || config.generateInterfaces || it.name in requiredTypeCollector.requiredTypes }
             .map { EnumTypeGenerator(config).generate(it, findEnumExtensions(it.name, definitions)) }
             .fold(CodeGenResult()) { t: CodeGenResult, u: CodeGenResult -> t.merge(u) }
     }
@@ -183,7 +183,7 @@ class CodeGen(private val config: CodeGenConfig) {
             .filterIsInstance<ObjectTypeDefinition>()
             .excludeSchemaTypeExtension()
             .filter { it.name != "Query" && it.name != "Mutation" && it.name != "RelayPageInfo" }
-            .filter { config.generateDataTypes || it.name in requiredTypeCollector.requiredTypes }
+            .filter { config.generateInterfaces || config.generateDataTypes || it.name in requiredTypeCollector.requiredTypes }
             .map {
                 DataTypeGenerator(config, document).generate(it, findTypeExtensions(it.name, definitions))
             }.fold(CodeGenResult()) { t: CodeGenResult, u: CodeGenResult -> t.merge(u) }

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/DataTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/DataTypeGenerator.kt
@@ -60,15 +60,33 @@ class DataTypeGenerator(private val config: CodeGenConfig, private val document:
             interfaceCodeGenResult = generateInterface(interfaceName, superInterfaces, fieldDefinitions)
         }
 
-        val fieldDefinitions = definition.fieldDefinitions
-            .filterSkipped()
-            .map {
-                Field(it.name, typeUtils.findReturnType(it.type, useInterfaceType), overrideGetter = overrideGetter, description = it.description)
-            }
-            .plus(extensions.flatMap { it.fieldDefinitions }.filterSkipped().map { Field(it.name, typeUtils.findReturnType(it.type, useInterfaceType), overrideGetter = overrideGetter, description = it.description) })
+        if (config.generateDataTypes) {
+            val fieldDefinitions = definition.fieldDefinitions
+                .filterSkipped()
+                .map {
+                    Field(
+                        it.name,
+                        typeUtils.findReturnType(it.type, useInterfaceType),
+                        overrideGetter = overrideGetter,
+                        description = it.description
+                    )
+                }
+                .plus(
+                    extensions.flatMap { it.fieldDefinitions }.filterSkipped().map {
+                        Field(
+                            it.name,
+                            typeUtils.findReturnType(it.type, useInterfaceType),
+                            overrideGetter = overrideGetter,
+                            description = it.description
+                        )
+                    }
+                )
 
-        return generate(name, unionTypes.plus(implements), fieldDefinitions, false, definition.description)
-            .merge(interfaceCodeGenResult)
+            return generate(name, unionTypes.plus(implements), fieldDefinitions, false, definition.description)
+                .merge(interfaceCodeGenResult)
+        }
+
+        return interfaceCodeGenResult
     }
 }
 


### PR DESCRIPTION
Currently interfaces can be generated only when generation of data types is enabled.  For scenarios where the user would like to generate the interface for each schema data type, but implement the data classes themselves, it is useful to turn off generation of data types and just have interfaces. This PR addresses the issue describe here: https://github.com/Netflix/dgs-codegen/issues/232