### PR TITLE
Use kotlin-reflect in InputValueSerializer, add Transient marker

### DIFF
--- a/dependencies.lock
+++ b/dependencies.lock
@@ -1,93 +1,93 @@
 {
     "apiDependenciesMetadata": {
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
-            "locked": "1.5.31"
+            "locked": "1.6.21"
         }
     },
     "compileClasspath": {
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
-            "locked": "1.5.31"
+            "locked": "1.6.21"
         }
     },
     "implementationDependenciesMetadata": {
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
-            "locked": "1.5.31"
+            "locked": "1.6.21"
         }
     },
     "kotlinCompilerClasspath": {
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
-            "locked": "1.5.31"
+            "locked": "1.6.21"
         }
     },
     "kotlinCompilerPluginClasspathMain": {
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
-            "locked": "1.5.31"
+            "locked": "1.6.21"
         }
     },
     "kotlinCompilerPluginClasspathTest": {
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
-            "locked": "1.5.31"
+            "locked": "1.6.21"
         }
     },
     "kotlinKlibCommonizerClasspath": {
         "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable": {
-            "locked": "1.5.31"
+            "locked": "1.6.21"
         }
     },
     "runtimeClasspath": {
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
-            "locked": "1.5.31"
+            "locked": "1.6.21"
         }
     },
     "testCompileClasspath": {
         "org.assertj:assertj-core": {
-            "locked": "3.21.0"
+            "locked": "3.22.0"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
-            "locked": "1.5.31"
+            "locked": "1.6.21"
         },
         "org.junit.jupiter:junit-jupiter": {
-            "locked": "5.8.1"
+            "locked": "5.8.2"
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.8.1"
+            "locked": "5.8.2"
         },
         "org.junit:junit-bom": {
-            "locked": "5.8.1"
+            "locked": "5.8.2"
         }
     },
     "testImplementationDependenciesMetadata": {
         "org.assertj:assertj-core": {
-            "locked": "3.21.0"
+            "locked": "3.22.0"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
-            "locked": "1.5.31"
+            "locked": "1.6.21"
         },
         "org.junit.jupiter:junit-jupiter": {
-            "locked": "5.8.1"
+            "locked": "5.8.2"
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.8.1"
+            "locked": "5.8.2"
         },
         "org.junit:junit-bom": {
-            "locked": "5.8.1"
+            "locked": "5.8.2"
         }
     },
     "testRuntimeClasspath": {
         "org.assertj:assertj-core": {
-            "locked": "3.21.0"
+            "locked": "3.22.0"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
-            "locked": "1.5.31"
+            "locked": "1.6.21"
         },
         "org.junit.jupiter:junit-jupiter": {
-            "locked": "5.8.1"
+            "locked": "5.8.2"
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.8.1"
+            "locked": "5.8.2"
         },
         "org.junit:junit-bom": {
-            "locked": "5.8.1"
+            "locked": "5.8.2"
         }
     }
 }

--- a/graphql-dgs-codegen-client-core/build.gradle
+++ b/graphql-dgs-codegen-client-core/build.gradle
@@ -26,7 +26,6 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-reflect"
     compileOnly 'com.graphql-java:graphql-java'
     compileOnly 'com.fasterxml.jackson.core:jackson-databind'
-    implementation "org.reflections:reflections"
 
     testImplementation 'com.netflix.graphql.dgs:graphql-dgs-extended-scalars'
     testImplementation 'com.graphql-java:graphql-java'

--- a/graphql-dgs-codegen-client-core/dependencies.lock
+++ b/graphql-dgs-codegen-client-core/dependencies.lock
@@ -1,182 +1,164 @@
 {
     "apiDependenciesMetadata": {
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
-            "locked": "1.5.31"
+            "locked": "1.6.21"
         }
     },
     "compileClasspath": {
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.12.3"
+            "locked": "2.13.2"
         },
         "com.graphql-java:graphql-java": {
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs-platform-dependencies": {
-            "locked": "4.9.2"
+            "locked": "4.10.1"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
-            "locked": "1.5.31"
+            "locked": "1.6.21"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
-            "locked": "1.5.31"
-        },
-        "org.reflections:reflections": {
-            "locked": "0.10.2"
+            "locked": "1.6.21"
         }
     },
     "compileOnlyDependenciesMetadata": {
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.12.3"
+            "locked": "2.13.2"
         },
         "com.graphql-java:graphql-java": {
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs-platform-dependencies": {
-            "locked": "4.9.2"
+            "locked": "4.10.1"
         }
     },
     "implementationDependenciesMetadata": {
         "com.netflix.graphql.dgs:graphql-dgs-platform-dependencies": {
-            "locked": "4.9.2"
+            "locked": "4.10.1"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
-            "locked": "1.5.31"
+            "locked": "1.6.21"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
-            "locked": "1.5.31"
-        },
-        "org.reflections:reflections": {
-            "locked": "0.10.2"
+            "locked": "1.6.21"
         }
     },
     "kotlinCompilerClasspath": {
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
-            "locked": "1.5.31"
+            "locked": "1.6.21"
         }
     },
     "kotlinCompilerPluginClasspathMain": {
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
-            "locked": "1.5.31"
+            "locked": "1.6.21"
         }
     },
     "kotlinCompilerPluginClasspathTest": {
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
-            "locked": "1.5.31"
+            "locked": "1.6.21"
         }
     },
     "kotlinKlibCommonizerClasspath": {
         "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable": {
-            "locked": "1.5.31"
+            "locked": "1.6.21"
         }
     },
     "runtimeClasspath": {
         "com.netflix.graphql.dgs:graphql-dgs-platform-dependencies": {
-            "locked": "4.9.2"
+            "locked": "4.10.1"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
-            "locked": "1.5.31"
+            "locked": "1.6.21"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
-            "locked": "1.5.31"
-        },
-        "org.reflections:reflections": {
-            "locked": "0.10.2"
+            "locked": "1.6.21"
         }
     },
     "testCompileClasspath": {
         "com.graphql-java:graphql-java": {
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs-extended-scalars": {
-            "locked": "4.9.2"
+            "locked": "4.10.1"
         },
         "com.netflix.graphql.dgs:graphql-dgs-platform-dependencies": {
-            "locked": "4.9.2"
+            "locked": "4.10.1"
         },
         "org.assertj:assertj-core": {
-            "locked": "3.21.0"
+            "locked": "3.22.0"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
-            "locked": "1.5.31"
+            "locked": "1.6.21"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
-            "locked": "1.5.31"
+            "locked": "1.6.21"
         },
         "org.junit.jupiter:junit-jupiter": {
-            "locked": "5.8.1"
+            "locked": "5.8.2"
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.8.1"
+            "locked": "5.8.2"
         },
         "org.junit:junit-bom": {
-            "locked": "5.8.1"
-        },
-        "org.reflections:reflections": {
-            "locked": "0.10.2"
+            "locked": "5.8.2"
         }
     },
     "testImplementationDependenciesMetadata": {
         "com.graphql-java:graphql-java": {
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs-extended-scalars": {
-            "locked": "4.9.2"
+            "locked": "4.10.1"
         },
         "com.netflix.graphql.dgs:graphql-dgs-platform-dependencies": {
-            "locked": "4.9.2"
+            "locked": "4.10.1"
         },
         "org.assertj:assertj-core": {
-            "locked": "3.21.0"
+            "locked": "3.22.0"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
-            "locked": "1.5.31"
+            "locked": "1.6.21"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
-            "locked": "1.5.31"
+            "locked": "1.6.21"
         },
         "org.junit.jupiter:junit-jupiter": {
-            "locked": "5.8.1"
+            "locked": "5.8.2"
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.8.1"
+            "locked": "5.8.2"
         },
         "org.junit:junit-bom": {
-            "locked": "5.8.1"
-        },
-        "org.reflections:reflections": {
-            "locked": "0.10.2"
+            "locked": "5.8.2"
         }
     },
     "testRuntimeClasspath": {
         "com.graphql-java:graphql-java": {
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs-extended-scalars": {
-            "locked": "4.9.2"
+            "locked": "4.10.1"
         },
         "com.netflix.graphql.dgs:graphql-dgs-platform-dependencies": {
-            "locked": "4.9.2"
+            "locked": "4.10.1"
         },
         "org.assertj:assertj-core": {
-            "locked": "3.21.0"
+            "locked": "3.22.0"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
-            "locked": "1.5.31"
+            "locked": "1.6.21"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
-            "locked": "1.5.31"
+            "locked": "1.6.21"
         },
         "org.junit.jupiter:junit-jupiter": {
-            "locked": "5.8.1"
+            "locked": "5.8.2"
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.8.1"
+            "locked": "5.8.2"
         },
         "org.junit:junit-bom": {
-            "locked": "5.8.1"
-        },
-        "org.reflections:reflections": {
-            "locked": "0.10.2"
+            "locked": "5.8.2"
         }
     }
 }

--- a/graphql-dgs-codegen-client-core/src/test/kotlin/com/netflix/graphql/dgs/client/codegen/GraphQLQueryRequestTest.kt
+++ b/graphql-dgs-codegen-client-core/src/test/kotlin/com/netflix/graphql/dgs/client/codegen/GraphQLQueryRequestTest.kt
@@ -33,7 +33,7 @@ class GraphQLQueryRequestTest {
         }
         val request = GraphQLQueryRequest(query)
         val result = request.serialize()
-        assertThat(result).isEqualTo("query {test(actors: \"actorA\", movies: [\"movie1\", \"movie2\"]) }")
+        assertThat(result).isEqualTo("""query {test(actors: "actorA", movies: ["movie1", "movie2"]) }""")
     }
 
     @Test
@@ -54,7 +54,7 @@ class GraphQLQueryRequestTest {
         }
         val request = GraphQLQueryRequest(query)
         val result = request.serialize()
-        assertThat(result).isEqualTo("query {test(name: \"noname\", age: 30) }")
+        assertThat(result).isEqualTo("""query {test(name: "noname", age: 30) }""")
     }
 
     @Test
@@ -64,7 +64,7 @@ class GraphQLQueryRequestTest {
         }
         val request = GraphQLQueryRequest(query)
         val result = request.serialize()
-        assertThat(result).isEqualTo("query {test(movie: {movieId:1234, name:\"testMovie\" }) }")
+        assertThat(result).isEqualTo("""query {test(movie: {movieId:1234, name:"testMovie"}) }""")
     }
 
     @Test
@@ -74,7 +74,7 @@ class GraphQLQueryRequestTest {
         }
         val request = GraphQLQueryRequest(query, MovieProjection().name().movieId())
         val result = request.serialize()
-        assertThat(result).isEqualTo("query {test(movie: {movieId:1234, name:\"testMovie\" }){ name movieId } }")
+        assertThat(result).isEqualTo("""query {test(movie: {movieId:1234, name:"testMovie"}){ name movieId } }""")
     }
 
     @Test
@@ -84,7 +84,7 @@ class GraphQLQueryRequestTest {
         }
         val request = GraphQLQueryRequest(query, MovieProjection().name().movieId())
         val result = request.serialize()
-        assertThat(result).isEqualTo("mutation {testMutation(movie: {movieId:1234, name:\"testMovie\" }){ name movieId } }")
+        assertThat(result).isEqualTo("""mutation {testMutation(movie: {movieId:1234, name:"testMovie"}){ name movieId } }""")
     }
 
     @Test
@@ -94,7 +94,7 @@ class GraphQLQueryRequestTest {
         }
         val request = GraphQLQueryRequest(query, MovieProjection().name().movieId())
         val result = request.serialize()
-        assertThat(result).isEqualTo("query TestNamedQuery {test(movie: {movieId:123, name:\"greatMovie\" }){ name movieId } }")
+        assertThat(result).isEqualTo("""query TestNamedQuery {test(movie: {movieId:123, name:"greatMovie"}){ name movieId } }""")
     }
 
     @Test
@@ -107,7 +107,7 @@ class GraphQLQueryRequestTest {
             GraphQLQueryRequest(query, MovieProjection(), mapOf(DateRange::class.java to DateRangeScalar()))
 
         val result = request.serialize()
-        assertThat(result).isEqualTo("query TestNamedQuery {test(movie: {movieId:123, name:\"greatMovie\" }, dateRange: \"01/01/2020-05/11/2021\") }")
+        assertThat(result).isEqualTo("""query TestNamedQuery {test(movie: {movieId:123, name:"greatMovie"}, dateRange: "01/01/2020-05/11/2021") }""")
     }
 
     @Test
@@ -147,7 +147,7 @@ class GraphQLQueryRequestTest {
             GraphQLQueryRequest(query, MovieProjection(), mapOf(DateRange::class.java to DateRangeScalar()))
 
         val result = request.serialize()
-        assertThat(result).isEqualTo("query TestNamedQuery {test(movie: {movieId:123, name:\"greatMovie\", window:\"01/01/2020-05/11/2021\" }) }")
+        assertThat(result).isEqualTo("""query TestNamedQuery {test(movie: {movieId:123, name:"greatMovie", window:"01/01/2020-05/11/2021"}) }""")
     }
 
     @Test
@@ -158,7 +158,7 @@ class GraphQLQueryRequestTest {
         }
         val request = GraphQLQueryRequest(query, MovieProjection(), mapOf(DateRange::class.java to DateRangeScalar()))
         val result = request.serialize()
-        assertThat(result).isEqualTo("query {test(actors: { name: \"actorA\", movies: [\"movie1\", \"movie2\"] }, movie: {movieId:123, name:\"greatMovie\", window:\"01/01/2020-05/11/2021\" }) }")
+        assertThat(result).isEqualTo("""query {test(actors: { name: "actorA", movies: ["movie1", "movie2"] }, movie: {movieId:123, name:"greatMovie", window:"01/01/2020-05/11/2021"}) }""")
     }
 }
 

--- a/graphql-dgs-codegen-client-core/src/test/kotlin/com/netflix/graphql/dgs/client/codegen/InputValueSerializerTest.kt
+++ b/graphql-dgs-codegen-client-core/src/test/kotlin/com/netflix/graphql/dgs/client/codegen/InputValueSerializerTest.kt
@@ -39,7 +39,7 @@ class InputValueSerializerTest {
         )
 
         val serialize = InputValueSerializer(mapOf(DateRange::class.java to DateRangeScalar())).serialize(movieInput)
-        assertThat(serialize).isEqualTo("{movieId:1, title:\"Some movie\", genre:ACTION, director:{name:\"The Director\" }, actor:[{name:\"Actor 1\", roleName:\"Role 1\" }, {name:\"Actor 2\", roleName:\"Role 2\" }], releaseWindow:\"01/01/2020-01/01/2021\" }")
+        assertThat(serialize).isEqualTo("{movieId:1, title:\"Some movie\", genre:ACTION, director:{name:\"The Director\"}, actor:[{name:\"Actor 1\", roleName:\"Role 1\"}, {name:\"Actor 2\", roleName:\"Role 2\"}], releaseWindow:\"01/01/2020-01/01/2021\"}")
     }
 
     @Test
@@ -58,7 +58,7 @@ class InputValueSerializerTest {
         )
 
         val serialize = InputValueSerializer(mapOf(DateRange::class.java to DateRangeScalar())).serialize(listOf(movieInput))
-        assertThat(serialize).isEqualTo("[{movieId:1, title:\"Some movie\", genre:ACTION, director:{name:\"The Director\" }, actor:[{name:\"Actor 1\", roleName:\"Role 1\" }, {name:\"Actor 2\", roleName:\"Role 2\" }], releaseWindow:\"01/01/2020-01/01/2021\" }]")
+        assertThat(serialize).isEqualTo("[{movieId:1, title:\"Some movie\", genre:ACTION, director:{name:\"The Director\"}, actor:[{name:\"Actor 1\", roleName:\"Role 1\"}, {name:\"Actor 2\", roleName:\"Role 2\"}], releaseWindow:\"01/01/2020-01/01/2021\"}]")
     }
 
     @Test
@@ -67,7 +67,7 @@ class InputValueSerializerTest {
         val movieInput = MovieInput(1)
 
         val serialize = InputValueSerializer(mapOf(DateRange::class.java to DateRangeScalar())).serialize(movieInput)
-        assertThat(serialize).isEqualTo("{movieId:1 }")
+        assertThat(serialize).isEqualTo("{movieId:1}")
     }
 
     @Test
@@ -109,7 +109,7 @@ class InputValueSerializerTest {
     @Test
     fun `Companion objects should be ignored`() {
         val serialize = InputValueSerializer().serialize(MyDataWithCompanion("some title"))
-        assertThat(serialize).isEqualTo("{title:\"some title\" }")
+        assertThat(serialize).isEqualTo("{title:\"some title\"}")
     }
 
     @Test
@@ -121,14 +121,14 @@ class InputValueSerializerTest {
     @Test
     fun `Base class properties should be found`() {
         val serialize = InputValueSerializer().serialize(MySubClass("DGS", 1500))
-        assertThat(serialize).isEqualTo("{stars:1500, name:\"DGS\" }")
+        assertThat(serialize).isEqualTo("{stars:1500, name:\"DGS\"}")
     }
 
     @Test
     fun `Date without scalar`() {
         val input = WithLocalDateTime(LocalDateTime.of(2021, 5, 13, 4, 34))
         val serialize = InputValueSerializer().serialize(input)
-        assertThat(serialize).isEqualTo("""{date:"2021-05-13T04:34" }""")
+        assertThat(serialize).isEqualTo("""{date:"2021-05-13T04:34"}""")
     }
 
     @Test
@@ -136,6 +136,27 @@ class InputValueSerializerTest {
         val input = EvilGenre.ACTION
         val serialize = InputValueSerializer().serialize(input)
         assertThat(serialize).isEqualTo("ACTION")
+    }
+
+    @Test
+    fun `overridden properties are serialized`() {
+        abstract class Base {
+            val baseField: Boolean = true
+            open val field: String = "default"
+        }
+        class QueryInput(override val field: String) : Base()
+        val serialized = InputValueSerializer().serialize(QueryInput("hello"))
+        assertThat(serialized).isEqualTo("""{field:"hello", baseField:true}""")
+    }
+
+    @Test
+    fun `properties annotated with @Transient should not be included`() {
+        data class QueryInput(val visible: String) {
+            @Transient
+            val notVisible = "do not serialize"
+        }
+        val serialized = InputValueSerializer().serialize(QueryInput("serialize me"))
+        assertThat(serialized).isEqualTo("""{visible:"serialize me"}""")
     }
 
     enum class EvilGenre {

--- a/graphql-dgs-codegen-core/build.gradle
+++ b/graphql-dgs-codegen-core/build.gradle
@@ -36,7 +36,7 @@ dependencies {
     implementation 'com.github.ajalt.clikt:clikt:3.4.+'
 
     testImplementation 'com.google.testing.compile:compile-testing:0.+'
-    testImplementation 'org.jetbrains.kotlin:kotlin-compiler:1.5.31'
+    testImplementation 'org.jetbrains.kotlin:kotlin-compiler:1.6.21'
 }
 
 application {

--- a/graphql-dgs-codegen-core/dependencies.lock
+++ b/graphql-dgs-codegen-core/dependencies.lock
@@ -1,27 +1,27 @@
 {
     "apiDependenciesMetadata": {
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
-            "locked": "1.5.31"
+            "locked": "1.6.21"
         }
     },
     "compileClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.12.3"
+            "locked": "2.13.2"
         },
         "com.github.ajalt.clikt:clikt": {
-            "locked": "3.3.0"
+            "locked": "3.4.2"
         },
         "com.graphql-java:graphql-java": {
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-client-core": {
             "project": true
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
-            "locked": "4.9.2"
+            "locked": "4.10.1"
         },
         "com.netflix.graphql.dgs:graphql-dgs-platform-dependencies": {
-            "locked": "4.9.2"
+            "locked": "4.10.1"
         },
         "com.squareup:javapoet": {
             "locked": "1.13.0"
@@ -33,7 +33,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-client-core"
             ],
-            "locked": "1.5.31"
+            "locked": "1.6.21"
         },
         "org.slf4j:slf4j-api": {
             "locked": "1.7.30"
@@ -41,22 +41,22 @@
     },
     "implementationDependenciesMetadata": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.12.3"
+            "locked": "2.13.2"
         },
         "com.github.ajalt.clikt:clikt": {
-            "locked": "3.3.0"
+            "locked": "3.4.2"
         },
         "com.graphql-java:graphql-java": {
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-client-core": {
             "project": true
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
-            "locked": "4.9.2"
+            "locked": "4.10.1"
         },
         "com.netflix.graphql.dgs:graphql-dgs-platform-dependencies": {
-            "locked": "4.9.2"
+            "locked": "4.10.1"
         },
         "com.squareup:javapoet": {
             "locked": "1.13.0"
@@ -68,7 +68,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-client-core"
             ],
-            "locked": "1.5.31"
+            "locked": "1.6.21"
         },
         "org.slf4j:slf4j-api": {
             "locked": "1.7.30"
@@ -76,45 +76,45 @@
     },
     "kotlinCompilerClasspath": {
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
-            "locked": "1.5.31"
+            "locked": "1.6.21"
         }
     },
     "kotlinCompilerPluginClasspathMain": {
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
-            "locked": "1.5.31"
+            "locked": "1.6.21"
         }
     },
     "kotlinCompilerPluginClasspathTest": {
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
-            "locked": "1.5.31"
+            "locked": "1.6.21"
         }
     },
     "kotlinKlibCommonizerClasspath": {
         "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable": {
-            "locked": "1.5.31"
+            "locked": "1.6.21"
         }
     },
     "runtimeClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.12.3"
+            "locked": "2.13.2"
         },
         "com.github.ajalt.clikt:clikt": {
-            "locked": "3.3.0"
+            "locked": "3.4.2"
         },
         "com.graphql-java:graphql-java": {
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-client-core": {
             "project": true
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
-            "locked": "4.9.2"
+            "locked": "4.10.1"
         },
         "com.netflix.graphql.dgs:graphql-dgs-platform-dependencies": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-client-core"
             ],
-            "locked": "4.9.2"
+            "locked": "4.10.1"
         },
         "com.squareup:javapoet": {
             "locked": "1.13.0"
@@ -126,45 +126,39 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-client-core"
             ],
-            "locked": "1.5.31"
+            "locked": "1.6.21"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-client-core"
             ],
-            "locked": "1.5.31"
-        },
-        "org.reflections:reflections": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-client-core"
-            ],
-            "locked": "0.10.2"
+            "locked": "1.6.21"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.30"
+            "locked": "1.7.35"
         }
     },
     "testCompileClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.12.3"
+            "locked": "2.13.2"
         },
         "com.github.ajalt.clikt:clikt": {
-            "locked": "3.3.0"
+            "locked": "3.4.2"
         },
         "com.google.testing.compile:compile-testing": {
             "locked": "0.19"
         },
         "com.graphql-java:graphql-java": {
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-client-core": {
             "project": true
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
-            "locked": "4.9.2"
+            "locked": "4.10.1"
         },
         "com.netflix.graphql.dgs:graphql-dgs-platform-dependencies": {
-            "locked": "4.9.2"
+            "locked": "4.10.1"
         },
         "com.squareup:javapoet": {
             "locked": "1.13.0"
@@ -173,25 +167,25 @@
             "locked": "1.10.2"
         },
         "org.assertj:assertj-core": {
-            "locked": "3.21.0"
+            "locked": "3.22.0"
         },
         "org.jetbrains.kotlin:kotlin-compiler": {
-            "locked": "1.5.31"
+            "locked": "1.6.21"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-client-core"
             ],
-            "locked": "1.5.31"
+            "locked": "1.6.21"
         },
         "org.junit.jupiter:junit-jupiter": {
-            "locked": "5.8.1"
+            "locked": "5.8.2"
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.8.1"
+            "locked": "5.8.2"
         },
         "org.junit:junit-bom": {
-            "locked": "5.8.1"
+            "locked": "5.8.2"
         },
         "org.slf4j:slf4j-api": {
             "locked": "1.7.30"
@@ -199,25 +193,25 @@
     },
     "testImplementationDependenciesMetadata": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.12.3"
+            "locked": "2.13.2"
         },
         "com.github.ajalt.clikt:clikt": {
-            "locked": "3.3.0"
+            "locked": "3.4.2"
         },
         "com.google.testing.compile:compile-testing": {
             "locked": "0.19"
         },
         "com.graphql-java:graphql-java": {
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-client-core": {
             "project": true
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
-            "locked": "4.9.2"
+            "locked": "4.10.1"
         },
         "com.netflix.graphql.dgs:graphql-dgs-platform-dependencies": {
-            "locked": "4.9.2"
+            "locked": "4.10.1"
         },
         "com.squareup:javapoet": {
             "locked": "1.13.0"
@@ -226,25 +220,25 @@
             "locked": "1.10.2"
         },
         "org.assertj:assertj-core": {
-            "locked": "3.21.0"
+            "locked": "3.22.0"
         },
         "org.jetbrains.kotlin:kotlin-compiler": {
-            "locked": "1.5.31"
+            "locked": "1.6.21"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-client-core"
             ],
-            "locked": "1.5.31"
+            "locked": "1.6.21"
         },
         "org.junit.jupiter:junit-jupiter": {
-            "locked": "5.8.1"
+            "locked": "5.8.2"
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.8.1"
+            "locked": "5.8.2"
         },
         "org.junit:junit-bom": {
-            "locked": "5.8.1"
+            "locked": "5.8.2"
         },
         "org.slf4j:slf4j-api": {
             "locked": "1.7.30"
@@ -252,28 +246,28 @@
     },
     "testRuntimeClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.12.3"
+            "locked": "2.13.2"
         },
         "com.github.ajalt.clikt:clikt": {
-            "locked": "3.3.0"
+            "locked": "3.4.2"
         },
         "com.google.testing.compile:compile-testing": {
             "locked": "0.19"
         },
         "com.graphql-java:graphql-java": {
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-client-core": {
             "project": true
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
-            "locked": "4.9.2"
+            "locked": "4.10.1"
         },
         "com.netflix.graphql.dgs:graphql-dgs-platform-dependencies": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-client-core"
             ],
-            "locked": "4.9.2"
+            "locked": "4.10.1"
         },
         "com.squareup:javapoet": {
             "locked": "1.13.0"
@@ -282,40 +276,34 @@
             "locked": "1.10.2"
         },
         "org.assertj:assertj-core": {
-            "locked": "3.21.0"
+            "locked": "3.22.0"
         },
         "org.jetbrains.kotlin:kotlin-compiler": {
-            "locked": "1.5.31"
+            "locked": "1.6.21"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-client-core"
             ],
-            "locked": "1.5.31"
+            "locked": "1.6.21"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-client-core"
             ],
-            "locked": "1.5.31"
+            "locked": "1.6.21"
         },
         "org.junit.jupiter:junit-jupiter": {
-            "locked": "5.8.1"
+            "locked": "5.8.2"
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.8.1"
+            "locked": "5.8.2"
         },
         "org.junit:junit-bom": {
-            "locked": "5.8.1"
-        },
-        "org.reflections:reflections": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-client-core"
-            ],
-            "locked": "0.10.2"
+            "locked": "5.8.2"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.30"
+            "locked": "1.7.35"
         }
     }
 }

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/TestUtils.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/TestUtils.kt
@@ -77,7 +77,6 @@ fun assertCompilesKotlin(files: Collection<FileSpec>): Path {
                     }.joinToString(":")
                 noStdlib = true
                 noReflect = true
-                skipRuntimeVersionCheck = true
             }
         )
         assertThat(exitCode).isEqualTo(ExitCode.OK)

--- a/graphql-dgs-codegen-gradle/dependencies.lock
+++ b/graphql-dgs-codegen-gradle/dependencies.lock
@@ -7,7 +7,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
-            "locked": "1.5.31"
+            "locked": "1.6.21"
         }
     },
     "compileClasspath": {
@@ -21,7 +21,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
-            "locked": "1.5.31"
+            "locked": "1.6.21"
         }
     },
     "compileOnlyDependenciesMetadata": {
@@ -37,27 +37,27 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
-            "locked": "1.5.31"
+            "locked": "1.6.21"
         }
     },
     "kotlinCompilerClasspath": {
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
-            "locked": "1.5.31"
+            "locked": "1.6.21"
         }
     },
     "kotlinCompilerPluginClasspathMain": {
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
-            "locked": "1.5.31"
+            "locked": "1.6.21"
         }
     },
     "kotlinCompilerPluginClasspathTest": {
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
-            "locked": "1.5.31"
+            "locked": "1.6.21"
         }
     },
     "kotlinKlibCommonizerClasspath": {
         "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable": {
-            "locked": "1.5.31"
+            "locked": "1.6.21"
         }
     },
     "runtimeClasspath": {
@@ -65,19 +65,19 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
-            "locked": "2.12.3"
+            "locked": "2.13.2"
         },
         "com.github.ajalt.clikt:clikt": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
-            "locked": "3.3.0"
+            "locked": "3.4.2"
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-client-core": {
             "firstLevelTransitive": [
@@ -92,14 +92,14 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
-            "locked": "4.9.2"
+            "locked": "4.10.1"
         },
         "com.netflix.graphql.dgs:graphql-dgs-platform-dependencies": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-client-core",
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
-            "locked": "4.9.2"
+            "locked": "4.10.1"
         },
         "com.squareup:javapoet": {
             "firstLevelTransitive": [
@@ -117,26 +117,20 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-client-core"
             ],
-            "locked": "1.5.31"
+            "locked": "1.6.21"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-client-core",
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
-            "locked": "1.5.31"
-        },
-        "org.reflections:reflections": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-client-core"
-            ],
-            "locked": "0.10.2"
+            "locked": "1.6.21"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
-            "locked": "1.7.30"
+            "locked": "1.7.35"
         }
     },
     "testCompileClasspath": {
@@ -147,22 +141,22 @@
             "project": true
         },
         "org.assertj:assertj-core": {
-            "locked": "3.21.0"
+            "locked": "3.22.0"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
-            "locked": "1.5.31"
+            "locked": "1.6.21"
         },
         "org.junit.jupiter:junit-jupiter": {
-            "locked": "5.8.1"
+            "locked": "5.8.2"
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.8.1"
+            "locked": "5.8.2"
         },
         "org.junit:junit-bom": {
-            "locked": "5.8.1"
+            "locked": "5.8.2"
         }
     },
     "testImplementationDependenciesMetadata": {
@@ -173,22 +167,22 @@
             "project": true
         },
         "org.assertj:assertj-core": {
-            "locked": "3.21.0"
+            "locked": "3.22.0"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
-            "locked": "1.5.31"
+            "locked": "1.6.21"
         },
         "org.junit.jupiter:junit-jupiter": {
-            "locked": "5.8.1"
+            "locked": "5.8.2"
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.8.1"
+            "locked": "5.8.2"
         },
         "org.junit:junit-bom": {
-            "locked": "5.8.1"
+            "locked": "5.8.2"
         }
     },
     "testRuntimeClasspath": {
@@ -196,13 +190,13 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
-            "locked": "2.12.3"
+            "locked": "2.13.2"
         },
         "com.github.ajalt.clikt:clikt": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
-            "locked": "3.3.0"
+            "locked": "3.4.2"
         },
         "com.google.guava:guava": {
             "locked": "31.0.1-jre"
@@ -211,7 +205,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-client-core": {
             "firstLevelTransitive": [
@@ -226,14 +220,14 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
-            "locked": "4.9.2"
+            "locked": "4.10.1"
         },
         "com.netflix.graphql.dgs:graphql-dgs-platform-dependencies": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-client-core",
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
-            "locked": "4.9.2"
+            "locked": "4.10.1"
         },
         "com.squareup:javapoet": {
             "firstLevelTransitive": [
@@ -248,41 +242,35 @@
             "locked": "1.10.2"
         },
         "org.assertj:assertj-core": {
-            "locked": "3.21.0"
+            "locked": "3.22.0"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-client-core"
             ],
-            "locked": "1.5.31"
+            "locked": "1.6.21"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-client-core",
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
-            "locked": "1.5.31"
+            "locked": "1.6.21"
         },
         "org.junit.jupiter:junit-jupiter": {
-            "locked": "5.8.1"
+            "locked": "5.8.2"
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.8.1"
+            "locked": "5.8.2"
         },
         "org.junit:junit-bom": {
-            "locked": "5.8.1"
-        },
-        "org.reflections:reflections": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-client-core"
-            ],
-            "locked": "0.10.2"
+            "locked": "5.8.2"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
-            "locked": "1.7.30"
+            "locked": "1.7.35"
         }
     }
 }


### PR DESCRIPTION
Use kotlin-reflect in InputValueSerializer instead of using the reflections
library. Additionally, add a `@Transient` annotation which can be used to
instruct InputValueSerializer to ignore properties on a class.