### PR TITLE
Leverage graphql-java in InputValueSerializer

### DIFF
--- a/graphql-dgs-codegen-client-core/build.gradle
+++ b/graphql-dgs-codegen-client-core/build.gradle
@@ -21,12 +21,12 @@ plugins {
 }
 
 dependencies {
+    api platform('com.netflix.graphql.dgs:graphql-dgs-platform-dependencies:latest.release')
     implementation platform('com.netflix.graphql.dgs:graphql-dgs-platform-dependencies:latest.release')
     compileOnly platform('com.netflix.graphql.dgs:graphql-dgs-platform-dependencies:latest.release')
     implementation "org.jetbrains.kotlin:kotlin-reflect"
-    compileOnly 'com.graphql-java:graphql-java'
+    api 'com.graphql-java:graphql-java'
     compileOnly 'com.fasterxml.jackson.core:jackson-databind'
 
     testImplementation 'com.netflix.graphql.dgs:graphql-dgs-extended-scalars'
-    testImplementation 'com.graphql-java:graphql-java'
 }

--- a/graphql-dgs-codegen-client-core/dependencies.lock
+++ b/graphql-dgs-codegen-client-core/dependencies.lock
@@ -1,5 +1,11 @@
 {
     "apiDependenciesMetadata": {
+        "com.graphql-java:graphql-java": {
+            "locked": "18.0"
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform-dependencies": {
+            "locked": "4.10.1"
+        },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "locked": "1.6.21"
         }
@@ -25,14 +31,14 @@
         "com.fasterxml.jackson.core:jackson-databind": {
             "locked": "2.13.2"
         },
-        "com.graphql-java:graphql-java": {
-            "locked": "18.0"
-        },
         "com.netflix.graphql.dgs:graphql-dgs-platform-dependencies": {
             "locked": "4.10.1"
         }
     },
     "implementationDependenciesMetadata": {
+        "com.graphql-java:graphql-java": {
+            "locked": "18.0"
+        },
         "com.netflix.graphql.dgs:graphql-dgs-platform-dependencies": {
             "locked": "4.10.1"
         },
@@ -64,6 +70,9 @@
         }
     },
     "runtimeClasspath": {
+        "com.graphql-java:graphql-java": {
+            "locked": "18.0"
+        },
         "com.netflix.graphql.dgs:graphql-dgs-platform-dependencies": {
             "locked": "4.10.1"
         },

--- a/graphql-dgs-codegen-client-core/src/test/kotlin/com/netflix/graphql/dgs/client/codegen/DateRangeScalar.kt
+++ b/graphql-dgs-codegen-client-core/src/test/kotlin/com/netflix/graphql/dgs/client/codegen/DateRangeScalar.kt
@@ -17,6 +17,7 @@
 package com.netflix.graphql.dgs.client.codegen
 
 import graphql.language.StringValue
+import graphql.language.Value
 import graphql.schema.Coercing
 import graphql.schema.CoercingParseLiteralException
 import graphql.schema.CoercingParseValueException
@@ -25,7 +26,7 @@ import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 
 class DateRangeScalar : Coercing<DateRange, String> {
-    private var formatter = DateTimeFormatter.ofPattern("MM/dd/yyyy")
+    private val formatter = DateTimeFormatter.ofPattern("MM/dd/yyyy")
 
     @Throws(CoercingSerializeException::class)
     override fun serialize(dataFetcherResult: Any): String {
@@ -37,7 +38,7 @@ class DateRangeScalar : Coercing<DateRange, String> {
     override fun parseValue(input: Any): DateRange {
         val split = (input as String).split("-").toTypedArray()
         val from = LocalDate.parse(split[0], formatter)
-        val to = LocalDate.parse(split[0], formatter)
+        val to = LocalDate.parse(split[1], formatter)
         return DateRange(from, to)
     }
 
@@ -45,8 +46,12 @@ class DateRangeScalar : Coercing<DateRange, String> {
     override fun parseLiteral(input: Any): DateRange {
         val split = (input as StringValue).value.split("-").toTypedArray()
         val from = LocalDate.parse(split[0], formatter)
-        val to = LocalDate.parse(split[0], formatter)
+        val to = LocalDate.parse(split[1], formatter)
         return DateRange(from, to)
+    }
+
+    override fun valueToLiteral(input: Any): Value<*> {
+        return StringValue.of(serialize(input))
     }
 }
 

--- a/graphql-dgs-codegen-client-core/src/test/kotlin/com/netflix/graphql/dgs/client/codegen/GraphQLQueryRequestTest.kt
+++ b/graphql-dgs-codegen-client-core/src/test/kotlin/com/netflix/graphql/dgs/client/codegen/GraphQLQueryRequestTest.kt
@@ -18,11 +18,13 @@
 
 package com.netflix.graphql.dgs.client.codegen
 
+import graphql.language.StringValue
+import graphql.language.Value
 import graphql.schema.Coercing
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
-import java.util.*
+import java.util.UUID
 
 class GraphQLQueryRequestTest {
     @Test
@@ -64,7 +66,7 @@ class GraphQLQueryRequestTest {
         }
         val request = GraphQLQueryRequest(query)
         val result = request.serialize()
-        assertThat(result).isEqualTo("""query {test(movie: {movieId:1234, name:"testMovie"}) }""")
+        assertThat(result).isEqualTo("""query {test(movie: {movieId : 1234, name : "testMovie"}) }""")
     }
 
     @Test
@@ -74,7 +76,7 @@ class GraphQLQueryRequestTest {
         }
         val request = GraphQLQueryRequest(query, MovieProjection().name().movieId())
         val result = request.serialize()
-        assertThat(result).isEqualTo("""query {test(movie: {movieId:1234, name:"testMovie"}){ name movieId } }""")
+        assertThat(result).isEqualTo("""query {test(movie: {movieId : 1234, name : "testMovie"}){ name movieId } }""")
     }
 
     @Test
@@ -84,7 +86,7 @@ class GraphQLQueryRequestTest {
         }
         val request = GraphQLQueryRequest(query, MovieProjection().name().movieId())
         val result = request.serialize()
-        assertThat(result).isEqualTo("""mutation {testMutation(movie: {movieId:1234, name:"testMovie"}){ name movieId } }""")
+        assertThat(result).isEqualTo("""mutation {testMutation(movie: {movieId : 1234, name : "testMovie"}){ name movieId } }""")
     }
 
     @Test
@@ -94,7 +96,7 @@ class GraphQLQueryRequestTest {
         }
         val request = GraphQLQueryRequest(query, MovieProjection().name().movieId())
         val result = request.serialize()
-        assertThat(result).isEqualTo("""query TestNamedQuery {test(movie: {movieId:123, name:"greatMovie"}){ name movieId } }""")
+        assertThat(result).isEqualTo("""query TestNamedQuery {test(movie: {movieId : 123, name : "greatMovie"}){ name movieId } }""")
     }
 
     @Test
@@ -107,7 +109,7 @@ class GraphQLQueryRequestTest {
             GraphQLQueryRequest(query, MovieProjection(), mapOf(DateRange::class.java to DateRangeScalar()))
 
         val result = request.serialize()
-        assertThat(result).isEqualTo("""query TestNamedQuery {test(movie: {movieId:123, name:"greatMovie"}, dateRange: "01/01/2020-05/11/2021") }""")
+        assertThat(result).isEqualTo("""query TestNamedQuery {test(movie: {movieId : 123, name : "greatMovie"}, dateRange: "01/01/2020-05/11/2021") }""")
     }
 
     @Test
@@ -121,7 +123,7 @@ class GraphQLQueryRequestTest {
             GraphQLQueryRequest(query, MovieProjection(), mapOf(UUID::class.java to UUIDScalar))
 
         val result = request.serialize()
-        assertThat(result).isEqualTo("query TestNamedQuery {test(id: \"$randomUUID\") }")
+        assertThat(result).isEqualTo("""query TestNamedQuery {test(id: "$randomUUID") }""")
     }
 
     object UUIDScalar : Coercing<UUID, String> {
@@ -136,6 +138,10 @@ class GraphQLQueryRequestTest {
         override fun parseLiteral(input: Any): UUID {
             return UUID.fromString(input.toString())
         }
+
+        override fun valueToLiteral(input: Any): Value<*> {
+            return StringValue.of(serialize(input))
+        }
     }
 
     @Test
@@ -147,7 +153,7 @@ class GraphQLQueryRequestTest {
             GraphQLQueryRequest(query, MovieProjection(), mapOf(DateRange::class.java to DateRangeScalar()))
 
         val result = request.serialize()
-        assertThat(result).isEqualTo("""query TestNamedQuery {test(movie: {movieId:123, name:"greatMovie", window:"01/01/2020-05/11/2021"}) }""")
+        assertThat(result).isEqualTo("""query TestNamedQuery {test(movie: {movieId : 123, name : "greatMovie", window : "01/01/2020-05/11/2021"}) }""")
     }
 
     @Test
@@ -158,7 +164,7 @@ class GraphQLQueryRequestTest {
         }
         val request = GraphQLQueryRequest(query, MovieProjection(), mapOf(DateRange::class.java to DateRangeScalar()))
         val result = request.serialize()
-        assertThat(result).isEqualTo("""query {test(actors: { name: "actorA", movies: ["movie1", "movie2"] }, movie: {movieId:123, name:"greatMovie", window:"01/01/2020-05/11/2021"}) }""")
+        assertThat(result).isEqualTo("""query {test(actors: {name : "actorA", movies : ["movie1", "movie2"]}, movie: {movieId : 123, name : "greatMovie", window : "01/01/2020-05/11/2021"}) }""")
     }
 }
 

--- a/graphql-dgs-codegen-client-core/src/test/kotlin/com/netflix/graphql/dgs/client/codegen/InputValueSerializerTest.kt
+++ b/graphql-dgs-codegen-client-core/src/test/kotlin/com/netflix/graphql/dgs/client/codegen/InputValueSerializerTest.kt
@@ -39,7 +39,7 @@ class InputValueSerializerTest {
         )
 
         val serialize = InputValueSerializer(mapOf(DateRange::class.java to DateRangeScalar())).serialize(movieInput)
-        assertThat(serialize).isEqualTo("{movieId:1, title:\"Some movie\", genre:ACTION, director:{name:\"The Director\"}, actor:[{name:\"Actor 1\", roleName:\"Role 1\"}, {name:\"Actor 2\", roleName:\"Role 2\"}], releaseWindow:\"01/01/2020-01/01/2021\"}")
+        assertThat(serialize).isEqualTo("""{movieId : 1, title : "Some movie", genre : ACTION, director : {name : "The Director"}, actor : [{name : "Actor 1", roleName : "Role 1"}, {name : "Actor 2", roleName : "Role 2"}], releaseWindow : "01/01/2020-01/01/2021"}""")
     }
 
     @Test
@@ -58,7 +58,7 @@ class InputValueSerializerTest {
         )
 
         val serialize = InputValueSerializer(mapOf(DateRange::class.java to DateRangeScalar())).serialize(listOf(movieInput))
-        assertThat(serialize).isEqualTo("[{movieId:1, title:\"Some movie\", genre:ACTION, director:{name:\"The Director\"}, actor:[{name:\"Actor 1\", roleName:\"Role 1\"}, {name:\"Actor 2\", roleName:\"Role 2\"}], releaseWindow:\"01/01/2020-01/01/2021\"}]")
+        assertThat(serialize).isEqualTo("""[{movieId : 1, title : "Some movie", genre : ACTION, director : {name : "The Director"}, actor : [{name : "Actor 1", roleName : "Role 1"}, {name : "Actor 2", roleName : "Role 2"}], releaseWindow : "01/01/2020-01/01/2021"}]""")
     }
 
     @Test
@@ -67,7 +67,7 @@ class InputValueSerializerTest {
         val movieInput = MovieInput(1)
 
         val serialize = InputValueSerializer(mapOf(DateRange::class.java to DateRangeScalar())).serialize(movieInput)
-        assertThat(serialize).isEqualTo("{movieId:1}")
+        assertThat(serialize).isEqualTo("{movieId : 1}")
     }
 
     @Test
@@ -109,7 +109,7 @@ class InputValueSerializerTest {
     @Test
     fun `Companion objects should be ignored`() {
         val serialize = InputValueSerializer().serialize(MyDataWithCompanion("some title"))
-        assertThat(serialize).isEqualTo("{title:\"some title\"}")
+        assertThat(serialize).isEqualTo("""{title : "some title"}""")
     }
 
     @Test
@@ -121,14 +121,14 @@ class InputValueSerializerTest {
     @Test
     fun `Base class properties should be found`() {
         val serialize = InputValueSerializer().serialize(MySubClass("DGS", 1500))
-        assertThat(serialize).isEqualTo("{stars:1500, name:\"DGS\"}")
+        assertThat(serialize).isEqualTo("""{stars : 1500, name : "DGS"}""")
     }
 
     @Test
     fun `Date without scalar`() {
         val input = WithLocalDateTime(LocalDateTime.of(2021, 5, 13, 4, 34))
         val serialize = InputValueSerializer().serialize(input)
-        assertThat(serialize).isEqualTo("""{date:"2021-05-13T04:34"}""")
+        assertThat(serialize).isEqualTo("""{date : "2021-05-13T04:34"}""")
     }
 
     @Test
@@ -146,7 +146,7 @@ class InputValueSerializerTest {
         }
         class QueryInput(override val field: String) : Base()
         val serialized = InputValueSerializer().serialize(QueryInput("hello"))
-        assertThat(serialized).isEqualTo("""{field:"hello", baseField:true}""")
+        assertThat(serialized).isEqualTo("""{field : "hello", baseField : true}""")
     }
 
     @Test
@@ -156,7 +156,7 @@ class InputValueSerializerTest {
             val notVisible = "do not serialize"
         }
         val serialized = InputValueSerializer().serialize(QueryInput("serialize me"))
-        assertThat(serialized).isEqualTo("""{visible:"serialize me"}""")
+        assertThat(serialized).isEqualTo("""{visible : "serialize me"}""")
     }
 
     enum class EvilGenre {

--- a/graphql-dgs-codegen-core/dependencies.lock
+++ b/graphql-dgs-codegen-core/dependencies.lock
@@ -12,6 +12,9 @@
             "locked": "3.4.2"
         },
         "com.graphql-java:graphql-java": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-client-core"
+            ],
             "locked": "18.0"
         },
         "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-client-core": {
@@ -21,6 +24,9 @@
             "locked": "4.10.1"
         },
         "com.netflix.graphql.dgs:graphql-dgs-platform-dependencies": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-client-core"
+            ],
             "locked": "4.10.1"
         },
         "com.squareup:javapoet": {
@@ -47,6 +53,9 @@
             "locked": "3.4.2"
         },
         "com.graphql-java:graphql-java": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-client-core"
+            ],
             "locked": "18.0"
         },
         "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-client-core": {
@@ -56,6 +65,9 @@
             "locked": "4.10.1"
         },
         "com.netflix.graphql.dgs:graphql-dgs-platform-dependencies": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-client-core"
+            ],
             "locked": "4.10.1"
         },
         "com.squareup:javapoet": {
@@ -102,6 +114,9 @@
             "locked": "3.4.2"
         },
         "com.graphql-java:graphql-java": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-client-core"
+            ],
             "locked": "18.0"
         },
         "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-client-core": {
@@ -149,6 +164,9 @@
             "locked": "0.19"
         },
         "com.graphql-java:graphql-java": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-client-core"
+            ],
             "locked": "18.0"
         },
         "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-client-core": {
@@ -158,6 +176,9 @@
             "locked": "4.10.1"
         },
         "com.netflix.graphql.dgs:graphql-dgs-platform-dependencies": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-client-core"
+            ],
             "locked": "4.10.1"
         },
         "com.squareup:javapoet": {
@@ -202,6 +223,9 @@
             "locked": "0.19"
         },
         "com.graphql-java:graphql-java": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-client-core"
+            ],
             "locked": "18.0"
         },
         "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-client-core": {
@@ -211,6 +235,9 @@
             "locked": "4.10.1"
         },
         "com.netflix.graphql.dgs:graphql-dgs-platform-dependencies": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-client-core"
+            ],
             "locked": "4.10.1"
         },
         "com.squareup:javapoet": {
@@ -255,6 +282,9 @@
             "locked": "0.19"
         },
         "com.graphql-java:graphql-java": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-client-core"
+            ],
             "locked": "18.0"
         },
         "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-client-core": {

--- a/graphql-dgs-codegen-gradle/dependencies.lock
+++ b/graphql-dgs-codegen-gradle/dependencies.lock
@@ -75,6 +75,7 @@
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
+                "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-client-core",
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
             "locked": "18.0"
@@ -203,6 +204,7 @@
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
+                "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-client-core",
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
             ],
             "locked": "18.0"


### PR DESCRIPTION
Use AstPrinter and Value classes from graphql-java in InputValueSerializer
instead of manually converting values to Strings.