### PR TITLE
feat: Generate relay pagination types

### DIFF
--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/TypeUtils.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/TypeUtils.kt
@@ -34,6 +34,7 @@ import java.util.*
 import com.squareup.javapoet.TypeName as JavaTypeName
 
 class TypeUtils(private val packageName: String, private val config: CodeGenConfig, private val document: Document) {
+
     private val commonScalars = mapOf<String, JavaTypeName>(
         "LocalTime" to ClassName.get(LocalTime::class.java),
         "LocalDate" to ClassName.get(LocalDate::class.java),

--- a/graphql-dgs-codegen-gradle/src/main/kotlin/com/netflix/graphql/dgs/codegen/gradle/GenerateJavaTask.kt
+++ b/graphql-dgs-codegen-gradle/src/main/kotlin/com/netflix/graphql/dgs/codegen/gradle/GenerateJavaTask.kt
@@ -112,6 +112,9 @@ open class GenerateJavaTask : DefaultTask() {
     @Input
     var snakeCaseConstantNames = false
 
+    @Input
+    var generateDgsPaginationTypes = false
+
     @TaskAction
     fun generate() {
         val schemaPaths = schemaPaths.map { Paths.get(it.toString()).toFile() }.sorted().toSet()
@@ -147,7 +150,8 @@ open class GenerateJavaTask : DefaultTask() {
             omitNullInputFields = omitNullInputFields,
             maxProjectionDepth = maxProjectionDepth,
             kotlinAllFieldsOptional = kotlinAllFieldsOptional,
-            snakeCaseConstantNames = snakeCaseConstantNames
+            snakeCaseConstantNames = snakeCaseConstantNames,
+            generateDgsPaginationTypes = generateDgsPaginationTypes
         )
 
         logger.info("Codegen config: {}", config)


### PR DESCRIPTION
The purpose of this PR is to support the generation of pagination connection types in accordance with the [DGS Relay Pagination documentation](https://netflix.github.io/dgs/advanced/relay-pagination/). Currently, combining dgs-codegen with dgs-pagination results in compilation errors as the pagination plugin only adjusts the schema at runtime. This new feature is opinionated about types with the `*Connection` suffix and directives named `@connection` and is therefore turned off by default

Handles #93 