### PR TITLE
feat: allow to customize code generation to not include a constructor…

### DIFF
--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
@@ -437,6 +437,7 @@ data class CodeGenConfig(
     /** If enabled, the names of the classes available via the DgsConstant class will be snake cased.*/
     val snakeCaseConstantNames: Boolean = false,
     val generateInterfaceSetters: Boolean = true,
+    var generateAllConstructor: Boolean = true,
 ) {
     val packageNameClient: String = "$packageName.$subPackageNameClient"
 

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/DataTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/DataTypeGenerator.kt
@@ -95,7 +95,7 @@ class DataTypeGenerator(private val config: CodeGenConfig, private val document:
                     }
                 )
 
-            return generate(name, unionTypes + implements, fieldDefinitions, definition.description)
+            return generate(name, unionTypes + implements, fieldDefinitions, definition.description, config.generateAllConstructor)
                 .merge(interfaceCodeGenResult)
         }
 
@@ -140,7 +140,7 @@ class InputTypeGenerator(private val config: CodeGenConfig, document: Document) 
             }
             Field(name = it.name, type = typeUtils.findReturnType(it.type), initialValue = defaultValue, description = it.description, directives = it.directives.map { directive -> directive.name })
         }.plus(extensions.flatMap { it.inputValueDefinitions }.map { Field(it.name, typeUtils.findReturnType(it.type)) })
-        return generate(name, emptyList(), fieldDefinitions, definition.description)
+        return generate(name, emptyList(), fieldDefinitions, definition.description, config.generateAllConstructor)
     }
 }
 
@@ -153,7 +153,8 @@ abstract class BaseDataTypeGenerator(internal val packageName: String, config: C
         name: String,
         interfaces: List<String>,
         fields: List<Field>,
-        description: Description? = null
+        description: Description? = null,
+        generateAllConstructor: Boolean,
     ): CodeGenResult {
         val javaType = TypeSpec.classBuilder(name)
             .addModifiers(Modifier.PUBLIC)
@@ -176,7 +177,7 @@ abstract class BaseDataTypeGenerator(internal val packageName: String, config: C
 
         addDefaultConstructor(javaType)
 
-        if (fields.isNotEmpty()) {
+        if (generateAllConstructor && fields.isNotEmpty()) {
             addParameterizedConstructor(fields, javaType)
         }
 

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/EntitiesRepresentationTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/EntitiesRepresentationTypeGenerator.kt
@@ -114,7 +114,8 @@ class EntitiesRepresentationTypeGenerator(
             name = representationName,
             interfaces = emptyList(),
             fields = fieldDefinitions.plus(typeName),
-            description = null
+            description = null,
+            config.generateAllConstructor,
         )
         generatedRepresentations[representationName] = typeUtils.qualifyName(representationName)
         // Merge all results.

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinDataTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinDataTypeGenerator.kt
@@ -191,7 +191,10 @@ abstract class AbstractKotlinDataTypeGenerator(packageName: String, protected va
                 parameterSpec.addModifiers(KModifier.OVERRIDE)
             }
 
-            constructorBuilder.addParameter(parameterSpec.build())
+            if (config.generateAllConstructor) {
+                constructorBuilder.addParameter(parameterSpec.build())
+            }
+
             val propertySpecBuilder = PropertySpec.builder(field.name, returnType)
             if (field.description != null) {
                 propertySpecBuilder.addKdoc("%L", field.description.sanitizeKdoc())

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
@@ -759,7 +759,7 @@ class CodeGenTest {
             )
         ).generate()
 
-        assertThat(dataTypes[0].typeSpec.methodSpecs).filteredOn { it.name.equals("<init>") && it.parameters.size>0 }.hasSize(0)
+        assertThat(dataTypes[0].typeSpec.methodSpecs).filteredOn { it.name.equals("<init>") && it.parameters.size> 0 }.hasSize(0)
         assertCompilesJava(dataTypes)
     }
 
@@ -783,7 +783,7 @@ class CodeGenTest {
             )
         ).generate()
 
-        assertThat(dataTypes[0].typeSpec.methodSpecs).filteredOn { it.name.equals("<init>") && it.parameters.size>0 }.hasSize(1)
+        assertThat(dataTypes[0].typeSpec.methodSpecs).filteredOn { it.name.equals("<init>") && it.parameters.size> 0 }.hasSize(1)
         assertCompilesJava(dataTypes)
     }
 

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
@@ -739,6 +739,55 @@ class CodeGenTest {
     }
 
     @Test
+    fun generateDataClassWithNoAllConstructor() {
+        val schema = """
+            type Query {
+                cars: [Car]
+            }
+            
+            type Car {
+                make: String
+                model: String
+            }
+        """.trimIndent()
+
+        val (dataTypes) = CodeGen(
+            CodeGenConfig(
+                schemas = setOf(schema),
+                packageName = basePackageName,
+                generateAllConstructor = false
+            )
+        ).generate()
+
+        assertThat(dataTypes[0].typeSpec.methodSpecs).filteredOn { it.name.equals("<init>") && it.parameters.size>0 }.hasSize(0)
+        assertCompilesJava(dataTypes)
+    }
+
+    @Test
+    fun generateDataClassWithAllConstructor() {
+        val schema = """
+            type Query {
+                cars: [Car]
+            }
+            
+            type Car {
+                make: String
+                model: String
+            }
+        """.trimIndent()
+
+        val (dataTypes) = CodeGen(
+            CodeGenConfig(
+                schemas = setOf(schema),
+                packageName = basePackageName,
+            )
+        ).generate()
+
+        assertThat(dataTypes[0].typeSpec.methodSpecs).filteredOn { it.name.equals("<init>") && it.parameters.size>0 }.hasSize(1)
+        assertCompilesJava(dataTypes)
+    }
+
+    @Test
     fun generateEnum() {
         val schema = """
             type Query {

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
@@ -716,6 +716,58 @@ class KotlinCodeGenTest {
     }
 
     @Test
+    fun generateDataClassWithNoAllConstructor() {
+        val schema = """
+            type Query {
+                cars: [Car]
+            }
+            
+            type Car {
+                make: String
+                model: String
+            }
+        """.trimIndent()
+
+        val result = CodeGen(
+            CodeGenConfig(
+                schemas = setOf(schema),
+                packageName = basePackageName,
+                language = Language.KOTLIN,
+                generateAllConstructor = false
+            )
+        ).generate().kotlinDataTypes
+        val type = result[0].members[0] as TypeSpec
+        assertThat(type.primaryConstructor?.parameters?.size ?: 1).isEqualTo(0)
+        assertCompilesKotlin(result)
+    }
+
+    @Test
+    fun generateDataClassWithAllConstructor() {
+        val schema = """
+            type Query {
+                cars: [Car]
+            }
+            
+            type Car {
+                make: String
+                model: String
+            }
+        """.trimIndent()
+
+        val result = CodeGen(
+            CodeGenConfig(
+                schemas = setOf(schema),
+                packageName = basePackageName,
+                language = Language.KOTLIN,
+                generateAllConstructor = true
+            )
+        ).generate().kotlinDataTypes
+        val type = result[0].members[0] as TypeSpec
+        assertThat(type.primaryConstructor?.parameters?.size ?: 0).isGreaterThan(0)
+        assertCompilesKotlin(result)
+    }
+
+    @Test
     fun generateEnum() {
 
         val schema = """


### PR DESCRIPTION
allow to customize code generation to not include a constructor with all arguments
`generateAllConstructor = false`
Resolve https://github.com/Netflix/dgs-framework/issues/193