### PR TITLE
Make GenerateJavaTask cacheable

### DIFF
--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
@@ -52,9 +52,6 @@ class CodeGen(private val config: CodeGenConfig) {
 
     @Suppress("DuplicatedCode")
     fun generate(): CodeGenResult {
-        if (config.writeToFiles) {
-            config.outputDir.toFile().deleteRecursively()
-        }
 
         val codeGenResult = when (config.language) {
             Language.JAVA -> generateJava()

--- a/graphql-dgs-codegen-gradle/src/main/kotlin/com/netflix/graphql/dgs/codegen/gradle/GenerateJavaTask.kt
+++ b/graphql-dgs-codegen-gradle/src/main/kotlin/com/netflix/graphql/dgs/codegen/gradle/GenerateJavaTask.kt
@@ -22,19 +22,24 @@ import com.netflix.graphql.dgs.codegen.CodeGen
 import com.netflix.graphql.dgs.codegen.CodeGenConfig
 import com.netflix.graphql.dgs.codegen.Language
 import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 import org.jetbrains.kotlin.gradle.plugin.KotlinPluginWrapper
 import java.io.File
 import java.nio.file.Paths
 import java.util.*
 
+@CacheableTask
 open class GenerateJavaTask : DefaultTask() {
     @Input
     var generatedSourcesDir: String = project.buildDir.absolutePath
 
+    @PathSensitive(PathSensitivity.RELATIVE)
     @InputFiles
     var schemaPaths = mutableListOf<Any>("${project.projectDir}/src/main/resources/schema")
 


### PR DESCRIPTION
Annotate GenerateJavaTask with @CacheableTask, and avoid removing the
output directory on every run.