### PR TITLE
feat: generate constants for query input arguments

### DIFF
--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ConstantsGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ConstantsGenerator.kt
@@ -30,11 +30,7 @@ import com.squareup.javapoet.FieldSpec
 import com.squareup.javapoet.JavaFile
 import com.squareup.javapoet.TypeName
 import com.squareup.javapoet.TypeSpec
-import graphql.language.Document
-import graphql.language.InputObjectTypeDefinition
-import graphql.language.InterfaceTypeDefinition
-import graphql.language.ObjectTypeDefinition
-import graphql.language.UnionTypeDefinition
+import graphql.language.*
 import javax.lang.model.element.Modifier
 
 class ConstantsGenerator(private val config: CodeGenConfig, private val document: Document) {
@@ -55,6 +51,7 @@ class ConstantsGenerator(private val config: CodeGenConfig, private val document
 
                 fields.forEach { field ->
                     addFieldNameConstant(constantsType, field.name)
+                    addQueryInputArgument(constantsType, field)
                 }
 
                 javaType.addType(constantsType.build())
@@ -137,5 +134,16 @@ class ConstantsGenerator(private val config: CodeGenConfig, private val document
             )
                 .addModifiers(Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL).initializer(""""$fieldName"""").build()
         )
+    }
+
+    private fun addQueryInputArgument(constantsType: TypeSpec.Builder, field: FieldDefinition) {
+        val inputFields = field.inputValueDefinitions
+        if (inputFields.isNotEmpty()) {
+            val inputConstantsType = createConstantTypeBuilder(config, field.name + "_INPUT_ARGUMENT")
+            inputFields.forEach { inputField ->
+                addFieldNameConstant(inputConstantsType, inputField.name)
+            }
+            constantsType.addType(inputConstantsType.build())
+        }
     }
 }

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinConstantsGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinConstantsGenerator.kt
@@ -30,11 +30,7 @@ import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.TypeSpec
-import graphql.language.Document
-import graphql.language.InputObjectTypeDefinition
-import graphql.language.InterfaceTypeDefinition
-import graphql.language.ObjectTypeDefinition
-import graphql.language.UnionTypeDefinition
+import graphql.language.*
 
 class KotlinConstantsGenerator(private val config: CodeGenConfig, private val document: Document) {
     fun generate(): CodeGenResult {
@@ -53,6 +49,7 @@ class KotlinConstantsGenerator(private val config: CodeGenConfig, private val do
 
                 fields.filter(ReservedKeywordFilter.filterInvalidNames).forEach { field ->
                     addFieldName(constantsType, field.name)
+                    addQueryInputArgument(constantsType, field)
                 }
 
                 baseConstantsType.addType(constantsType.build())
@@ -126,6 +123,20 @@ class KotlinConstantsGenerator(private val config: CodeGenConfig, private val do
     }
 
     private fun addFieldName(constantsType: TypeSpec.Builder, name: String) {
-        constantsType.addProperty(PropertySpec.builder(name.capitalized(), String::class).addModifiers(KModifier.CONST).initializer(""""$name"""").build())
+        constantsType.addProperty(
+            PropertySpec.builder(name.capitalized(), String::class).addModifiers(KModifier.CONST)
+                .initializer(""""$name"""").build()
+        )
+    }
+
+    private fun addQueryInputArgument(constantsType: TypeSpec.Builder, field: FieldDefinition) {
+        val inputFields = field.inputValueDefinitions
+        if (inputFields.isNotEmpty()) {
+            val inputConstantsType = createConstantTypeBuilder(config, field.name + "_INPUT_ARGUMENT")
+            inputFields.forEach { inputField ->
+                addFieldName(inputConstantsType, inputField.name)
+            }
+            constantsType.addType(inputConstantsType.build())
+        }
     }
 }

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
@@ -742,6 +742,39 @@ class KotlinCodeGenTest {
     }
 
     @Test
+    fun generateConstantsForQueryInputArguments() {
+        val schema = """
+            type Query {
+                shows(titleFilter: String,moveFilter: MovieFilter): [Show]
+            }
+            
+            type Show {
+                name: String
+            }
+            
+            input MovieFilter {
+                title: String
+                genre: Genre
+                language: Language
+                tags: [String]
+            }
+        """.trimIndent()
+
+        val result = CodeGen(
+            CodeGenConfig(
+                schemas = setOf(schema),
+                packageName = basePackageName,
+                language = Language.KOTLIN,
+            )
+        ).generate()
+        val type = result.kotlinConstants[0].members[0] as TypeSpec
+        assertThat(type.typeSpecs).extracting("name").containsExactly("QUERY", "SHOW", "MOVIEFILTER")
+        assertThat(type.typeSpecs[0].typeSpecs).extracting("name").containsExactly("SHOWS_INPUT_ARGUMENT")
+        assertThat(type.typeSpecs[0].typeSpecs[0].propertySpecs).extracting("name")
+            .containsExactly("TitleFilter", "MoveFilter")
+    }
+
+    @Test
     fun generateEnum() {
 
         val schema = """

--- a/graphql-dgs-codegen-core/src/test/resources/kotlin2/constantsForInputTypes/expected/DgsConstants.kt
+++ b/graphql-dgs-codegen-core/src/test/resources/kotlin2/constantsForInputTypes/expected/DgsConstants.kt
@@ -9,6 +9,10 @@ public object DgsConstants {
     public const val TYPE_NAME: String = "Query"
 
     public const val People: String = "people"
+
+    public object PEOPLE_INPUT_ARGUMENT {
+      public const val Filter: String = "filter"
+    }
   }
 
   public object PERSON {

--- a/graphql-dgs-codegen-core/src/test/resources/kotlin2/constantsWithExtendedInputTypes/expected/DgsConstants.kt
+++ b/graphql-dgs-codegen-core/src/test/resources/kotlin2/constantsWithExtendedInputTypes/expected/DgsConstants.kt
@@ -9,6 +9,10 @@ public object DgsConstants {
     public const val TYPE_NAME: String = "Query"
 
     public const val People: String = "people"
+
+    public object PEOPLE_INPUT_ARGUMENT {
+      public const val Filter: String = "filter"
+    }
   }
 
   public object PERSON {

--- a/graphql-dgs-codegen-core/src/test/resources/kotlin2/dataClassDocs/expected/DgsConstants.kt
+++ b/graphql-dgs-codegen-core/src/test/resources/kotlin2/dataClassDocs/expected/DgsConstants.kt
@@ -9,6 +9,10 @@ public object DgsConstants {
     public const val TYPE_NAME: String = "Query"
 
     public const val Search: String = "search"
+
+    public object SEARCH_INPUT_ARGUMENT {
+      public const val MovieFilter: String = "movieFilter"
+    }
   }
 
   public object MOVIE {

--- a/graphql-dgs-codegen-core/src/test/resources/kotlin2/dataClassFieldDocs/expected/DgsConstants.kt
+++ b/graphql-dgs-codegen-core/src/test/resources/kotlin2/dataClassFieldDocs/expected/DgsConstants.kt
@@ -9,6 +9,10 @@ public object DgsConstants {
     public const val TYPE_NAME: String = "Query"
 
     public const val Search: String = "search"
+
+    public object SEARCH_INPUT_ARGUMENT {
+      public const val MovieFilter: String = "movieFilter"
+    }
   }
 
   public object MOVIE {

--- a/graphql-dgs-codegen-core/src/test/resources/kotlin2/input/expected/DgsConstants.kt
+++ b/graphql-dgs-codegen-core/src/test/resources/kotlin2/input/expected/DgsConstants.kt
@@ -9,6 +9,10 @@ public object DgsConstants {
     public const val TYPE_NAME: String = "Query"
 
     public const val Movies: String = "movies"
+
+    public object MOVIES_INPUT_ARGUMENT {
+      public const val Filter: String = "filter"
+    }
   }
 
   public object MOVIEFILTER {

--- a/graphql-dgs-codegen-core/src/test/resources/kotlin2/inputWithExtendedType/expected/DgsConstants.kt
+++ b/graphql-dgs-codegen-core/src/test/resources/kotlin2/inputWithExtendedType/expected/DgsConstants.kt
@@ -9,6 +9,10 @@ public object DgsConstants {
     public const val TYPE_NAME: String = "Query"
 
     public const val Movies: String = "movies"
+
+    public object MOVIES_INPUT_ARGUMENT {
+      public const val Filter: String = "filter"
+    }
   }
 
   public object MOVIEFILTER {

--- a/graphql-dgs-codegen-core/src/test/resources/kotlin2/projectionWithPrimitiveAndArgs/expected/DgsConstants.kt
+++ b/graphql-dgs-codegen-core/src/test/resources/kotlin2/projectionWithPrimitiveAndArgs/expected/DgsConstants.kt
@@ -9,6 +9,14 @@ public object DgsConstants {
     public const val TYPE_NAME: String = "Query"
 
     public const val String: String = "string"
+
+    public object STRING_INPUT_ARGUMENT {
+      public const val A1: String = "a1"
+
+      public const val A2: String = "a2"
+
+      public const val A3: String = "a3"
+    }
   }
 
   public object I {

--- a/graphql-dgs-codegen-core/src/test/resources/kotlin2/projectionWithTypeAndArgs/expected/DgsConstants.kt
+++ b/graphql-dgs-codegen-core/src/test/resources/kotlin2/projectionWithTypeAndArgs/expected/DgsConstants.kt
@@ -9,6 +9,14 @@ public object DgsConstants {
     public const val TYPE_NAME: String = "Query"
 
     public const val Person: String = "person"
+
+    public object PERSON_INPUT_ARGUMENT {
+      public const val A1: String = "a1"
+
+      public const val A2: String = "a2"
+
+      public const val A3: String = "a3"
+    }
   }
 
   public object EMPLOYEE {

--- a/graphql-dgs-codegen-core/src/test/resources/kotlin2/unionTypesWithoutInterfaceCanDeserialize/expected/DgsConstants.kt
+++ b/graphql-dgs-codegen-core/src/test/resources/kotlin2/unionTypesWithoutInterfaceCanDeserialize/expected/DgsConstants.kt
@@ -9,6 +9,10 @@ public object DgsConstants {
     public const val TYPE_NAME: String = "Query"
 
     public const val Search: String = "search"
+
+    public object SEARCH_INPUT_ARGUMENT {
+      public const val Text: String = "text"
+    }
   }
 
   public object HUMAN {


### PR DESCRIPTION
Generate constants for query input arguments
`DgsConstants.QUERY.SHOWS_INPUT_ARGUMENT.TitleFilter` maybe is better than `DgsConstants.SHOWS.TitleFilter`
Resolve https://github.com/Netflix/dgs-codegen/issues/18