### PR TITLE
Replace deprecated JavaPluginConvention

### DIFF
--- a/graphql-dgs-codegen-gradle/src/main/kotlin/com/netflix/graphql/dgs/codegen/gradle/CodegenPlugin.kt
+++ b/graphql-dgs-codegen-gradle/src/main/kotlin/com/netflix/graphql/dgs/codegen/gradle/CodegenPlugin.kt
@@ -22,7 +22,7 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.logging.Logging
 import org.gradle.api.plugins.JavaPlugin
-import org.gradle.api.plugins.JavaPluginConvention
+import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.api.tasks.SourceSet
 import java.util.Optional
 
@@ -41,7 +41,14 @@ class CodegenPlugin : Plugin<Project> {
         val generateJavaTaskProvider = project.tasks.register("generateJava", GenerateJavaTask::class.java)
         generateJavaTaskProvider.configure { it.group = GRADLE_GROUP }
 
-        val javaConvention = project.convention.getPlugin(JavaPluginConvention::class.java)
+        project.getTasksByName("compileJava", false).forEach {
+            it.dependsOn(generateJavaTaskProvider.get())
+        }
+        project.getTasksByName("compileKotlin", false).forEach {
+            it.dependsOn(generateJavaTaskProvider.get())
+        }
+
+        val javaConvention = project.extensions.getByType(JavaPluginExtension::class.java)
         val sourceSets = javaConvention.sourceSets
         val mainSourceSet = sourceSets.getByName(SourceSet.MAIN_SOURCE_SET_NAME)
         val outputDir = generateJavaTaskProvider.map(GenerateJavaTask::getOutputDir)

--- a/graphql-dgs-codegen-gradle/src/test/kotlin/com/netflix/graphql/dgs/CodegenGradlePluginCompatibilityTest.kt
+++ b/graphql-dgs-codegen-gradle/src/test/kotlin/com/netflix/graphql/dgs/CodegenGradlePluginCompatibilityTest.kt
@@ -40,7 +40,7 @@ class CodegenGradlePluginCompatibilityTest {
     lateinit var projectDir: File
 
     @ParameterizedTest
-    @ValueSource(strings = ["6.8.1", "7.0.2", "7.1.1", "7.2"])
+    @ValueSource(strings = ["7.1", "7.2", "7.3", "7.4"])
     fun `Test generateJava against multiple Gradle Versions`(gradleVersion: String) {
         prepareBuildGraphQLSchema(
             """


### PR DESCRIPTION
I noticed the deprecation warning from gradle. `JavaPluginConvention` will be removed in 8.