### PR TITLE
Align Kotlin Entity Client Generation with what is supported for Java

### DIFF
--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/EntitiesRepresentationTypeGeneratorUtils.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/EntitiesRepresentationTypeGeneratorUtils.kt
@@ -1,0 +1,120 @@
+/*
+ *
+ *  Copyright 2020 Netflix, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package com.netflix.graphql.dgs.codegen.generators
+
+import com.netflix.graphql.dgs.codegen.CodeGenConfig
+import com.netflix.graphql.dgs.codegen.CodeGenResult
+import graphql.language.*
+
+object EntitiesRepresentationTypeGeneratorUtils {
+
+    fun interface RepresentationGenerator {
+        fun generate(
+            definitionName: String,
+            representationName: String,
+            fields: List<FieldDefinition>,
+            generatedRepresentations: MutableMap<String, Any>,
+            keyFields: Map<String, Any>
+        ): CodeGenResult
+    }
+
+    fun generate(
+        config: CodeGenConfig,
+        definition: ObjectTypeDefinition,
+        generatedRepresentations: MutableMap<String, Any>,
+        representationGenerator: RepresentationGenerator
+    ): CodeGenResult {
+        if (config.skipEntityQueries) {
+            return CodeGenResult()
+        }
+        val representationName = toRepresentationName(definition)
+        if (representationName in generatedRepresentations) {
+            return CodeGenResult()
+        }
+
+        val directiveArg =
+            definition
+                .getDirectives("key")
+                .map { it.argumentsByName["fields"]?.value as StringValue }
+                .map { it.value }
+
+        val keyFields = parseKeyDirectiveValue(directiveArg)
+
+        return representationGenerator.generate(
+            definition.name,
+            representationName,
+            definition.fieldDefinitions,
+            generatedRepresentations,
+            keyFields
+        )
+    }
+
+    fun findType(typeName: Type<*>, document: Document): TypeDefinition<*>? {
+        return when (typeName) {
+            is NonNullType -> {
+                findType(typeName.type, document)
+            }
+            is ListType -> {
+                findType(typeName.type, document)
+            }
+            else -> document.definitions.filterIsInstance<TypeDefinition<*>>()
+                .find { it.name == (typeName as TypeName).name }
+        }
+    }
+
+    fun parseKeyDirectiveValue(keyDirective: List<String>): Map<String, Any> {
+        data class Node(val key: String, val map: MutableMap<String, Any>, val parent: Node?)
+
+        val keys = keyDirective.map { ds ->
+            ds.map { if (it == '{' || it == '}') " $it " else "$it" }
+                .joinToString("", "", "")
+                .split(" ")
+        }.flatten()
+
+        // handle simple keys and nested keys by constructing the path to each  key
+        // e.g. type Movie @key(fields: "movieId") or type MovieCast @key(fields: movie { movieId } actors { name } }
+        val mappedKeyTypes = mutableMapOf<String, Any>()
+        var parent = Node("", mappedKeyTypes, null)
+        var current = Node("", mappedKeyTypes, null)
+        keys.filter { it != " " && it != "" }
+            .forEach {
+                when (it) {
+                    "{" -> {
+                        // push a new map for the next level
+                        val previous = parent
+                        parent = current
+                        current = Node("", current.map[current.key] as MutableMap<String, Any>, previous)
+                    }
+                    "}" -> {
+                        // pop back to parent level
+                        current = parent
+                        parent = parent.parent!!
+                    }
+                    else -> {
+                        // make an entry at the current level
+                        current.map.putIfAbsent(it, mutableMapOf<String, Any>())
+                        current = Node(it, current.map, parent)
+                    }
+                }
+            }
+        return mappedKeyTypes
+    }
+
+    fun toRepresentationName(definition: TypeDefinition<*>) = "${definition.name}Representation"
+}

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/EntitiesRepresentationTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/EntitiesRepresentationTypeGenerator.kt
@@ -21,9 +21,16 @@ package com.netflix.graphql.dgs.codegen.generators.java
 import com.netflix.graphql.dgs.codegen.CodeGenConfig
 import com.netflix.graphql.dgs.codegen.CodeGenResult
 import com.netflix.graphql.dgs.codegen.fieldDefinitions
+import com.netflix.graphql.dgs.codegen.generators.EntitiesRepresentationTypeGeneratorUtils
+import com.netflix.graphql.dgs.codegen.generators.EntitiesRepresentationTypeGeneratorUtils.findType
+import com.netflix.graphql.dgs.codegen.generators.EntitiesRepresentationTypeGeneratorUtils.toRepresentationName
 import com.squareup.javapoet.ClassName
 import com.squareup.javapoet.CodeBlock
-import graphql.language.*
+import graphql.language.Document
+import graphql.language.EnumTypeDefinition
+import graphql.language.FieldDefinition
+import graphql.language.InterfaceTypeDefinition
+import graphql.language.ObjectTypeDefinition
 import org.slf4j.LoggerFactory
 
 @Suppress("UNCHECKED_CAST")
@@ -32,27 +39,15 @@ class EntitiesRepresentationTypeGenerator(
     document: Document
 ) : BaseDataTypeGenerator(config.packageNameClient, config, document) {
 
-    fun generate(definition: ObjectTypeDefinition, generatedRepresentations: MutableMap<String, Any>): CodeGenResult {
-        if (config.skipEntityQueries) {
-            return CodeGenResult()
-        }
-        val representationName = toRepresentationName(definition)
-        if (generatedRepresentations.containsKey(representationName)) {
-            return CodeGenResult()
-        }
-        val directiveArg =
-            definition
-                .getDirectives("key")
-                .map { it.argumentsByName["fields"]?.value as StringValue }
-                .map { it.value }
-
-        val keyFields = parseKeyDirectiveValue(directiveArg)
-        return generateRepresentations(
-            definition.name,
-            representationName,
-            definition.fieldDefinitions,
+    fun generate(
+        definition: ObjectTypeDefinition,
+        generatedRepresentations: MutableMap<String, Any>
+    ): CodeGenResult {
+        return EntitiesRepresentationTypeGeneratorUtils.generate(
+            config,
+            definition,
             generatedRepresentations,
-            keyFields
+            this::generateRepresentations
         )
     }
 
@@ -74,7 +69,6 @@ class EntitiesRepresentationTypeGenerator(
                 .filter { keyFields.containsKey(it.name) }
                 .map {
                     val type = findType(it.type, document)
-
                     if (type != null &&
                         (
                             type is ObjectTypeDefinition ||
@@ -105,8 +99,7 @@ class EntitiesRepresentationTypeGenerator(
                         }
                         Field(it.name, ClassName.get("", fieldRepresentationType))
                     } else {
-                        val returnType = typeUtils.findReturnType(it.type)
-                        Field(it.name, returnType)
+                        Field(it.name, typeUtils.findReturnType(it.type))
                     }
                 }
         // Generate base type representation...
@@ -121,61 +114,8 @@ class EntitiesRepresentationTypeGenerator(
         return parentRepresentationCodeGen.merge(fieldsCodeGenAccumulator)
     }
 
-    private fun findType(typeName: Type<*>, document: Document): TypeDefinition<*>? {
-        return when (typeName) {
-            is NonNullType -> {
-                findType(typeName.type, document)
-            }
-            is ListType -> {
-                findType(typeName.type, document)
-            }
-            else -> document.definitions.filterIsInstance<TypeDefinition<*>>()
-                .find { it.name == (typeName as TypeName).name }
-        }
-    }
-
-    private fun parseKeyDirectiveValue(keyDirective: List<String>): Map<String, Any> {
-        data class Node(val key: String, val map: MutableMap<String, Any>, val parent: Node?)
-
-        val keys = keyDirective.map { ds ->
-            ds.map { if (it == '{' || it == '}') " $it " else "$it" }
-                .joinToString("", "", "")
-                .split(" ")
-        }.flatten()
-
-        // handle simple keys and nested keys by constructing the path to each  key
-        // e.g. type Movie @key(fields: "movieId") or type MovieCast @key(fields: movie { movieId } actors { name } }
-        val mappedKeyTypes = mutableMapOf<String, Any>()
-        var parent = Node("", mappedKeyTypes, null)
-        var current = Node("", mappedKeyTypes, null)
-        keys.filter { it != " " && it != "" }
-            .forEach {
-                when (it) {
-                    "{" -> {
-                        // push a new map for the next level
-                        val previous = parent
-                        parent = current
-                        current = Node("", current.map[current.key] as MutableMap<String, Any>, previous)
-                    }
-                    "}" -> {
-                        // pop back to parent level
-                        current = parent
-                        parent = parent.parent!!
-                    }
-                    else -> {
-                        // make an entry at the current level
-                        current.map.putIfAbsent(it, mutableMapOf<String, Any>())
-                        current = Node(it, current.map, parent)
-                    }
-                }
-            }
-        return mappedKeyTypes
-    }
-
     companion object {
         private val logger: org.slf4j.Logger =
             LoggerFactory.getLogger(EntitiesRepresentationTypeGenerator::class.java)
-
-        private fun toRepresentationName(definition: TypeDefinition<*>) = "${definition.name}Representation"
     }
 }

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinDataTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinDataTypeGenerator.kt
@@ -68,10 +68,6 @@ class KotlinDataTypeGenerator(config: CodeGenConfig, document: Document) :
         val interfaces = definition.implements
         return generate(definition.name, fields, interfaces, document, definition.description)
     }
-
-    override fun getPackageName(): String {
-        return config.packageNameTypes
-    }
 }
 
 class KotlinInputTypeGenerator(config: CodeGenConfig, document: Document) :
@@ -119,10 +115,6 @@ class KotlinInputTypeGenerator(config: CodeGenConfig, document: Document) :
             is ParameterizedTypeName -> typeArguments[0].className
             else -> TODO()
         }
-
-    override fun getPackageName(): String {
-        return config.packageNameTypes
-    }
 }
 
 internal data class Field(
@@ -245,5 +237,7 @@ abstract class AbstractKotlinDataTypeGenerator(
         return CodeGenResult(kotlinDataTypes = listOf(fileSpec))
     }
 
-    abstract fun getPackageName(): String
+    open fun getPackageName(): String {
+        return config.packageNameTypes
+    }
 }

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinEntitiesRepresentationTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinEntitiesRepresentationTypeGenerator.kt
@@ -21,6 +21,9 @@ package com.netflix.graphql.dgs.codegen.generators.kotlin
 import com.netflix.graphql.dgs.codegen.CodeGenConfig
 import com.netflix.graphql.dgs.codegen.CodeGenResult
 import com.netflix.graphql.dgs.codegen.fieldDefinitions
+import com.netflix.graphql.dgs.codegen.generators.EntitiesRepresentationTypeGeneratorUtils
+import com.netflix.graphql.dgs.codegen.generators.EntitiesRepresentationTypeGeneratorUtils.findType
+import com.netflix.graphql.dgs.codegen.generators.EntitiesRepresentationTypeGeneratorUtils.toRepresentationName
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.LIST
@@ -28,126 +31,109 @@ import com.squareup.kotlinpoet.ParameterizedTypeName
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.STRING
 import graphql.language.Document
+import graphql.language.EnumTypeDefinition
 import graphql.language.FieldDefinition
 import graphql.language.InterfaceTypeDefinition
-import graphql.language.ListType
-import graphql.language.NonNullType
 import graphql.language.ObjectTypeDefinition
-import graphql.language.StringValue
-import graphql.language.Type
-import graphql.language.TypeDefinition
-import graphql.language.TypeName
+import org.slf4j.LoggerFactory
 
 class KotlinEntitiesRepresentationTypeGenerator(config: CodeGenConfig, document: Document) :
     AbstractKotlinDataTypeGenerator(packageName = config.packageNameClient, config = config, document = document) {
 
-    fun generate(definition: ObjectTypeDefinition, generatedRepresentations: MutableMap<String, Any>): CodeGenResult {
-        val name = "${definition.name}Representation"
-        if (name in generatedRepresentations) {
-            return CodeGenResult()
-        }
-        val directiveArg = definition.getDirectives("key")
-            .asSequence()
-            .map { it.argumentsByName["fields"]?.value as StringValue }
-            .map { it.value }
-            .toList()
-        val keyFields = parseKeyDirectiveValue(directiveArg)
-        return generateRepresentations(definition.name, definition.fieldDefinitions, generatedRepresentations, keyFields)
+    fun generate(
+        definition: ObjectTypeDefinition,
+        generatedRepresentations: MutableMap<String, Any>
+    ): CodeGenResult {
+        return EntitiesRepresentationTypeGeneratorUtils.generate(
+            config,
+            definition,
+            generatedRepresentations,
+            this::generateRepresentations
+        )
     }
 
     private fun generateRepresentations(
         definitionName: String,
+        representationName: String,
         fields: List<FieldDefinition>,
         generatedRepresentations: MutableMap<String, Any>,
         keyFields: Map<String, Any>
     ): CodeGenResult {
-        val name = "${definitionName}Representation"
-        if (name in generatedRepresentations) {
+        if (representationName in generatedRepresentations) {
             return CodeGenResult()
         }
-
-        var result = CodeGenResult()
+        var fieldsCodeGenAccumulator = CodeGenResult()
         // generate representations of entity types that have @key, including the __typename field, and the  key fields
         val typeName = Field("__typename", STRING, false, CodeBlock.of("%S", definitionName))
-        val fieldDefinitions = fields
-            .filter {
-                keyFields.containsKey(it.name)
-            }
-            .map {
-                val type = findType(it.type, document)
-                val fieldType = typeUtils.findReturnType(it.type)
-                if (type != null && (type is ObjectTypeDefinition || type is InterfaceTypeDefinition)) {
-                    val representationType = fieldType.toString().replace(type.name, "${type.name}Representation").removeSuffix("?")
-                    if (!generatedRepresentations.containsKey(name)) {
-                        result = generateRepresentations(type.name, type.fieldDefinitions(), generatedRepresentations, keyFields[it.name] as Map<String, Any>)
-                    }
-                    generatedRepresentations["${type.name}Representation"] = representationType
-                    if (fieldType is ParameterizedTypeName && fieldType.rawType.simpleName == "List") {
-                        Field(it.name, LIST.parameterizedBy(ClassName(getPackageName(), "${type.name}Representation")), typeUtils.isNullable(it.type))
-                    } else {
-                        Field(it.name, ClassName(getPackageName(), representationType), typeUtils.isNullable(it.type))
-                    }
-                } else {
-                    Field(it.name, typeUtils.findReturnType(it.type), typeUtils.isNullable(it.type))
-                }
-            }
+        val fieldDefinitions =
+            fields
+                .filter { keyFields.containsKey(it.name) }
+                .map {
+                    val type = findType(it.type, document)
+                    if (type != null &&
+                        (
+                            type is ObjectTypeDefinition ||
+                                type is InterfaceTypeDefinition ||
+                                type is EnumTypeDefinition
+                            )
+                    ) {
+                        val fieldType = typeUtils.findReturnType(it.type)
+                        val fieldTypeRepresentationName = toRepresentationName(type)
+                        val fieldRepresentationType =
+                            fieldType
+                                .toString()
+                                .replace(type.name, fieldTypeRepresentationName).removeSuffix("?")
 
-        return generate(name, fieldDefinitions + typeName, emptyList(), document).merge(result)
+                        if (generatedRepresentations.containsKey(fieldTypeRepresentationName)) {
+                            logger.trace("Representation fo $fieldTypeRepresentationName was already generated.")
+                        } else {
+                            logger.debug("Generating entity representation {} ...", fieldTypeRepresentationName)
+                            val fieldTypeRepresentation = generateRepresentations(
+                                type.name,
+                                fieldTypeRepresentationName,
+                                type.fieldDefinitions(),
+                                generatedRepresentations,
+                                keyFields[it.name] as Map<String, Any>
+                            )
+                            fieldsCodeGenAccumulator = fieldsCodeGenAccumulator.merge(fieldTypeRepresentation)
+                            generatedRepresentations[fieldTypeRepresentationName] = fieldRepresentationType
+                        }
+                        if (fieldType is ParameterizedTypeName && fieldType.rawType.simpleName == "List") {
+                            Field(
+                                it.name,
+                                LIST.parameterizedBy(ClassName(getPackageName(), fieldTypeRepresentationName)),
+                                typeUtils.isNullable(it.type)
+                            )
+                        } else {
+                            Field(
+                                it.name,
+                                ClassName(getPackageName(), fieldTypeRepresentationName),
+                                typeUtils.isNullable(it.type)
+                            )
+                        }
+                    } else {
+                        Field(it.name, typeUtils.findReturnType(it.type), typeUtils.isNullable(it.type))
+                    }
+                }
+        // Generate base type representation...
+        val parentRepresentationCodeGen = super.generate(
+            name = representationName,
+            interfaces = emptyList(),
+            fields = fieldDefinitions.plus(typeName),
+            description = null,
+            document = document
+        )
+        generatedRepresentations[representationName] = typeUtils.qualifyName(representationName)
+        // Merge all results.
+        return parentRepresentationCodeGen.merge(fieldsCodeGenAccumulator)
     }
 
     override fun getPackageName(): String {
         return config.packageNameClient
     }
 
-    private fun findType(typeName: Type<*>, document: Document): TypeDefinition<*>? {
-        return when (typeName) {
-            is NonNullType -> {
-                findType(typeName.type, document)
-            }
-            is ListType -> {
-                findType(typeName.type, document)
-            }
-            else -> document.definitions.filterIsInstance<TypeDefinition<*>>().find { it.name == (typeName as TypeName).name }
-        }
-    }
-
-    private fun parseKeyDirectiveValue(keyDirective: List<String>): Map<String, Any> {
-        data class Node(val key: String, val map: MutableMap<String, Any>, val parent: Node?)
-
-        val keys = keyDirective.map { ds ->
-            ds.map { if (it == '{' || it == '}') " $it " else "$it" }
-                .joinToString("", "", "")
-                .split(" ")
-        }.flatten()
-
-        // handle simple keys and nested keys by constructing the path to each  key
-        // e.g. type Movie @key(fields: "movieId") or type MovieCast @key(fields: movie { movieId } actors { name } }
-        val mappedKeyTypes = mutableMapOf<String, Any>()
-        var parent = Node("", mappedKeyTypes, null)
-        var current = Node("", mappedKeyTypes, null)
-        keys.filter { it != " " && it != "" }
-            .forEach {
-                when (it) {
-                    "{" -> {
-                        // set the key and corresponding map for the next level
-                        val previous = parent
-                        parent = current
-                        if (current.map.containsKey(current.key)) {
-                            current = Node("", current.map[current.key] as MutableMap<String, Any>, previous)
-                        }
-                    }
-                    "}" -> {
-                        // pop back to parent level
-                        current = parent
-                        parent = parent.parent!!
-                    }
-                    else -> {
-                        // make an entry at the current level
-                        current.map.putIfAbsent(it, mutableMapOf<String, Any>())
-                        current = Node(it, current.map, parent)
-                    }
-                }
-            }
-        return mappedKeyTypes
+    companion object {
+        private val logger: org.slf4j.Logger =
+            LoggerFactory.getLogger(KotlinEntitiesRepresentationTypeGenerator::class.java)
     }
 }

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinTypeUtils.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinTypeUtils.kt
@@ -49,6 +49,10 @@ class KotlinTypeUtils(private val packageName: String, private val config: CodeG
         "Header" to "com.netflix.graphql.types.core.resolvers.PresignedUrlResponse.Header".toKtTypeName()
     )
 
+    fun qualifyName(name: String): String {
+        return "$packageName.$name"
+    }
+
     fun findReturnType(fieldType: Type<*>): KtTypeName {
         val visitor = object : NodeVisitorStub() {
             override fun visitTypeName(node: TypeName, context: TraverserContext<Node<Node<*>>>): TraversalControl {

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinEntitiesClientApiGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinEntitiesClientApiGenTest.kt
@@ -20,7 +20,6 @@ package com.netflix.graphql.dgs.codegen
 
 import org.assertj.core.api.Assertions.*
 import org.assertj.core.data.Index
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 
 class KotlinEntitiesClientApiGenTest {
@@ -323,9 +322,7 @@ class KotlinEntitiesClientApiGenTest {
         codeGenResult.assertCompile()
     }
 
-    // TODO MovieGenreRepresentation is missing.
     @Test
-    @Disabled
     fun `Entities can have keys that are enums`() {
         val schema = """
             type Query {
@@ -362,9 +359,7 @@ class KotlinEntitiesClientApiGenTest {
         codeGenResult.assertCompile()
     }
 
-    // TODO understand why we are missing Person and MovieGenre Representations
     @Test
-    @Disabled
     fun `Entities can have the @key directive used multiple times`() {
         val schema = """
             type Movie @key(fields: "id genre") @key(fields: "id actor{ id }") @key(fields: "id location { id }") {


### PR DESCRIPTION
This PR aligns, for Kotlin, what we already support for Java Entity Client generation.
As part of this PR we are introducing the EntitiesRepresentationTypeGeneratorUtils.kt as a mechanism to share
code between the Java and Kotlin Entity Client generators.