### PR TITLE
Allow null for optional input args in projection.

### DIFF
--- a/graphql-dgs-codegen-client-core/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/BaseProjectionNode.kt
+++ b/graphql-dgs-codegen-client-core/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/BaseProjectionNode.kt
@@ -36,5 +36,5 @@ abstract class BaseProjectionNode(
     val fragments: MutableList<BaseSubProjectionNode<*, *>> = LinkedList()
     val inputArguments: MutableMap<String, List<InputArgument>> = LinkedHashMap()
 
-    data class InputArgument(val name: String, val value: Any)
+    data class InputArgument(val name: String, val value: Any?)
 }


### PR DESCRIPTION
Null checks for non-nullable input arguments are enforced in `graphql-java` when the query is executed. Codegen should allow for optionals to be set as null. These won't be serialized, but we should not be throwing an error.

Fixes: https://github.com/Netflix/dgs-codegen/issues/314