### PR TITLE
feat: Support Generic Types on Type Mapping Definitions

### DIFF
--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinPoetUtils.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinPoetUtils.kt
@@ -21,10 +21,9 @@ package com.netflix.graphql.dgs.codegen.generators.kotlin
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonTypeInfo
-import com.squareup.kotlinpoet.AnnotationSpec
-import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.*
 import graphql.introspection.Introspection
-
+import graphql.language.Description
 /**
  * Generate a [JsonTypeInfo] annotation, which allows for Jackson
  * polymorphic type handling when deserializing from JSON.
@@ -107,4 +106,21 @@ fun jsonPropertyAnnotation(name: String): AnnotationSpec {
     return AnnotationSpec.builder(JsonProperty::class)
         .addMember("%S", name)
         .build()
+}
+
+fun Description.sanitizeKdoc(): String {
+    return this.content.lineSequence().joinToString("\n")
+}
+
+fun String.toKtTypeName(isGenericParam: Boolean = false): TypeName {
+    val normalizedClassName = this.trim()
+
+    if (!isGenericParam)
+        ClassName.bestGuess(normalizedClassName)
+
+    return when {
+        normalizedClassName == "*" -> STAR
+        normalizedClassName.endsWith("?") -> ClassName.bestGuess(normalizedClassName.dropLast(1)).copy(nullable = true)
+        else -> ClassName.bestGuess(normalizedClassName)
+    }
 }

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/shared/SharedTypeUtils.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/shared/SharedTypeUtils.kt
@@ -1,0 +1,122 @@
+/*
+ *
+ *  Copyright 2020 Netflix, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package com.netflix.graphql.dgs.codegen.generators.shared
+
+internal sealed class GenericSymbol(open val index: Int) {
+    class OpenBracket(str: String, startFrom: Int = 0) : GenericSymbol(str.indexOf("<", startFrom))
+    class CloseBracket(str: String, startFrom: Int = 0) : GenericSymbol(str.indexOf(">", startFrom))
+    class Comma(str: String, startFrom: Int = 0) : GenericSymbol(str.indexOf(",", startFrom))
+
+    fun notFound(): Boolean = index == -1
+
+    companion object {
+        fun findNext(mappedTypeArg: String, startFrom: Int = 0): GenericSymbolsAhead {
+            return GenericSymbolsAhead(
+                openBracket = OpenBracket(mappedTypeArg, startFrom),
+                closeBracket = CloseBracket(mappedTypeArg, startFrom),
+                comma = Comma(mappedTypeArg, startFrom),
+            )
+        }
+    }
+}
+
+internal data class GenericSymbolsAhead(
+    val openBracket: GenericSymbol.OpenBracket,
+    val closeBracket: GenericSymbol.CloseBracket,
+    val comma: GenericSymbol.Comma,
+) {
+    fun nextSymbol(): GenericSymbol? {
+        return listOf(openBracket, closeBracket, comma).filterNot { it.notFound() }.minByOrNull { it.index }
+    }
+}
+
+internal class GenericSymbolsAheadIterator(private val mappedTypeArg: String) : Iterator<GenericSymbolsAhead> {
+    private var lastSymbolIndex = -1
+    private var currentSymbolIndex = -1
+
+    override fun next(): GenericSymbolsAhead {
+        lastSymbolIndex = currentSymbolIndex
+
+        val next = GenericSymbol.findNext(mappedTypeArg, lastSymbolIndex + 1)
+
+        next.nextSymbol()?.apply {
+            currentSymbolIndex = this.index
+        }
+
+        return next
+    }
+
+    override fun hasNext(): Boolean {
+        return GenericSymbol.findNext(mappedTypeArg, getLastSymbolIndex() + 1).nextSymbol() != null
+    }
+
+    fun getLastSymbolIndex(): Int = lastSymbolIndex
+}
+
+internal fun genericSymbolsAheadIterator(mappedType: String) = GenericSymbolsAheadIterator(mappedType)
+
+internal fun <T> parseMappedType(
+    mappedType: String,
+    toTypeName: String.(isGenericParam: Boolean) -> T,
+    parameterize: (current: Pair<T, MutableList<T>>) -> T,
+    onCloseBracketCallBack: ((current: Pair<T, MutableList<T>>, typeString: String) -> Unit)
+): T {
+    val stack = mutableListOf<Pair<T, MutableList<T>>>()
+    val iterator = genericSymbolsAheadIterator(mappedType)
+
+    if (!iterator.hasNext())
+        return mappedType.toTypeName(false)
+
+    for (genericSymbolsAhead in iterator) {
+        when (val symbolAhead = genericSymbolsAhead.nextSymbol()) {
+            is GenericSymbol.OpenBracket -> {
+                val startIndex = iterator.getLastSymbolIndex() + 1
+                val typeString = mappedType.substring(startIndex, symbolAhead.index)
+                stack.add(Pair(typeString.toTypeName(true), mutableListOf()))
+            }
+            is GenericSymbol.Comma -> {
+                val typeString = mappedType.substring(iterator.getLastSymbolIndex() + 1, symbolAhead.index)
+                if (typeString.trim().isNotEmpty()) {
+                    stack.last().second.add(typeString.toTypeName(true))
+                }
+            }
+            is GenericSymbol.CloseBracket -> {
+                if (stack.isEmpty()) throw IllegalArgumentException("Wrong mapped type $mappedType")
+
+                val current = stack.removeLast()
+                if (iterator.getLastSymbolIndex() + 1 <= symbolAhead.index) {
+                    val typeString = mappedType.substring(iterator.getLastSymbolIndex() + 1, symbolAhead.index)
+                    if (typeString.trim().isNotEmpty()) {
+                        onCloseBracketCallBack?.let { it(current, typeString) }
+                    }
+                }
+
+                val parameterized = parameterize(current)
+
+                if (stack.isEmpty())
+                    return parameterized
+
+                stack.last().second.add(parameterized)
+            }
+        }
+    }
+
+    if (stack.isNotEmpty()) throw IllegalArgumentException("Wrong mapped type $mappedType")
+    return mappedType.toTypeName(true)
+}

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
@@ -25,10 +25,14 @@ import com.squareup.javapoet.JavaFile
 import com.squareup.javapoet.ParameterizedTypeName
 import com.squareup.javapoet.WildcardTypeName
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.Arguments.of
 import org.junit.jupiter.params.provider.MethodSource
+import org.junit.jupiter.params.provider.ValueSource
 import java.util.stream.Stream
 
 class CodeGenTest {
@@ -859,6 +863,108 @@ class CodeGenTest {
         assertCompilesJava(dataTypes)
     }
 
+    @Nested
+    inner class GenerateDataClassesWithParameterizedMappedTypes {
+        private val schema = """
+            type Query {
+                data: JSON
+                person: Person
+            }
+            
+            type Person {
+                firstname: String
+                data: JSON
+            }
+        """.trimIndent()
+
+        @Nested
+        inner class ValidCases {
+            @ParameterizedTest
+            @ValueSource(
+                strings = [
+                    "java.util.Map",
+                    "java.util.ArrayList<String>",
+                    "java.util.Map<String, Object>",
+                    "java.util.ArrayList<? extends Number>",
+                    "java.util.ArrayList<? super Integer>",
+                    "java.util.Map<? extends Number, ? super Integer>",
+                    "java.util.ArrayList<java.util.ArrayList<String>>",
+                    "java.util.ArrayList<java.util.ArrayList<java.util.ArrayList<java.util.ArrayList<String>>>>",
+                    "java.util.Map<java.util.ArrayList, java.util.Map<String, Object>>",
+                    "java.util.Map<java.util.ArrayList<String>, java.util.Map<String, Object>>",
+                    "java.util.Map<java.util.Map<Object, String>, java.util.Map<String, Object>>",
+                ]
+            )
+            fun testValidCase(mappedTypeAsString: String) {
+                verifyValidCase(mappedTypeAsString)
+            }
+
+            @Test
+            fun testGenericQuestionTurnsToObject() {
+                verifyValidCase("java.util.ArrayList<?>", "java.util.ArrayList<java.lang.Object>")
+            }
+
+            @Test
+            fun testTwoGenericQuestionsTurnToObject() {
+                verifyValidCase("java.util.Map<?, ?>", "java.util.Map<java.lang.Object, java.lang.Object>")
+            }
+
+            private fun verifyValidCase(mappedTypeAsString: String, expectedTypeAsString: String = mappedTypeAsString) {
+                val (dataTypes) = CodeGen(
+                    CodeGenConfig(
+                        schemas = setOf(schema),
+                        packageName = basePackageName,
+                        typeMapping = mapOf("JSON" to mappedTypeAsString),
+                    )
+                ).generate()
+
+                assertThat(dataTypes.size).isEqualTo(1)
+                assertThat(dataTypes[0].typeSpec.name).isEqualTo("Person")
+                assertThat(dataTypes[0].packageName).isEqualTo(typesPackageName)
+
+                assertThat(dataTypes[0].typeSpec.fieldSpecs).hasSize(2)
+                assertThat(dataTypes[0].typeSpec.fieldSpecs).extracting("name").contains("firstname", "data")
+
+                assertThat(dataTypes[0].typeSpec.fieldSpecs[1].type.toString()).isEqualTo(expectedTypeAsString)
+
+                assertCompilesJava(dataTypes)
+            }
+        }
+
+        @Nested
+        inner class WrongCases {
+            @ParameterizedTest
+            @ValueSource(
+                strings = [
+                    "",
+                    "java.util.Map<",
+                    "java.util.Map>",
+                    "java.util.Map><",
+                    "java.util.Map<>",
+                    "java.util.Map<String, java.util.ArrayList<>",
+                    "java.util.Map<<String, java.util.ArrayList<String>>",
+                    "java.util.Map<String, java.util.ArrayList<>>>",
+                    "java.util.Map<? extends>",
+                    "java.util.Map<? super>",
+                    "java.util.Map<extends>",
+                    "java.util.Map<super>",
+                    "?",
+                ]
+            )
+            fun testWrongCase(mappedTypeAsString: String) {
+                assertThrows<IllegalArgumentException> {
+                    CodeGen(
+                        CodeGenConfig(
+                            schemas = setOf(schema),
+                            packageName = basePackageName,
+                            typeMapping = mapOf("JSON" to mappedTypeAsString),
+                        )
+                    ).generate()
+                }
+            }
+        }
+    }
+
     @Test
     fun `Skip generating a data class when the type is mapped`() {
 
@@ -1321,22 +1427,6 @@ class CodeGenTest {
         assertThat(type.name).isEqualTo("DgsConstants")
         assertThat(type.typeSpecs).extracting("name").containsExactlyElementsOf(constantNames)
         assertThat(type.typeSpecs[0].fieldSpecs).extracting("name").containsExactly("TYPE_NAME", "People")
-    }
-
-    companion object {
-        @JvmStatic
-        fun generateConstantsArguments(): Stream<Arguments> {
-            return Stream.of(
-                Arguments.of(
-                    true,
-                    listOf("QUERY", "PERSON", "PERSON_META_DATA", "V_PERSON_META_DATA", "V_1_PERSON_META_DATA", "URL_META_DATA")
-                ),
-                Arguments.of(
-                    false,
-                    listOf("QUERY", "PERSON", "PERSONMETADATA", "VPERSONMETADATA", "V1PERSONMETADATA", "URLMETADATA")
-                ),
-            )
-        }
     }
 
     @Test
@@ -2546,4 +2636,25 @@ It takes a title and such.
 
     private val CodeGenResult.javaFiles: Collection<JavaFile>
         get() = javaDataTypes + javaInterfaces + javaEnumTypes + javaDataFetchers + javaQueryTypes + clientProjections + javaConstants
+
+    companion object {
+        @JvmStatic
+        fun generateConstantsArguments(): Stream<Arguments> {
+            return Stream.of(
+                of(
+                    true,
+                    listOf("QUERY", "PERSON", "PERSON_META_DATA", "V_PERSON_META_DATA", "V_1_PERSON_META_DATA", "URL_META_DATA")
+                ),
+                of(
+                    false,
+                    listOf("QUERY", "PERSON", "PERSONMETADATA", "VPERSONMETADATA", "V1PERSONMETADATA", "URLMETADATA")
+                ),
+            )
+        }
+
+        @JvmStatic
+        fun generateDataClassesWithParameterizedMappedTypesWrongCases() = Stream.of(
+            of("java.util.Map<String,String,>"),
+        )
+    }
 }


### PR DESCRIPTION
Related to : https://github.com/Netflix/dgs-codegen/issues/215

Added generic types to type mappings

java

```kotlin
generateJava {
    typeMapping = [
        "Type1"         : "java.util.Map<String, Object>",
        "Type2"         : "java.util.Map<java.util.ArrayList, java.util.Map<String, Object>>"
        "Type3"         : "java.util.ArrayList<?>",
        "Type4"         : "java.util.ArrayList<? extends Number>",
    ]
}
```

kotlin

```kotlin
generateJava {
    typeMapping = [
        "Type1"         : "kotlin.collections.Map<*, *>",
        "Type2"         : "kotlin.collections.Map<String, kotlin.Any?>"
        "Type3"         : "kotlin.collections.List<kotlin.collections.List<String?>?>",
        "Type4"         : "kotlin.collections.List<*>"
    ]
}
```