### PR TITLE
feature: read and use operation types from schema

### DIFF
--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/OperationTypes.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/OperationTypes.kt
@@ -1,0 +1,53 @@
+/*
+ *
+ *  Copyright 2020 Netflix, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package com.netflix.graphql.dgs.codegen
+
+import graphql.language.Document
+import graphql.language.SchemaDefinition
+
+object OperationTypes {
+    fun initialize(document: Document) {
+        restoreDefaults()
+        val schemaDefinitionList = document.definitions.filterIsInstance<SchemaDefinition>()
+
+        if (schemaDefinitionList.isNotEmpty()) {
+            val schemaDefinition = schemaDefinitionList.last()
+            schemaDefinition.operationTypeDefinitions
+                .forEach {
+                    when (it.name) {
+                        "query" -> query = it.typeName.name
+                        "mutation" -> mutation = it.typeName.name
+                        "subscription" -> subscription = it.typeName.name
+                    }
+                }
+        }
+    }
+
+    private fun restoreDefaults() {
+        query = "Query"
+        mutation = "Mutation"
+        subscription = "Subscription"
+    }
+
+    fun isOperationType(typeName: String) = typeName == query || typeName == mutation || typeName == subscription
+
+    var query = "Query"
+    var mutation = "Mutation"
+    var subscription = "Subscription"
+}

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/RequiredTypeCollector.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/RequiredTypeCollector.kt
@@ -42,11 +42,14 @@ class RequiredTypeCollector(
 
     init {
         val fieldDefinitions = mutableListOf<FieldDefinition>()
+
+        OperationTypes.initialize(document)
+
         for (definition in document.definitions.asSequence().filterIsInstance<ObjectTypeDefinition>()) {
             when (definition.name) {
-                "Query" -> definition.fieldDefinitions.filterTo(fieldDefinitions) { it.name in queries }
-                "Mutation" -> definition.fieldDefinitions.filterTo(fieldDefinitions) { it.name in mutations }
-                "Subscription" -> definition.fieldDefinitions.filterTo(fieldDefinitions) { it.name in subscriptions }
+                OperationTypes.query -> definition.fieldDefinitions.filterTo(fieldDefinitions) { it.name in queries }
+                OperationTypes.mutation -> definition.fieldDefinitions.filterTo(fieldDefinitions) { it.name in mutations }
+                OperationTypes.subscription -> definition.fieldDefinitions.filterTo(fieldDefinitions) { it.name in subscriptions }
             }
         }
 

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ConstantsGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ConstantsGenerator.kt
@@ -20,6 +20,7 @@ package com.netflix.graphql.dgs.codegen.generators.java
 
 import com.netflix.graphql.dgs.codegen.CodeGenConfig
 import com.netflix.graphql.dgs.codegen.CodeGenResult
+import com.netflix.graphql.dgs.codegen.OperationTypes
 import com.netflix.graphql.dgs.codegen.generators.shared.CodeGeneratorUtils
 import com.netflix.graphql.dgs.codegen.generators.shared.CodeGeneratorUtils.capitalized
 import com.netflix.graphql.dgs.codegen.generators.shared.SchemaExtensionsUtils.findInputExtensions
@@ -103,13 +104,13 @@ class ConstantsGenerator(private val config: CodeGenConfig, private val document
                 constantsType.addField(FieldSpec.builder(TypeName.get(String::class.java), "TYPE_NAME").addModifiers(Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL).initializer(""""${it.name}"""").build())
             }
 
-        if (document.definitions.any { it is ObjectTypeDefinition && it.name == "Query" }) {
+        if (document.definitions.any { it is ObjectTypeDefinition && it.name == OperationTypes.query }) {
             javaType.addField(FieldSpec.builder(TypeName.get(String::class.java), "QUERY_TYPE").addModifiers(Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL).initializer(""""Query"""").build())
         }
-        if (document.definitions.any { it is ObjectTypeDefinition && it.name == "MUTATION" }) {
+        if (document.definitions.any { it is ObjectTypeDefinition && it.name == OperationTypes.mutation }) {
             javaType.addField(FieldSpec.builder(TypeName.get(String::class.java), "MUTATION_TYPE").addModifiers(Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL).initializer(""""Mutation"""").build())
         }
-        if (document.definitions.any { it is ObjectTypeDefinition && it.name == "Subscription" }) {
+        if (document.definitions.any { it is ObjectTypeDefinition && it.name == OperationTypes.subscription }) {
             javaType.addField(FieldSpec.builder(TypeName.get(String::class.java), "SUBSCRIPTION_TYPE").addModifiers(Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL).initializer(""""Subscription"""").build())
         }
 

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/DatafetcherGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/DatafetcherGenerator.kt
@@ -22,6 +22,7 @@ import com.netflix.graphql.dgs.DgsComponent
 import com.netflix.graphql.dgs.DgsData
 import com.netflix.graphql.dgs.codegen.CodeGenConfig
 import com.netflix.graphql.dgs.codegen.CodeGenResult
+import com.netflix.graphql.dgs.codegen.OperationTypes
 import com.netflix.graphql.dgs.codegen.generators.shared.CodeGeneratorUtils.capitalized
 import com.squareup.javapoet.AnnotationSpec
 import com.squareup.javapoet.JavaFile
@@ -60,7 +61,7 @@ class DatafetcherGenerator(private val config: CodeGenConfig, private val docume
         val methodSpec = MethodSpec.methodBuilder("get$fieldName")
             .returns(returnType)
             .addModifiers(Modifier.PUBLIC)
-            .addAnnotation(AnnotationSpec.builder(DgsData::class.java).addMember("parentType", "\$S", "Query").addMember("field", "\$S", field.name).build())
+            .addAnnotation(AnnotationSpec.builder(DgsData::class.java).addMember("parentType", "\$S", OperationTypes.query).addMember("field", "\$S", field.name).build())
             .addParameter(ParameterSpec.builder(DataFetchingEnvironment::class.java, "dataFetchingEnvironment").build())
             .addStatement("return $returnValue")
 

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinConstantsGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinConstantsGenerator.kt
@@ -20,6 +20,7 @@ package com.netflix.graphql.dgs.codegen.generators.kotlin
 
 import com.netflix.graphql.dgs.codegen.CodeGenConfig
 import com.netflix.graphql.dgs.codegen.CodeGenResult
+import com.netflix.graphql.dgs.codegen.OperationTypes
 import com.netflix.graphql.dgs.codegen.generators.shared.CodeGeneratorUtils
 import com.netflix.graphql.dgs.codegen.generators.shared.CodeGeneratorUtils.capitalized
 import com.netflix.graphql.dgs.codegen.generators.shared.SchemaExtensionsUtils
@@ -99,15 +100,15 @@ class KotlinConstantsGenerator(private val config: CodeGenConfig, private val do
                 baseConstantsType.addType(constantsType.build())
             }
 
-        if (document.definitions.any { it is ObjectTypeDefinition && it.name == "Query" }) {
+        if (document.definitions.any { it is ObjectTypeDefinition && it.name == OperationTypes.query }) {
             baseConstantsType.addProperty(PropertySpec.builder("QUERY_TYPE", String::class).addModifiers(KModifier.CONST).initializer(""""Query"""").build())
         }
 
-        if (document.definitions.any { it is ObjectTypeDefinition && it.name == "Mutation" }) {
+        if (document.definitions.any { it is ObjectTypeDefinition && it.name == OperationTypes.mutation }) {
             baseConstantsType.addProperty(PropertySpec.builder("Mutation_TYPE", String::class).addModifiers(KModifier.CONST).initializer(""""Mutation"""").build())
         }
 
-        if (document.definitions.any { it is ObjectTypeDefinition && it.name == "Subscription" }) {
+        if (document.definitions.any { it is ObjectTypeDefinition && it.name == OperationTypes.subscription }) {
             baseConstantsType.addProperty(PropertySpec.builder("Subscription_TYPE", String::class).addModifiers(KModifier.CONST).initializer(""""Subscription"""").build())
         }
 

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
@@ -2621,6 +2621,38 @@ It takes a title and such.
     }
 
     @Test
+    fun generateUsingSchemaDefinitions() {
+        val schema = """
+            schema {
+                query: SomeQuery
+                mutation: SomeMutation
+            }
+            type SomeQuery {
+                people: [Person]
+            }
+            type SomeMutation {
+                addPerson: Boolean
+            }
+            
+            type Person {
+                firstname: String
+                lastname: String
+            }
+        """.trimIndent()
+
+        val (dataTypes) = CodeGen(
+            CodeGenConfig(
+                schemas = setOf(schema),
+                packageName = basePackageName,
+            )
+        ).generate()
+
+        assertThat(dataTypes.size).isEqualTo(1)
+        val typeSpec = dataTypes[0].typeSpec
+        assertThat(typeSpec.name).isEqualTo("Person")
+    }
+
+    @Test
     fun generateInterfaceJavaDoc() {
         val schema = """           
             ""${'"'}

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/TestUtils.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/TestUtils.kt
@@ -47,6 +47,7 @@ fun assertCompilesJava(codeGenResult: CodeGenResult): Compilation {
 }
 
 fun assertCompilesJava(javaFiles: Collection<JavaFile>): Compilation {
+    println(javaFiles.map { it.toString() })
     val result = javac()
         .withOptions("-parameters")
         .compile(javaFiles.map(JavaFile::toJavaFileObject))


### PR DESCRIPTION
Instead of using hardcoded values for the operation types `Query`, `Mutation` and `Subscription`, read type names from `schema` block inside the schema itself (see https://spec.graphql.org/June2018/#example-e2969) and use hardcoded values as fallback.