### PR TITLE
Leverage graphql-java in GraphQLQueryRequest and ProjectionSerializer

### DIFF
--- a/graphql-dgs-codegen-client-core/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/GraphQLQuery.kt
+++ b/graphql-dgs-codegen-client-core/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/GraphQLQuery.kt
@@ -16,10 +16,11 @@
 
 package com.netflix.graphql.dgs.client.codegen
 
-import java.util.*
+import graphql.language.VariableDefinition
 
 abstract class GraphQLQuery(val operation: String, val name: String?) {
-    val input: MutableMap<String, Any> = LinkedHashMap()
+    val input: MutableMap<String, Any> = mutableMapOf()
+    val variableDefinitions = mutableListOf<VariableDefinition>()
 
     constructor(operation: String) : this(operation, null)
     constructor() : this("query")

--- a/graphql-dgs-codegen-client-core/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/InputValueSerializer.kt
+++ b/graphql-dgs-codegen-client-core/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/InputValueSerializer.kt
@@ -68,9 +68,13 @@ class InputValueSerializer(private val scalars: Map<Class<*>, Coercing<*, *>> = 
         return AstPrinter.printAst(toValue(input))
     }
 
-    private fun toValue(input: Any?): Value<*> {
+    fun toValue(input: Any?): Value<*> {
         if (input == null) {
             return NullValue.newNullValue().build()
+        }
+
+        if (input is Value<*>) {
+            return input
         }
 
         if (input::class.java in scalars) {

--- a/graphql-dgs-codegen-client-core/src/test/kotlin/com/netflix/graphql/dgs/client/codegen/ProjectionSerializerTest.kt
+++ b/graphql-dgs-codegen-client-core/src/test/kotlin/com/netflix/graphql/dgs/client/codegen/ProjectionSerializerTest.kt
@@ -36,8 +36,15 @@ internal class ProjectionSerializerTest {
 
         val projection = ShowsProjectionRoot()
             .reviews(3, OffsetDateTime.of(2021, 6, 16, 15, 20, 0, 0, ZoneOffset.UTC)).starScore().root
-        val serialize = projectionSerializer.serialize(projection)
-        assertThat(serialize).isEqualTo("{ reviews(minScore: 3, since: \"2021-06-16T15:20:00Z\")   { starScore } }")
+        val serialized = projectionSerializer.serialize(projection)
+
+        assertThat(serialized).isEqualTo(
+            """{
+          |  reviews(minScore: 3, since: "2021-06-16T15:20:00Z") {
+          |    starScore
+          |  }
+          |}""".trimMargin()
+        )
     }
 
     @Test
@@ -48,21 +55,48 @@ internal class ProjectionSerializerTest {
             .moveId().title().releaseYear()
             .reviews(username = "Foo", score = 10).username().score()
         // when
-        val serialize = ProjectionSerializer(InputValueSerializer()).serialize(root, isFragment = true)
+        val serialized = ProjectionSerializer(InputValueSerializer()).serialize(root)
         // then
-        assertThat(serialize).isEqualTo("""... on Entities { ... on Movie { __typename moveId title releaseYear reviews(username: "Foo", score: 10)   { username score } } }""")
+        assertThat(serialized).isEqualTo(
+            """{
+            |  ... on Movie {
+            |    __typename
+            |    moveId
+            |    title
+            |    releaseYear
+            |    reviews(username: "Foo", score: 10) {
+            |      username
+            |      score
+            |    }
+            |  }
+            |}""".trimMargin()
+        )
     }
 
     @Test
     fun `Projection for entity with no explicit schema type`() {
         // given
         val root = EntitiesProjectionRoot()
-        root.onMovie(Optional.empty())
+            .onMovie(Optional.empty())
             .moveId().title().releaseYear()
             .reviews(username = "Foo", score = 10).username().score()
+            .root()
         // when
-        val serialize = ProjectionSerializer(InputValueSerializer()).serialize(root, isFragment = true)
+        val serialized = ProjectionSerializer(InputValueSerializer()).serialize(root)
         // then
-        assertThat(serialize).isEqualTo("""... on Entities { ... on EntitiesMovieKey { __typename moveId title releaseYear reviews(username: "Foo", score: 10)   { username score } } }""")
+        assertThat(serialized).isEqualTo(
+            """{
+            |  ... on EntitiesMovieKey {
+            |    __typename
+            |    moveId
+            |    title
+            |    releaseYear
+            |    reviews(username: "Foo", score: 10) {
+            |      username
+            |      score
+            |    }
+            |  }
+            |}""".trimMargin()
+        )
     }
 }


### PR DESCRIPTION
Instead of manually building the GraphQL query via String concatenation,
lean on graphql-java to build up the query, and AstPrinter to serialize
it to a String.

- Change GraphQLQueryRequest to build an OperationDefinition and then serialize
it with AstPrinter.
- Add variableDefinitions field to GraphQLQueryRequest to allow specifying variables.
- Expose toValue method on InputValueSerializer.
- Add toSelectionSet method on ProjectionSerializer, which builds a SelectionSet
  based on the supplied projection, including field selections and any inline
  fragments.
- Update EntitiesGraphQLQuery to use GraphQLQueryRequest's variableDefinitions
  property, instead of relying on a hacky method of including the variable
  definitions in the operation name.