### PR TITLE
Rename @nolog to @sensitive

### DIFF
--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/DataTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/DataTypeGenerator.kt
@@ -264,7 +264,7 @@ abstract class BaseDataTypeGenerator(internal val packageName: String, config: C
         val methodBuilder = MethodSpec.methodBuilder("toString").addAnnotation(Override::class.java).addModifiers(Modifier.PUBLIC).returns(String::class.java)
         val toStringBody = StringBuilder("return \"${javaType.build().name}{\" + ")
         fieldDefinitions.forEachIndexed { index, field ->
-            val fieldValueStatement = if (field.directives.contains("nolog")) "\"*****\"" else ReservedKeywordSanitizer.sanitize(field.name)
+            val fieldValueStatement = if (field.directives.contains("sensitive")) "\"*****\"" else ReservedKeywordSanitizer.sanitize(field.name)
             toStringBody.append(
                 """
                 "${field.name}='" + $fieldValueStatement + "'${if (index < fieldDefinitions.size - 1) "," else ""}" +

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
@@ -1382,7 +1382,7 @@ class CodeGenTest {
     }
 
     @Test
-    fun generateToStringMethodForNoLogType() {
+    fun generateToStringMethodForSensitiveType() {
 
         val schema = """
             type Query {
@@ -1392,9 +1392,9 @@ class CodeGenTest {
             type Person {
                 firstname: String
                 lastname: String
-                password: String @nolog(reason:"PII")
+                password: String @sensitive(reason:"PII")
             }
-            directive @nolog on FIELD_DEFINITION
+            directive @sensitive on FIELD_DEFINITION
         """.trimIndent()
 
         val (dataTypes) = CodeGen(
@@ -1414,16 +1414,16 @@ class CodeGenTest {
     }
 
     @Test
-    fun generateToStringMethodForNoLogInputType() {
+    fun generateToStringMethodForSensitiveInputType() {
 
         val schema = """
             type Query {
                 people(filter: PersonFilter): [Person]
             }
             input PersonFilter {
-                email: String @nolog
+                email: String @sensitive
             }
-            directive @nolog on INPUT_FIELD_DEFINITION
+            directive @sensitive on INPUT_FIELD_DEFINITION
         """.trimIndent()
 
         val (dataTypes) = CodeGen(


### PR DESCRIPTION
Renaming `@nolog` to `@sensitive` designates what a thing is instead of what to do with it. Ideally, this `@sensitive` directive could be observed in the DGS framework, and different policies apart from log masking could be applied to that data. This decouples data classifications and data handling