### PR TITLE
Append an explicit newline at the end of each schema file before concatenating schemas.

### DIFF
--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
@@ -104,6 +104,7 @@ class CodeGen(private val config: CodeGenConfig) {
             .filter { it.isFile }
 
         for (schemaFile in schemaFiles) {
+            schemaFile.appendText("\n")
             readerBuilder.reader(schemaFile.reader(), schemaFile.name)
         }
 


### PR DESCRIPTION
This fixes issues with schema parsing for files that don't have a newline at the end.