### PR TITLE
Set max tokens to allow for larger schemas when generating kotlin

### DIFF
--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
@@ -32,6 +32,7 @@ import graphql.language.*
 import graphql.parser.Parser
 import graphql.parser.ParserOptions
 import java.io.File
+import java.lang.Integer.MAX_VALUE
 import java.nio.file.Path
 import java.nio.file.Paths
 
@@ -221,7 +222,11 @@ class CodeGen(private val config: CodeGenConfig) {
     }
 
     private fun generateKotlinForSchema(schema: String): CodeGenResult {
-        document = Parser.parse(schema)
+        val options = ParserOptions
+            .getDefaultParserOptions()
+            .transform { o -> o.maxTokens(MAX_VALUE) }
+        val parser = Parser()
+        document = parser.parseDocument(schema, options)
         requiredTypeCollector = RequiredTypeCollector(
             document,
             queries = config.includeQueries,

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinTypeUtils.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinTypeUtils.kt
@@ -25,6 +25,7 @@ import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import graphql.language.*
 import graphql.language.TypeName
 import graphql.parser.Parser
+import graphql.parser.ParserOptions
 import graphql.relay.PageInfo
 import graphql.util.TraversalControl
 import graphql.util.TraverserContext
@@ -127,7 +128,11 @@ class KotlinTypeUtils(private val packageName: String, val config: CodeGenConfig
                 .map { it.readText() }
                 .plus(this.schemas)
             val joinedSchema = inputSchemas.joinToString("\n")
-            val document = Parser().parseDocument(joinedSchema)
+            val options = ParserOptions
+                .getDefaultParserOptions()
+                .transform { o -> o.maxTokens(Integer.MAX_VALUE) }
+
+            val document = Parser().parseDocument(joinedSchema, options)
 
             return document.definitions.filterIsInstance<ScalarTypeDefinition>().filterNot {
                 it.getDirectives("javaType").isNullOrEmpty()


### PR DESCRIPTION
Without this I got the below error:
```
More than 15000 parse tokens have been presented. To prevent Denial Of Service attacks, parsing has been cancelled. offending token '{'
```