### PR TITLE
Generate companion objects for union interfaces in Kotlin

### DIFF
--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinUnionTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinUnionTypeGenerator.kt
@@ -48,6 +48,9 @@ class KotlinUnionTypeGenerator(private val config: CodeGenConfig) {
             interfaceBuilder.addAnnotation(jsonTypeInfoAnnotation())
             interfaceBuilder.addAnnotation(jsonSubTypesAnnotation(memberTypes))
         }
+
+        interfaceBuilder.addType(TypeSpec.companionObjectBuilder().build())
+
         val fileSpec = FileSpec.get(packageName, interfaceBuilder.build())
         return CodeGenResult(kotlinInterfaces = listOf(fileSpec))
     }

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
@@ -1581,7 +1581,9 @@ class KotlinCodeGenTest {
                 |  JsonSubTypes.Type(value = Actor::class, name = "Actor"),
                 |  JsonSubTypes.Type(value = Rating::class, name = "Rating")
                 |])
-                |public interface SearchResult
+                |public interface SearchResult {
+                |  public companion object
+                |}
 
         """.trimMargin()
         )


### PR DESCRIPTION
A few weeks ago I did a PR to add companion objects for interfaces in Kotlin but forgot to do it for interfaces generated by unions, here is the feature.
Thank you.