### PR TITLE
fix: generateInterfaces creates duplicate methods when implementing interface

### DIFF
--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/DataTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/DataTypeGenerator.kt
@@ -47,9 +47,15 @@ class DataTypeGenerator(private val config: CodeGenConfig, private val document:
 
         if (config.generateInterfaces) {
             useInterfaceType = true
+            val fieldsFromSuperTypes = document.getDefinitionsOfType(InterfaceTypeDefinition::class.java)
+                .filter { ClassName.get(packageName, it.name).toString() in implements }
+                .flatMap { it.fieldDefinitions }
+                .map { it.name }
+
             overrideGetter = true
             val fieldDefinitions = definition.fieldDefinitions
                 .filterSkipped()
+                .filter { it.name !in fieldsFromSuperTypes }
                 .map {
                     Field(it.name, typeUtils.findReturnType(it.type, useInterfaceType, true))
                 }

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
@@ -1956,6 +1956,40 @@ class CodeGenTest {
     }
 
     @Test
+    fun generateObjectTypeInterfaceShouldNotRedeclareFields() {
+        val schema = """
+            interface Fruit {
+              seeds: [Seed]
+            }
+
+            type Apple implements Fruit {
+              seeds: [Seed]
+            }
+
+            type Seed {
+              shape: String
+            }
+        """.trimIndent()
+
+        val result = CodeGen(
+            CodeGenConfig(
+                schemas = setOf(schema),
+                packageName = basePackageName,
+                generateInterfaces = true
+            )
+        ).generate()
+
+        val interfaces = result.javaInterfaces
+        val dataTypes = result.javaDataTypes
+
+        val iapple = interfaces[0]
+        assertThat(iapple.typeSpec.name).isEqualTo("IApple")
+        assertThat(iapple.typeSpec.fieldSpecs).isEmpty()
+
+        assertCompilesJava(dataTypes + interfaces)
+    }
+
+    @Test
     fun generateObjectTypeInterfaceWithInterfaceInheritance() {
         val schema = """
         
@@ -1987,7 +2021,7 @@ class CodeGenTest {
         assertThat(iapple.typeSpec.name).isEqualTo("IApple")
         assertThat(iapple.typeSpec.superinterfaces.size).isEqualTo(1)
         assertThat((iapple.typeSpec.superinterfaces[0] as ClassName).simpleName()).isEqualTo("Fruit")
-        assertThat(iapple.typeSpec.methodSpecs).extracting("name").containsExactly("getName")
+        assertThat(iapple.typeSpec.methodSpecs).isEmpty()
 
         val ibasket = interfaces[1]
         assertThat(ibasket.typeSpec.name).isEqualTo("IBasket")
@@ -2292,11 +2326,11 @@ class CodeGenTest {
 
         val iActionGenre = interfaces[2]
         assertThat(iActionGenre.typeSpec.name).isEqualTo("IActionGenre")
-        assertThat(iActionGenre.typeSpec.methodSpecs).extracting("name").containsExactly("getName", "getHeroes")
+        assertThat(iActionGenre.typeSpec.methodSpecs).extracting("name").containsExactly("getHeroes")
 
         val iComedyGenre = interfaces[3]
         assertThat(iComedyGenre.typeSpec.name).isEqualTo("IComedyGenre")
-        assertThat(iComedyGenre.typeSpec.methodSpecs).extracting("name").containsExactly("getName", "getJokes")
+        assertThat(iComedyGenre.typeSpec.methodSpecs).extracting("name").containsExactly("getJokes")
 
         val iRating = interfaces[4]
         assertThat(iRating.typeSpec.name).isEqualTo("IRating")


### PR DESCRIPTION
Fix for issue: https://github.com/Netflix/dgs-codegen/issues/182