### PR TITLE
Entity Representations and Multiple Keys on an Entity.

### DIFF
--- a/graphql-dgs-codegen-core/build.gradle
+++ b/graphql-dgs-codegen-core/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     implementation(project(":graphql-dgs-codegen-client-core"))
     implementation 'com.graphql-java:graphql-java'
     implementation 'com.fasterxml.jackson.core:jackson-annotations'
+    implementation 'org.slf4j:slf4j-api'
 
     implementation 'com.squareup:javapoet:1.13.+'
     implementation 'com.squareup:kotlinpoet:1.9.+'

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ConstantsGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ConstantsGenerator.kt
@@ -30,6 +30,7 @@ import com.squareup.javapoet.JavaFile
 import com.squareup.javapoet.TypeName
 import com.squareup.javapoet.TypeSpec
 import graphql.language.*
+import java.util.Locale
 import javax.lang.model.element.Modifier
 
 class ConstantsGenerator(private val config: CodeGenConfig, private val document: Document) {
@@ -111,9 +112,9 @@ class ConstantsGenerator(private val config: CodeGenConfig, private val document
     private fun createConstantTypeBuilder(conf: CodeGenConfig, name: String): TypeSpec.Builder {
         val className =
             if (conf.snakeCaseConstantNames)
-                CodeGeneratorUtils.camelCasetoSnakeCase(name, CodeGeneratorUtils.Case.UPPERCASE)
+                CodeGeneratorUtils.camelCaseToSnakeCase(name, CodeGeneratorUtils.Case.UPPERCASE)
             else
-                name.toUpperCase()
+                name.uppercase(Locale.getDefault())
 
         return TypeSpec
             .classBuilder(className)

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/DataTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/DataTypeGenerator.kt
@@ -133,7 +133,13 @@ internal data class Field(val name: String, val type: com.squareup.javapoet.Type
 abstract class BaseDataTypeGenerator(internal val packageName: String, private val config: CodeGenConfig, document: Document) {
     internal val typeUtils = TypeUtils(packageName, config, document)
 
-    internal fun generate(name: String, interfaces: List<String>, fields: List<Field>, isInputType: Boolean, description: Description? = null): CodeGenResult {
+    internal fun generate(
+        name: String,
+        interfaces: List<String>,
+        fields: List<Field>,
+        isInputType: Boolean,
+        description: Description? = null
+    ): CodeGenResult {
         val javaType = TypeSpec.classBuilder(name)
             .addModifiers(Modifier.PUBLIC)
 
@@ -312,8 +318,16 @@ abstract class BaseDataTypeGenerator(internal val packageName: String, private v
 
         javaType.addMethod(getterMethodBuilder.build())
 
-        val setterName = "set${fieldDefinition.name[0].toUpperCase()}${fieldDefinition.name.substring(1)}"
-        javaType.addMethod(MethodSpec.methodBuilder(setterName).addModifiers(Modifier.PUBLIC).addParameter(returnType, ReservedKeywordSanitizer.sanitize(fieldDefinition.name)).addStatement("this.\$N = \$N", ReservedKeywordSanitizer.sanitize(fieldDefinition.name), ReservedKeywordSanitizer.sanitize(fieldDefinition.name)).build())
+        val setterName = "set${fieldDefinition.name[0].uppercase()}${fieldDefinition.name.substring(1)}"
+        javaType.addMethod(
+            MethodSpec.methodBuilder(setterName)
+                .addModifiers(Modifier.PUBLIC)
+                .addParameter(returnType, ReservedKeywordSanitizer.sanitize(fieldDefinition.name))
+                .addStatement(
+                    "this.\$N = \$N", ReservedKeywordSanitizer.sanitize(fieldDefinition.name),
+                    ReservedKeywordSanitizer.sanitize(fieldDefinition.name)
+                ).build()
+        )
     }
 
     private fun addAbstractGetter(returnType: com.squareup.javapoet.TypeName?, fieldDefinition: Field, javaType: TypeSpec.Builder) {

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/EnumTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/EnumTypeGenerator.kt
@@ -27,8 +27,11 @@ import javax.lang.model.element.Modifier
 
 class EnumTypeGenerator(private val config: CodeGenConfig) {
     fun generate(definition: EnumTypeDefinition, extensions: List<EnumTypeDefinition>): CodeGenResult {
-        val javaType = TypeSpec.enumBuilder(definition.name)
-            .addModifiers(Modifier.PUBLIC)
+        val javaType =
+            TypeSpec
+                .enumBuilder(definition.name)
+                .addModifiers(Modifier.PUBLIC)
+
         if (definition.description != null) {
             javaType.addJavadoc(definition.description.content.lines().joinToString("\n"))
         }
@@ -44,7 +47,7 @@ class EnumTypeGenerator(private val config: CodeGenConfig) {
         return CodeGenResult(javaEnumTypes = listOf(javaFile))
     }
 
-    fun getPackageName(): String {
+    private fun getPackageName(): String {
         return config.packageNameTypes
     }
 }

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/TypeUtils.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/TypeUtils.kt
@@ -47,6 +47,10 @@ class TypeUtils(private val packageName: String, private val config: CodeGenConf
         "Header" to ClassName.get("com.netflix.graphql.types.core.resolvers", "PresignedUrlResponse", "Header")
     )
 
+    fun qualifyName(name: String): String {
+        return "$packageName.$name"
+    }
+
     fun findReturnType(fieldType: Type<*>, useInterfaceType: Boolean = false, useWildcardType: Boolean = false): JavaTypeName {
         val visitor = object : NodeVisitorStub() {
             override fun visitTypeName(node: TypeName, context: TraverserContext<Node<Node<*>>>): TraversalControl {

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinConstantsGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinConstantsGenerator.kt
@@ -111,7 +111,7 @@ class KotlinConstantsGenerator(private val config: CodeGenConfig, private val do
     private fun createConstantTypeBuilder(conf: CodeGenConfig, name: String): TypeSpec.Builder {
         val className =
             if (conf.snakeCaseConstantNames)
-                CodeGeneratorUtils.camelCasetoSnakeCase(name, CodeGeneratorUtils.Case.UPPERCASE)
+                CodeGeneratorUtils.camelCaseToSnakeCase(name, CodeGeneratorUtils.Case.UPPERCASE)
             else
                 name.toUpperCase()
 

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/shared/CodeGeneratorUtils.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/shared/CodeGeneratorUtils.kt
@@ -29,16 +29,14 @@ object CodeGeneratorUtils {
     }
 
     /**
-     * Transforms the input string, that should express a camel case notation, into one that expresses a snake case notation.
-     *
-     * @see StringUtils.splitByCharacterTypeCamelCase
+     * Transforms the input string expressing camel-case notation into one that expresses a snake-case notation.
      * */
-    fun camelCasetoSnakeCase(input: String, case: Case = Case.LOWERCASE): String {
+    fun camelCaseToSnakeCase(input: String, case: Case = Case.LOWERCASE): String {
         val parts = splitByCharacterTypeCamelCase(input)
         return parts.joinToString(separator = "_") {
             when (case) {
-                Case.LOWERCASE -> it.toLowerCase()
-                Case.UPPERCASE -> it.toUpperCase()
+                Case.LOWERCASE -> it.lowercase(Locale.getDefault())
+                Case.UPPERCASE -> it.uppercase(Locale.getDefault())
             }
         }
     }

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/generators/shared/CodeGeneratorUtilsTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/generators/shared/CodeGeneratorUtilsTest.kt
@@ -29,7 +29,7 @@ internal class CodeGeneratorUtilsTest {
     @ParameterizedTest(name = "{index} => {0}, expected {1}")
     @MethodSource("toSnakeCaseData")
     fun toSnakeCase(input: String, output: String) {
-        assertThat(CodeGeneratorUtils.camelCasetoSnakeCase(input)).isEqualTo(output)
+        assertThat(CodeGeneratorUtils.camelCaseToSnakeCase(input)).isEqualTo(output)
     }
 
     companion object {


### PR DESCRIPTION
This commit attempts to address the following...
* Entities should be able to define `@keys` that point to fields with  enumerations.
* Entity Representations should have the proper field types
* Entity should support multiple `@keys`