### PR TITLE
bump kotlin-compiler to 1.5.31

### DIFF
--- a/graphql-dgs-codegen-core/build.gradle
+++ b/graphql-dgs-codegen-core/build.gradle
@@ -35,9 +35,8 @@ dependencies {
     implementation 'com.squareup:kotlinpoet:1.10.+'
     implementation 'com.github.ajalt.clikt:clikt:3.3.+'
 
-    testImplementation 'com.google.jimfs:jimfs:1.2'
     testImplementation 'com.google.testing.compile:compile-testing:0.+'
-    testImplementation 'org.jetbrains.kotlin:kotlin-compiler-embeddable:1.5.30'
+    testImplementation 'org.jetbrains.kotlin:kotlin-compiler:1.5.31'
 }
 
 application {

--- a/graphql-dgs-codegen-core/dependencies.lock
+++ b/graphql-dgs-codegen-core/dependencies.lock
@@ -27,7 +27,7 @@
             "locked": "1.13.0"
         },
         "com.squareup:kotlinpoet": {
-            "locked": "1.9.0"
+            "locked": "1.10.2"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
@@ -62,7 +62,7 @@
             "locked": "1.13.0"
         },
         "com.squareup:kotlinpoet": {
-            "locked": "1.9.0"
+            "locked": "1.10.2"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
@@ -120,7 +120,7 @@
             "locked": "1.13.0"
         },
         "com.squareup:kotlinpoet": {
-            "locked": "1.9.0"
+            "locked": "1.10.2"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
@@ -138,9 +138,6 @@
         },
         "com.github.ajalt.clikt:clikt": {
             "locked": "3.3.0"
-        },
-        "com.google.jimfs:jimfs": {
-            "locked": "1.2"
         },
         "com.google.testing.compile:compile-testing": {
             "locked": "0.19"
@@ -161,13 +158,13 @@
             "locked": "1.13.0"
         },
         "com.squareup:kotlinpoet": {
-            "locked": "1.9.0"
+            "locked": "1.10.2"
         },
         "org.assertj:assertj-core": {
             "locked": "3.21.0"
         },
-        "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
-            "locked": "1.5.30"
+        "org.jetbrains.kotlin:kotlin-compiler": {
+            "locked": "1.5.31"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
@@ -195,9 +192,6 @@
         "com.github.ajalt.clikt:clikt": {
             "locked": "3.3.0"
         },
-        "com.google.jimfs:jimfs": {
-            "locked": "1.2"
-        },
         "com.google.testing.compile:compile-testing": {
             "locked": "0.19"
         },
@@ -217,13 +211,13 @@
             "locked": "1.13.0"
         },
         "com.squareup:kotlinpoet": {
-            "locked": "1.9.0"
+            "locked": "1.10.2"
         },
         "org.assertj:assertj-core": {
             "locked": "3.21.0"
         },
-        "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
-            "locked": "1.5.30"
+        "org.jetbrains.kotlin:kotlin-compiler": {
+            "locked": "1.5.31"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
@@ -251,9 +245,6 @@
         "com.github.ajalt.clikt:clikt": {
             "locked": "3.3.0"
         },
-        "com.google.jimfs:jimfs": {
-            "locked": "1.2"
-        },
         "com.google.testing.compile:compile-testing": {
             "locked": "0.19"
         },
@@ -276,13 +267,13 @@
             "locked": "1.13.0"
         },
         "com.squareup:kotlinpoet": {
-            "locked": "1.9.0"
+            "locked": "1.10.2"
         },
         "org.assertj:assertj-core": {
             "locked": "3.21.0"
         },
-        "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
-            "locked": "1.5.30"
+        "org.jetbrains.kotlin:kotlin-compiler": {
+            "locked": "1.5.31"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [

--- a/graphql-dgs-codegen-gradle/dependencies.lock
+++ b/graphql-dgs-codegen-gradle/dependencies.lock
@@ -111,7 +111,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
-            "locked": "1.9.0"
+            "locked": "1.10.2"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
@@ -233,7 +233,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
-            "locked": "1.9.0"
+            "locked": "1.10.2"
         },
         "org.assertj:assertj-core": {
             "locked": "3.21.0"


### PR DESCRIPTION
Bump the version of the kotlin-compiler used in tests to 1.5.31, to
match the Kotlin version used in the rest of the project. Also, switch
from kotlin-compiler-embeddable to kotlin-compiler, and remove an unused
dependency.