### PR TITLE
Reverting kotlinpoet to 1.9.+

### DIFF
--- a/graphql-dgs-codegen-core/build.gradle
+++ b/graphql-dgs-codegen-core/build.gradle
@@ -32,7 +32,10 @@ dependencies {
     implementation 'org.slf4j:slf4j-api'
 
     implementation 'com.squareup:javapoet:1.13.+'
-    implementation 'com.squareup:kotlinpoet:1.10.+'
+    // kotlinpoet 1.10.+ caused the following...
+    //  `Execution failed for task 'generateJava'.
+    //      not a valid name: package`
+    implementation 'com.squareup:kotlinpoet:1.9.+'
     implementation 'com.github.ajalt.clikt:clikt:3.3.+'
 
     testImplementation 'com.google.jimfs:jimfs:1.2'

--- a/graphql-dgs-codegen-core/dependencies.lock
+++ b/graphql-dgs-codegen-core/dependencies.lock
@@ -27,7 +27,7 @@
             "locked": "1.13.0"
         },
         "com.squareup:kotlinpoet": {
-            "locked": "1.10.2"
+            "locked": "1.9.0"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
@@ -62,7 +62,7 @@
             "locked": "1.13.0"
         },
         "com.squareup:kotlinpoet": {
-            "locked": "1.10.2"
+            "locked": "1.9.0"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
@@ -120,7 +120,7 @@
             "locked": "1.13.0"
         },
         "com.squareup:kotlinpoet": {
-            "locked": "1.10.2"
+            "locked": "1.9.0"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
@@ -161,7 +161,7 @@
             "locked": "1.13.0"
         },
         "com.squareup:kotlinpoet": {
-            "locked": "1.10.2"
+            "locked": "1.9.0"
         },
         "org.assertj:assertj-core": {
             "locked": "3.21.0"
@@ -217,7 +217,7 @@
             "locked": "1.13.0"
         },
         "com.squareup:kotlinpoet": {
-            "locked": "1.10.2"
+            "locked": "1.9.0"
         },
         "org.assertj:assertj-core": {
             "locked": "3.21.0"
@@ -276,7 +276,7 @@
             "locked": "1.13.0"
         },
         "com.squareup:kotlinpoet": {
-            "locked": "1.10.2"
+            "locked": "1.9.0"
         },
         "org.assertj:assertj-core": {
             "locked": "3.21.0"

--- a/graphql-dgs-codegen-gradle/dependencies.lock
+++ b/graphql-dgs-codegen-gradle/dependencies.lock
@@ -111,7 +111,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
-            "locked": "1.10.2"
+            "locked": "1.9.0"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
@@ -233,7 +233,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
-            "locked": "1.10.2"
+            "locked": "1.9.0"
         },
         "org.assertj:assertj-core": {
             "locked": "3.21.0"


### PR DESCRIPTION
Using 'com.squareup:kotlinpoet:1.10.+' caused failures on some projects.

```
* What went wrong:
Execution failed for task ':metagate-dgs-client:generateJava'.
> not a valid name: package
```