### PR TITLE
The generateAllConstructor flag will only affect Java Types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,6 @@
 name: CI
 
-on:
-  push:
+on: [push, pull_request]
 
 jobs:
   build:

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
@@ -437,7 +437,7 @@ data class CodeGenConfig(
     /** If enabled, the names of the classes available via the DgsConstant class will be snake cased.*/
     val snakeCaseConstantNames: Boolean = false,
     val generateInterfaceSetters: Boolean = true,
-    var generateAllConstructor: Boolean = true,
+    var javaGenerateAllConstructor: Boolean = true,
     val implementSerializable: Boolean = false,
 ) {
     val packageNameClient: String = "$packageName.$subPackageNameClient"

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/EntitiesRepresentationTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/EntitiesRepresentationTypeGenerator.kt
@@ -28,8 +28,8 @@ import org.slf4j.LoggerFactory
 
 @Suppress("UNCHECKED_CAST")
 class EntitiesRepresentationTypeGenerator(
-    val config: CodeGenConfig,
-    private val document: Document
+    config: CodeGenConfig,
+    document: Document
 ) : BaseDataTypeGenerator(config.packageNameClient, config, document) {
 
     fun generate(definition: ObjectTypeDefinition, generatedRepresentations: MutableMap<String, Any>): CodeGenResult {
@@ -114,9 +114,7 @@ class EntitiesRepresentationTypeGenerator(
             name = representationName,
             interfaces = emptyList(),
             fields = fieldDefinitions.plus(typeName),
-            config.implementSerializable,
             description = null,
-            config.generateAllConstructor,
         )
         generatedRepresentations[representationName] = typeUtils.qualifyName(representationName)
         // Merge all results.

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinEntitiesRepresentationTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinEntitiesRepresentationTypeGenerator.kt
@@ -92,7 +92,7 @@ class KotlinEntitiesRepresentationTypeGenerator(config: CodeGenConfig, document:
                 }
             }
 
-        return generate(name, fieldDefinitions + typeName, emptyList(), config.implementSerializable, document).merge(result)
+        return generate(name, fieldDefinitions + typeName, emptyList(), document).merge(result)
     }
 
     override fun getPackageName(): String {

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
@@ -756,7 +756,7 @@ class CodeGenTest {
             CodeGenConfig(
                 schemas = setOf(schema),
                 packageName = basePackageName,
-                generateAllConstructor = false
+                javaGenerateAllConstructor = false
             )
         ).generate()
 

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
@@ -716,7 +716,7 @@ class KotlinCodeGenTest {
     }
 
     @Test
-    fun generateDataClassWithNoAllConstructor() {
+    fun `The javaGenerateAllConstructor flag is not applicable for Kotlin`() {
         val schema = """
             type Query {
                 cars: [Car]
@@ -733,33 +733,7 @@ class KotlinCodeGenTest {
                 schemas = setOf(schema),
                 packageName = basePackageName,
                 language = Language.KOTLIN,
-                generateAllConstructor = false
-            )
-        ).generate().kotlinDataTypes
-        val type = result[0].members[0] as TypeSpec
-        assertThat(type.primaryConstructor?.parameters?.size ?: 1).isEqualTo(0)
-        assertCompilesKotlin(result)
-    }
-
-    @Test
-    fun generateDataClassWithAllConstructor() {
-        val schema = """
-            type Query {
-                cars: [Car]
-            }
-            
-            type Car {
-                make: String
-                model: String
-            }
-        """.trimIndent()
-
-        val result = CodeGen(
-            CodeGenConfig(
-                schemas = setOf(schema),
-                packageName = basePackageName,
-                language = Language.KOTLIN,
-                generateAllConstructor = true
+                javaGenerateAllConstructor = false
             )
         ).generate().kotlinDataTypes
         val type = result[0].members[0] as TypeSpec


### PR DESCRIPTION
The case of supporting `generateAllConstructor` in Kotlin is very week since GraphQL Types are generated as _Kotlin Data Types. Because of that we decided to not support it as part of Kotlin. We also decided to rename the flag from `generateAllConstructor` to `javaGenerateAllConstructor`, such that it describes it is explicit to Java.