### PR TITLE
Update the schema token limit to INT.MAX_VALUE.

### DIFF
--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
@@ -30,6 +30,7 @@ import com.squareup.javapoet.JavaFile
 import com.squareup.kotlinpoet.FileSpec
 import graphql.language.*
 import graphql.parser.Parser
+import graphql.parser.ParserOptions
 import java.io.File
 import java.nio.file.Path
 import java.nio.file.Paths
@@ -80,6 +81,12 @@ class CodeGen(private val config: CodeGenConfig) {
     }
 
     private fun generateForSchema(schema: String): CodeGenResult {
+        val SDL_MAX_ALLOWED_SCHEMA_TOKENS: Int = Int.MAX_VALUE
+        val parserOptions = ParserOptions.getDefaultParserOptions()
+            .transform {
+                it.maxTokens(SDL_MAX_ALLOWED_SCHEMA_TOKENS)
+            }
+        ParserOptions.setDefaultParserOptions(parserOptions)
         document = Parser.parse(schema)
         requiredTypeCollector = RequiredTypeCollector(
             document,


### PR DESCRIPTION
graphql-java-17 imposes a 15k limit on the schema tokens which causes schema parsing to fail. This PR updates that limit for codegen since DOS attacks are not a concern during compilation.