### PR TITLE
Upgrade kotlinpoet 1.10.+ & adopt JDKS' SourceVersion to identify Jav…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,7 @@ allprojects {
     }
 
     sourceCompatibility = 1.8
+    targetCompatibility = 1.8
 }
 
 subprojects {

--- a/graphql-dgs-codegen-core/build.gradle
+++ b/graphql-dgs-codegen-core/build.gradle
@@ -32,10 +32,7 @@ dependencies {
     implementation 'org.slf4j:slf4j-api'
 
     implementation 'com.squareup:javapoet:1.13.+'
-    // kotlinpoet 1.10.+ caused the following...
-    //  `Execution failed for task 'generateJava'.
-    //      not a valid name: package`
-    implementation 'com.squareup:kotlinpoet:1.9.+'
+    implementation 'com.squareup:kotlinpoet:1.10.+'
     implementation 'com.github.ajalt.clikt:clikt:3.3.+'
 
     testImplementation 'com.google.jimfs:jimfs:1.2'

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ReservedKeywordSanitizer.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ReservedKeywordSanitizer.kt
@@ -18,29 +18,23 @@
 
 package com.netflix.graphql.dgs.codegen.generators.java
 
+import javax.lang.model.SourceVersion
+
 class ReservedKeywordSanitizer {
 
     companion object {
         private val reservedKeywords =
             setOf(
                 "_",
-                "boolean",
-                "default",
-                "enum",
-                "import",
-                "interface",
-                "package",
                 "parent",
                 "protected",
                 "root",
-                "short",
-                "volatile",
             )
 
         private const val prefix = "_"
 
         fun sanitize(originalName: String): String {
-            return if (reservedKeywords.contains(originalName)) {
+            return if (reservedKeywords.contains(originalName) || SourceVersion.isKeyword(originalName)) {
                 "$prefix$originalName"
             } else {
                 originalName


### PR DESCRIPTION
…a Keywords

* Upgrades to kotlinpoet 1.10.+ since it was wrongly reverted in a previous commit.
* Leverage JDK's SourceVersion to identify Java Keywords.