### PR TITLE
feature: mapped types autoprefix (java.lang, kotlin) for common classes

### DIFF
--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/JavaPoetUtils.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/JavaPoetUtils.kt
@@ -106,7 +106,7 @@ fun String.toTypeName(isGenericParam: Boolean = false): TypeName {
     val normalizedClassName = this.trim()
 
     if (!isGenericParam)
-        return ClassName.bestGuess(this.trim())
+        return typeClassBestGuess(normalizedClassName)
 
     val superKeyword = normalizedClassName.split(" super ")
     val extendsKeyword = normalizedClassName.split(" extends ")
@@ -115,6 +115,33 @@ fun String.toTypeName(isGenericParam: Boolean = false): TypeName {
         normalizedClassName == "?" -> WildcardTypeName.get(Object::class.java)
         superKeyword.size == 2 -> WildcardTypeName.supertypeOf(superKeyword[1].toTypeName())
         extendsKeyword.size == 2 -> WildcardTypeName.subtypeOf(extendsKeyword[1].toTypeName())
-        else -> ClassName.bestGuess(this.trim())
+        else -> typeClassBestGuess(normalizedClassName)
+    }
+}
+
+private fun typeClassBestGuess(name: String): TypeName {
+    return when (name) {
+        "String" -> ClassName.get("java.lang", "String")
+        "Integer" -> ClassName.get("java.lang", "Integer")
+        "Long" -> ClassName.get("java.lang", "Long")
+        "Float" -> ClassName.get("java.lang", "Float")
+        "Double" -> ClassName.get("java.lang", "Double")
+        "Character" -> ClassName.get("java.lang", "Character")
+        "Short" -> ClassName.get("java.lang", "Short")
+        "Byte" -> ClassName.get("java.lang", "Byte")
+        "Number" -> ClassName.get("java.lang", "Number")
+        "Boolean" -> ClassName.get("java.lang", "Boolean")
+        "Object" -> ClassName.get("java.lang", "Object")
+        "BigDecimal" -> ClassName.get("java.math", "BigDecimal")
+        "List" -> ClassName.get("java.util", "List")
+        "ArrayList" -> ClassName.get("java.util", "ArrayList")
+        "LinkedList" -> ClassName.get("java.util", "LinkedList")
+        "Map" -> ClassName.get("java.util", "Map")
+        "HashMap" -> ClassName.get("java.util", "HashMap")
+        "Set" -> ClassName.get("java.util", "Set")
+        "HashSet" -> ClassName.get("java.util", "HashSet")
+        "Queue" -> ClassName.get("java.util", "Queue")
+        "TreeMap" -> ClassName.get("java.util", "TreeMap")
+        else -> ClassName.bestGuess(name)
     }
 }

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinDataTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinDataTypeGenerator.kt
@@ -37,23 +37,7 @@ import com.squareup.kotlinpoet.ParameterizedTypeName
 import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.STRING
 import com.squareup.kotlinpoet.TypeSpec
-import graphql.language.ArrayValue
-import graphql.language.BooleanValue
-import graphql.language.Description
-import graphql.language.Document
-import graphql.language.EnumValue
-import graphql.language.FloatValue
-import graphql.language.InputObjectTypeDefinition
-import graphql.language.InputObjectTypeExtensionDefinition
-import graphql.language.IntValue
-import graphql.language.InterfaceTypeDefinition
-import graphql.language.NamedNode
-import graphql.language.ObjectTypeDefinition
-import graphql.language.ObjectTypeExtensionDefinition
-import graphql.language.StringValue
-import graphql.language.Type
-import graphql.language.UnionTypeDefinition
-import graphql.language.Value
+import graphql.language.*
 import com.squareup.kotlinpoet.TypeName as KtTypeName
 
 class KotlinDataTypeGenerator(private val config: CodeGenConfig, private val document: Document) : AbstractKotlinDataTypeGenerator(config.packageNameTypes, config) {

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinPoetUtils.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinPoetUtils.kt
@@ -116,11 +116,42 @@ fun String.toKtTypeName(isGenericParam: Boolean = false): TypeName {
     val normalizedClassName = this.trim()
 
     if (!isGenericParam)
-        ClassName.bestGuess(normalizedClassName)
+        ktTypeClassBestGuess(normalizedClassName)
 
     return when {
         normalizedClassName == "*" -> STAR
-        normalizedClassName.endsWith("?") -> ClassName.bestGuess(normalizedClassName.dropLast(1)).copy(nullable = true)
-        else -> ClassName.bestGuess(normalizedClassName)
+        normalizedClassName.endsWith("?") -> ktTypeClassBestGuess(normalizedClassName.dropLast(1)).copy(nullable = true)
+        else -> ktTypeClassBestGuess(normalizedClassName)
+    }
+}
+
+private fun ktTypeClassBestGuess(name: String): ClassName {
+    return when (name) {
+        STRING.simpleName -> STRING
+        INT.simpleName -> INT
+        LONG.simpleName -> LONG
+        CHAR.simpleName -> CHAR
+        FLOAT.simpleName -> FLOAT
+        DOUBLE.simpleName -> DOUBLE
+        CHAR_SEQUENCE.simpleName -> CHAR_SEQUENCE
+        BOOLEAN.simpleName -> BOOLEAN
+        ANY.simpleName -> ANY
+        SHORT.simpleName -> SHORT
+        NUMBER.simpleName -> NUMBER
+        LIST.simpleName -> LIST
+        SET.simpleName -> SET
+        MAP.simpleName -> MAP
+        "BigDecimal" -> ClassName("java.math", "BigDecimal")
+        MUTABLE_LIST.simpleName -> MUTABLE_LIST
+        MUTABLE_SET.simpleName -> MUTABLE_SET
+        MUTABLE_MAP.simpleName -> MUTABLE_MAP
+        BYTE_ARRAY.simpleName -> BYTE_ARRAY
+        CHAR_ARRAY.simpleName -> CHAR_ARRAY
+        SHORT_ARRAY.simpleName -> SHORT_ARRAY
+        INT_ARRAY.simpleName -> INT_ARRAY
+        LONG_ARRAY.simpleName -> LONG_ARRAY
+        FLOAT_ARRAY.simpleName -> FLOAT_ARRAY
+        DOUBLE_ARRAY.simpleName -> DOUBLE_ARRAY
+        else -> ClassName.bestGuess(name)
     }
 }

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinTypeUtils.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinTypeUtils.kt
@@ -107,13 +107,13 @@ class KotlinTypeUtils(private val packageName: String, val config: CodeGenConfig
         }
 
         return when (name) {
-            "String" -> STRING
+            STRING.simpleName -> STRING
             "StringValue" -> STRING
-            "Int" -> INT
+            INT.simpleName -> INT
             "IntValue" -> INT
-            "Float" -> DOUBLE
+            FLOAT.simpleName -> DOUBLE
             "FloatValue" -> DOUBLE
-            "Boolean" -> BOOLEAN
+            BOOLEAN.simpleName -> BOOLEAN
             "BooleanValue" -> BOOLEAN
             "ID" -> STRING
             "IDValue" -> STRING

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/shared/SharedTypeUtils.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/shared/SharedTypeUtils.kt
@@ -103,7 +103,7 @@ internal fun <T> parseMappedType(
                 if (iterator.getLastSymbolIndex() + 1 <= symbolAhead.index) {
                     val typeString = mappedType.substring(iterator.getLastSymbolIndex() + 1, symbolAhead.index)
                     if (typeString.trim().isNotEmpty()) {
-                        onCloseBracketCallBack?.let { it(current, typeString) }
+                        onCloseBracketCallBack.let { it(current, typeString) }
                     }
                 }
 


### PR DESCRIPTION
Inspired by https://github.com/Netflix/dgs-framework/issues/705


Currently if you want to map to one of common classes you have to specify fully qualified name

**Examples (how you need to map right now otherwise you'll get compilation error since String not found)**
```kotlin
typeMapping = mutableMapOf("JSON" to "kotlin.String")
or
typeMapping = mutableMapOf("JSON" to "java.lang.String")
```


It gets worse with generics and nested types like
```kotlin
typeMapping = mutableMapOf("JSON" to "java.util.ArrayList<java.util.LinkedList<java.util.Set<java.util.HashSet<java.lang.String>>>>")
``` 

With this PR you have ability to omit packages for common classes like String, Long, Boolean, List, Map etc. (supports java and kotlin)

So the example above will become
```kotlin
typeMapping = mutableMapOf("JSON" to "String")
and
typeMapping = mutableMapOf("JSON" to "ArrayList<LinkedList<Set<HashSet<String>>>>")
``` 

What do you think?

