### PR TITLE
Parse GraphQL schemas once and in single location

### DIFF
--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinEntitiesRepresentationTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinEntitiesRepresentationTypeGenerator.kt
@@ -38,14 +38,19 @@ import graphql.language.Type
 import graphql.language.TypeDefinition
 import graphql.language.TypeName
 
-class KotlinEntitiesRepresentationTypeGenerator(private val config: CodeGenConfig, private val document: Document) : AbstractKotlinDataTypeGenerator(config.packageNameClient, config) {
+class KotlinEntitiesRepresentationTypeGenerator(config: CodeGenConfig, document: Document) :
+    AbstractKotlinDataTypeGenerator(packageName = config.packageNameTypes, config = config, document = document) {
 
     fun generate(definition: ObjectTypeDefinition, generatedRepresentations: MutableMap<String, Any>): CodeGenResult {
         val name = "${definition.name}Representation"
-        if (generatedRepresentations.containsKey(name)) {
+        if (name in generatedRepresentations) {
             return CodeGenResult()
         }
-        val directiveArg = definition.getDirectives("key").map { it.argumentsByName["fields"]?.value as StringValue }.map { it.value }
+        val directiveArg = definition.getDirectives("key")
+            .asSequence()
+            .map { it.argumentsByName["fields"]?.value as StringValue }
+            .map { it.value }
+            .toList()
         val keyFields = parseKeyDirectiveValue(directiveArg)
         return generateRepresentations(definition.name, definition.fieldDefinitions, generatedRepresentations, keyFields)
     }
@@ -57,7 +62,7 @@ class KotlinEntitiesRepresentationTypeGenerator(private val config: CodeGenConfi
         keyFields: Map<String, Any>
     ): CodeGenResult {
         val name = "${definitionName}Representation"
-        if (generatedRepresentations.containsKey(name)) {
+        if (name in generatedRepresentations) {
             return CodeGenResult()
         }
 

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinInterfaceTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinInterfaceTypeGenerator.kt
@@ -27,22 +27,24 @@ import graphql.language.TypeName
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
-class KotlinInterfaceTypeGenerator(private val config: CodeGenConfig) {
+class KotlinInterfaceTypeGenerator(private val config: CodeGenConfig, private val document: Document) {
+
+    companion object {
+        private val logger: Logger = LoggerFactory.getLogger(KotlinInterfaceTypeGenerator::class.java)
+    }
 
     private val packageName = config.packageNameTypes
-    private val typeUtils = KotlinTypeUtils(packageName, config)
-    private val logger: Logger = LoggerFactory.getLogger(KotlinInterfaceTypeGenerator::class.java)
+    private val typeUtils = KotlinTypeUtils(packageName, config, document)
 
     fun generate(
         definition: InterfaceTypeDefinition,
-        document: Document,
         extensions: List<InterfaceTypeExtensionDefinition>
     ): CodeGenResult {
         if (definition.shouldSkip(config)) {
             return CodeGenResult()
         }
 
-        logger.info("Generating type ${definition.name}")
+        logger.info("Generating type {}", definition.name)
 
         val interfaceBuilder = TypeSpec.interfaceBuilder(definition.name)
         if (definition.description != null) {

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinTypeUtils.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinTypeUtils.kt
@@ -19,13 +19,12 @@
 package com.netflix.graphql.dgs.codegen.generators.kotlin
 
 import com.netflix.graphql.dgs.codegen.CodeGenConfig
+import com.netflix.graphql.dgs.codegen.generators.shared.findSchemaTypeMapping
 import com.netflix.graphql.dgs.codegen.generators.shared.parseMappedType
 import com.squareup.kotlinpoet.*
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import graphql.language.*
 import graphql.language.TypeName
-import graphql.parser.Parser
-import graphql.parser.ParserOptions
 import graphql.relay.PageInfo
 import graphql.util.TraversalControl
 import graphql.util.TraverserContext
@@ -33,7 +32,7 @@ import java.time.*
 import java.util.*
 import com.squareup.kotlinpoet.TypeName as KtTypeName
 
-class KotlinTypeUtils(private val packageName: String, val config: CodeGenConfig) {
+class KotlinTypeUtils(private val packageName: String, private val config: CodeGenConfig, private val document: Document) {
 
     private val commonScalars = mapOf(
         "LocalTime" to LocalTime::class.asTypeName(),
@@ -99,8 +98,9 @@ class KotlinTypeUtils(private val packageName: String, val config: CodeGenConfig
             )
         }
 
-        if (name in config.schemaTypeMapping) {
-            return config.schemaTypeMapping.getValue(name).toKtTypeName()
+        val schemaType = findSchemaTypeMapping(document, name)
+        if (schemaType != null) {
+            return schemaType.toKtTypeName()
         }
 
         if (name in commonScalars) {
@@ -121,27 +121,4 @@ class KotlinTypeUtils(private val packageName: String, val config: CodeGenConfig
             else -> "$packageName.$name".toKtTypeName()
         }
     }
-
-    private val CodeGenConfig.schemaTypeMapping: Map<String, String>
-        get() {
-            val inputSchemas = this.schemaFiles.flatMap { it.walkTopDown().toList().filter { file -> file.isFile } }
-                .map { it.readText() }
-                .plus(this.schemas)
-            val joinedSchema = inputSchemas.joinToString("\n")
-            val options = ParserOptions
-                .getDefaultParserOptions()
-                .transform { o -> o.maxTokens(Integer.MAX_VALUE) }
-
-            val document = Parser().parseDocument(joinedSchema, options)
-
-            return document.definitions.filterIsInstance<ScalarTypeDefinition>().filterNot {
-                it.getDirectives("javaType").isNullOrEmpty()
-            }.associate {
-                val javaType = it.getDirectives("javaType").singleOrNull()
-                    ?: throw IllegalArgumentException("multiple @javaType directives are defined")
-                val value = javaType.argumentsByName["name"]?.value
-                    ?: throw IllegalArgumentException("@javaType directive must contains name argument")
-                it.name to (value as StringValue).value
-            }
-        }
 }

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
@@ -29,9 +29,12 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtensionContext
 import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.*
+import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.Arguments.arguments
-import org.junit.jupiter.params.provider.Arguments.of
+import org.junit.jupiter.params.provider.ArgumentsProvider
+import org.junit.jupiter.params.provider.ArgumentsSource
+import org.junit.jupiter.params.provider.MethodSource
+import org.junit.jupiter.params.provider.ValueSource
 import java.util.stream.Stream
 
 class CodeGenTest {
@@ -2699,11 +2702,11 @@ It takes a title and such.
         @JvmStatic
         fun generateConstantsArguments(): Stream<Arguments> {
             return Stream.of(
-                of(
+                arguments(
                     true,
                     listOf("QUERY", "PERSON", "PERSON_META_DATA", "V_PERSON_META_DATA", "V_1_PERSON_META_DATA", "URL_META_DATA")
                 ),
-                of(
+                arguments(
                     false,
                     listOf("QUERY", "PERSON", "PERSONMETADATA", "VPERSONMETADATA", "V1PERSONMETADATA", "URLMETADATA")
                 ),
@@ -2711,8 +2714,8 @@ It takes a title and such.
         }
 
         @JvmStatic
-        fun generateDataClassesWithParameterizedMappedTypesWrongCases() = Stream.of(
-            of("java.util.Map<String,String,>"),
+        fun generateDataClassesWithParameterizedMappedTypesWrongCases(): Stream<Arguments> = Stream.of(
+            arguments("java.util.Map<String,String,>"),
         )
     }
 }


### PR DESCRIPTION
Clean up the way schemas are parsed, doing it only once in CodeGen. Additionally, change the
parsing code to leverage MultiSourceReader from graphql-java to avoid needing to create
one big String containing all schemas, and to maintain the source filename / location during
parsing.

Additionally, add a shared helper function, findSchemaTypeMapping, which is used by
TypeUtils and KotlinTypeUtils, but which now avoids reparsing the document.

This fixes #336.