### PR TITLE
Bug fixes related to generating kotlin interface types. 

### DIFF
--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
@@ -238,15 +238,7 @@ class CodeGen(private val config: CodeGenConfig) {
 
         val datatypesResult = generateKotlinDataTypes(definitions)
         val inputTypes = generateKotlinInputTypes(definitions)
-
-        val interfacesResult = definitions.asSequence()
-            .filterIsInstance<InterfaceTypeDefinition>()
-            .excludeSchemaTypeExtension()
-            .map {
-                val extensions = findInterfaceExtensions(it.name, definitions)
-                KotlinInterfaceTypeGenerator(config).generate(it, document, extensions)
-            }
-            .fold(CodeGenResult()) { t: CodeGenResult, u: CodeGenResult -> t.merge(u) }
+        val interfacesResult = generateKotlinInterfaceTypes(definitions)
 
         val unionResult = definitions.asSequence()
             .filterIsInstance<UnionTypeDefinition>()
@@ -309,6 +301,21 @@ class CodeGen(private val config: CodeGenConfig) {
             .map {
                 val extensions = findTypeExtensions(it.name, definitions)
                 KotlinDataTypeGenerator(config, document).generate(it, extensions)
+            }
+            .fold(CodeGenResult()) { t: CodeGenResult, u: CodeGenResult -> t.merge(u) }
+    }
+
+    private fun generateKotlinInterfaceTypes(definitions: Collection<Definition<*>>): CodeGenResult {
+        if (!config.generateDataTypes && !config.generateInterfaces) {
+            return CodeGenResult()
+        }
+
+        return definitions.asSequence()
+            .filterIsInstance<InterfaceTypeDefinition>()
+            .excludeSchemaTypeExtension()
+            .map {
+                val extensions = findInterfaceExtensions(it.name, definitions)
+                KotlinInterfaceTypeGenerator(config).generate(it, document, extensions)
             }
             .fold(CodeGenResult()) { t: CodeGenResult, u: CodeGenResult -> t.merge(u) }
     }

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinInterfaceTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinInterfaceTypeGenerator.kt
@@ -53,7 +53,8 @@ class KotlinInterfaceTypeGenerator(private val config: CodeGenConfig) {
 
         mergedFieldDefinitions.forEach { field ->
             val returnType = typeUtils.findReturnType(field.type)
-            val propertySpec = PropertySpec.builder(field.name, returnType)
+            val nullableType = if (typeUtils.isNullable(field.type)) returnType.copy(nullable = true) else returnType
+            val propertySpec = PropertySpec.builder(field.name, nullableType)
             if (field.description != null) {
                 propertySpec.addKdoc("%L", field.description.sanitizeKdoc())
             }

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
@@ -228,6 +228,38 @@ class KotlinCodeGenTest {
     }
 
     @Test
+    fun `interface type with kotlinAllFieldsOptional setting`() {
+
+        val schema = """
+            interface Person {
+                 name: String
+            }
+
+            type People implements Person {
+                 name: String
+            }
+        """.trimIndent()
+
+        val result = CodeGen(
+            CodeGenConfig(
+                schemas = setOf(schema),
+                packageName = basePackageName,
+                language = Language.KOTLIN,
+                kotlinAllFieldsOptional = true,
+            )
+        ).generate()
+        val dataTypes = result.kotlinDataTypes
+        val interfaceTypes = result.kotlinInterfaces
+
+        val type = dataTypes[0].members[0] as TypeSpec
+        assertThat(type.propertySpecs[0].type.isNullable).isTrue
+        val interfaceType = interfaceTypes[0].members[0] as TypeSpec
+        assertThat(interfaceType.propertySpecs[0].type.isNullable).isTrue
+
+        assertCompilesKotlin(dataTypes + interfaceTypes)
+    }
+
+    @Test
     fun generateDataClassWithNoFields() {
 
         val schema = """

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
@@ -260,6 +260,34 @@ class KotlinCodeGenTest {
     }
 
     @Test
+    fun `interface classes are not generated with generateDataTypes setting set to false`() {
+
+        val schema = """
+            interface Person {
+                 name: String
+            }
+
+            type People implements Person {
+                 name: String
+            }
+        """.trimIndent()
+
+        val result = CodeGen(
+            CodeGenConfig(
+                schemas = setOf(schema),
+                packageName = basePackageName,
+                language = Language.KOTLIN,
+                generateDataTypes = false,
+            )
+        ).generate()
+        val dataTypes = result.kotlinDataTypes
+        val interfaceTypes = result.kotlinInterfaces
+
+        assertThat(dataTypes.size).isEqualTo(0)
+        assertThat(interfaceTypes.size).isEqualTo(0)
+    }
+
+    @Test
     fun generateDataClassWithNoFields() {
 
         val schema = """


### PR DESCRIPTION
Fixes Issue #324 where we were only applying this setting for data classes and not interfaces.
Fixes Issue #330 where interfaces are being generated for kotlin even when generateDataTypes was set to false.