### PR TITLE
Adding option to create @Generated annotation on generated code

### DIFF
--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
@@ -413,7 +413,7 @@ data class CodeGenConfig(
     val generateInterfaceSetters: Boolean = true,
     var javaGenerateAllConstructor: Boolean = true,
     val implementSerializable: Boolean = false,
-    val generateGeneratedAnnotation: Boolean = false
+    val addGeneratedAnnotation: Boolean = false
 ) {
     val packageNameClient: String = "$packageName.$subPackageNameClient"
 
@@ -438,7 +438,7 @@ data class CodeGenConfig(
             ${if (skipEntityQueries) "--skip-entities" else ""}
             ${typeMapping.map { "--type-mapping ${it.key}=${it.value}" }.joinToString("\n")}           
             ${if (shortProjectionNames) "--short-projection-names" else ""}
-            ${if (generateGeneratedAnnotation) "--generate-generated-annotation" else ""}
+            ${if (addGeneratedAnnotation) "--add-generated-annotation" else ""}
             ${schemas.joinToString(" ")}
         """.trimIndent()
     }

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
@@ -438,6 +438,7 @@ data class CodeGenConfig(
             ${if (skipEntityQueries) "--skip-entities" else ""}
             ${typeMapping.map { "--type-mapping ${it.key}=${it.value}" }.joinToString("\n")}           
             ${if (shortProjectionNames) "--short-projection-names" else ""}
+            ${if (generateGeneratedAnnotation) "--generate-generated-annotation" else ""}
             ${schemas.joinToString(" ")}
         """.trimIndent()
     }

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
@@ -412,7 +412,8 @@ data class CodeGenConfig(
     val snakeCaseConstantNames: Boolean = false,
     val generateInterfaceSetters: Boolean = true,
     var javaGenerateAllConstructor: Boolean = true,
-    val implementSerializable: Boolean = false
+    val implementSerializable: Boolean = false,
+    val generateGeneratedAnnotation: Boolean = false
 ) {
     val packageNameClient: String = "$packageName.$subPackageNameClient"
 

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ClientApiGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ClientApiGenerator.kt
@@ -79,6 +79,7 @@ class ClientApiGenerator(private val config: CodeGenConfig, private val document
     private fun createQueryClass(it: FieldDefinition, operation: String, methodNames: MutableSet<String>): JavaFile {
         val methodName = generateMethodName(it.name.capitalized(), operation.lowercase(), methodNames)
         val javaType = TypeSpec.classBuilder(methodName)
+            .addOptionalGeneratedAnnotation(config)
             .addModifiers(Modifier.PUBLIC).superclass(ClassName.get(GraphQLQuery::class.java))
 
         if (it.description != null) {
@@ -101,6 +102,7 @@ class ClientApiGenerator(private val config: CodeGenConfig, private val document
         val setOfStringType = ParameterizedTypeName.get(setType, ClassName.get(String::class.java))
 
         val builderClass = TypeSpec.classBuilder("Builder").addModifiers(Modifier.STATIC, Modifier.PUBLIC)
+            .addOptionalGeneratedAnnotation(config)
             .addMethod(
                 MethodSpec.methodBuilder("build")
                     .addModifiers(Modifier.PUBLIC)
@@ -213,6 +215,7 @@ class ClientApiGenerator(private val config: CodeGenConfig, private val document
     private fun createRootProjection(type: TypeDefinition<*>, prefix: String): CodeGenResult {
         val clazzName = "${prefix}ProjectionRoot"
         val javaType = TypeSpec.classBuilder(clazzName)
+            .addOptionalGeneratedAnnotation(config)
             .addModifiers(Modifier.PUBLIC).superclass(ClassName.get(BaseProjectionNode::class.java))
 
         if (generatedClasses.contains(clazzName)) return CodeGenResult() else generatedClasses.add(clazzName)
@@ -318,6 +321,7 @@ class ClientApiGenerator(private val config: CodeGenConfig, private val document
     private fun createEntitiesRootProjection(federatedTypes: List<ObjectTypeDefinition>): CodeGenResult {
         val clazzName = "EntitiesProjectionRoot"
         val javaType = TypeSpec.classBuilder(clazzName)
+            .addOptionalGeneratedAnnotation(config)
             .addModifiers(Modifier.PUBLIC).superclass(ClassName.get(BaseProjectionNode::class.java))
 
         if (generatedClasses.contains(clazzName)) return CodeGenResult() else generatedClasses.add(clazzName)
@@ -446,6 +450,7 @@ class ClientApiGenerator(private val config: CodeGenConfig, private val document
         val clazzName = "${prefix}Projection"
         if (generatedClasses.contains(clazzName)) return null else generatedClasses.add(clazzName)
         val javaType = TypeSpec.classBuilder(clazzName)
+            .addOptionalGeneratedAnnotation(config)
             .addModifiers(Modifier.PUBLIC)
             .superclass(ParameterizedTypeName.get(className, ClassName.get(getPackageName(), parent.name), ClassName.get(getPackageName(), root.name)))
             .addMethod(

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ConstantsGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ConstantsGenerator.kt
@@ -36,6 +36,7 @@ import javax.lang.model.element.Modifier
 class ConstantsGenerator(private val config: CodeGenConfig, private val document: Document) {
     fun generate(): CodeGenResult {
         val javaType = TypeSpec.classBuilder("DgsConstants")
+            .addOptionalGeneratedAnnotation(config)
             .addModifiers(Modifier.PUBLIC)
 
         document.definitions.filterIsInstance<ObjectTypeDefinition>()

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/DataTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/DataTypeGenerator.kt
@@ -174,6 +174,7 @@ abstract class BaseDataTypeGenerator(
         description: Description? = null
     ): CodeGenResult {
         val javaType = TypeSpec.classBuilder(name)
+            .addOptionalGeneratedAnnotation(config)
             .addModifiers(Modifier.PUBLIC)
 
         if (config.implementSerializable) {
@@ -215,6 +216,7 @@ abstract class BaseDataTypeGenerator(
 
     internal fun generateInterface(name: String, superInterfaces: List<Type<*>>, fields: List<Field>): CodeGenResult {
         val javaType = TypeSpec.interfaceBuilder(name)
+            .addOptionalGeneratedAnnotation(config)
             .addModifiers(Modifier.PUBLIC)
 
         superInterfaces.forEach {

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/DatafetcherGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/DatafetcherGenerator.kt
@@ -64,6 +64,7 @@ class DatafetcherGenerator(private val config: CodeGenConfig, private val docume
             .addStatement("return $returnValue")
 
         val javaType = TypeSpec.classBuilder(clazzName)
+            .addOptionalGeneratedAnnotation(config)
             .addModifiers(Modifier.PUBLIC)
             .addAnnotation(DgsComponent::class.java)
             .addMethod(methodSpec.build())

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/EnumTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/EnumTypeGenerator.kt
@@ -42,6 +42,7 @@ class EnumTypeGenerator(private val config: CodeGenConfig) {
             TypeSpec
                 .enumBuilder(definition.name)
                 .addModifiers(Modifier.PUBLIC)
+                .addOptionalGeneratedAnnotation(config)
 
         if (definition.description != null) {
             javaType.addJavadoc(definition.description.sanitizeJavaDoc())

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/InterfaceGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/InterfaceGenerator.kt
@@ -49,6 +49,7 @@ class InterfaceGenerator(private val config: CodeGenConfig, private val document
 
         logger.info("Generating type ${definition.name}")
         val javaType = TypeSpec.interfaceBuilder(definition.name)
+            .addOptionalGeneratedAnnotation(config)
             .addModifiers(Modifier.PUBLIC)
 
         if (definition.description != null) {

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/JavaPoetUtils.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/JavaPoetUtils.kt
@@ -139,7 +139,7 @@ private fun generatedAnnotation(): AnnotationSpec? {
 
 fun TypeSpec.Builder.addOptionalGeneratedAnnotation(config: CodeGenConfig): TypeSpec.Builder =
     apply {
-        if (config.generateGeneratedAnnotation) {
+        if (config.addGeneratedAnnotation) {
             generatedAnnotation()?.also { it -> addAnnotation(it) }
         }
     }

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/UnionTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/UnionTypeGenerator.kt
@@ -36,6 +36,7 @@ class UnionTypeGenerator(private val config: CodeGenConfig) {
         }
 
         val javaType = TypeSpec.interfaceBuilder(definition.name)
+            .addOptionalGeneratedAnnotation(config)
             .addModifiers(Modifier.PUBLIC)
 
         val memberTypes = definition.memberTypes.plus(extensions.flatMap { it.memberTypes }).asSequence()

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinConstantsGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinConstantsGenerator.kt
@@ -35,6 +35,7 @@ import graphql.language.*
 class KotlinConstantsGenerator(private val config: CodeGenConfig, private val document: Document) {
     fun generate(): CodeGenResult {
         val baseConstantsType = TypeSpec.objectBuilder("DgsConstants")
+            .addOptionalGeneratedAnnotation(config)
 
         document.definitions.filterIsInstance<ObjectTypeDefinition>()
             .excludeSchemaTypeExtension()
@@ -121,6 +122,7 @@ class KotlinConstantsGenerator(private val config: CodeGenConfig, private val do
             }
 
         return TypeSpec.objectBuilder(className)
+            .addOptionalGeneratedAnnotation(config)
     }
 
     private fun addFieldName(constantsType: TypeSpec.Builder, name: String) {

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinDataTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinDataTypeGenerator.kt
@@ -144,6 +144,7 @@ abstract class AbstractKotlinDataTypeGenerator(
         description: Description? = null
     ): CodeGenResult {
         val kotlinType = TypeSpec.classBuilder(name)
+            .addOptionalGeneratedAnnotation(config)
 
         if (config.implementSerializable) {
             kotlinType.addSuperinterface(ClassName.bestGuess(Serializable::class.java.name))

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinEnumTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinEnumTypeGenerator.kt
@@ -39,7 +39,9 @@ class KotlinEnumTypeGenerator(private val config: CodeGenConfig) {
 
         logger.info("Generating enum type ${definition.name}")
 
-        val kotlinType = TypeSpec.classBuilder(definition.name).addModifiers(KModifier.ENUM)
+        val kotlinType = TypeSpec.classBuilder(definition.name)
+            .addOptionalGeneratedAnnotation(config)
+            .addModifiers(KModifier.ENUM)
 
         if (definition.description != null) {
             kotlinType.addKdoc("%L", definition.description.sanitizeKdoc())

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinInterfaceTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinInterfaceTypeGenerator.kt
@@ -47,6 +47,7 @@ class KotlinInterfaceTypeGenerator(private val config: CodeGenConfig, private va
         logger.info("Generating type {}", definition.name)
 
         val interfaceBuilder = TypeSpec.interfaceBuilder(definition.name)
+            .addOptionalGeneratedAnnotation(config)
         if (definition.description != null) {
             interfaceBuilder.addKdoc("%L", definition.description.sanitizeKdoc())
         }

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinPoetUtils.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinPoetUtils.kt
@@ -237,7 +237,7 @@ fun TypeSpec.Builder.addEnumConstants(enumSpecs: Iterable<TypeSpec>): TypeSpec.B
 
 fun TypeSpec.Builder.addOptionalGeneratedAnnotation(config: CodeGenConfig): TypeSpec.Builder =
     apply {
-        if (config.generateGeneratedAnnotation) {
+        if (config.addGeneratedAnnotation) {
             generatedAnnotation()?.also { addAnnotation(it) }
         }
     }

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinPoetUtils.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinPoetUtils.kt
@@ -24,6 +24,10 @@ import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonTypeInfo
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder
+import com.netflix.graphql.dgs.codegen.CodeGen
+import com.netflix.graphql.dgs.codegen.CodeGenConfig
+import com.netflix.graphql.dgs.codegen.generators.shared.generatedAnnotationClassName
+import com.netflix.graphql.dgs.codegen.generators.shared.generatedDate
 import com.squareup.kotlinpoet.*
 import graphql.introspection.Introspection
 import graphql.language.Description
@@ -125,6 +129,18 @@ fun jsonBuilderAnnotation(): AnnotationSpec {
         .build()
 }
 
+@Suppress("DuplicatedCode") // not duplicated - this is KotlinPoet, the other is JavaPoet
+private fun generatedAnnotation(): AnnotationSpec? {
+    val generatedAnnotation = generatedAnnotationClassName
+        ?.let { ClassName.bestGuess(it) }
+        ?: return null
+
+    return AnnotationSpec.builder(generatedAnnotation)
+        .addMember("value = [%S]", CodeGen::class.qualifiedName!!)
+        .addMember("date = %S", generatedDate)
+        .build()
+}
+
 /**
  * Generate a [JsonProperty] annotation for the supplied
  * field name.
@@ -218,3 +234,10 @@ fun FunSpec.Builder.addControlFlow(
 fun TypeSpec.Builder.addEnumConstants(enumSpecs: Iterable<TypeSpec>): TypeSpec.Builder = apply {
     enumSpecs.map { addEnumConstant(it.name!!, it) }
 }
+
+fun TypeSpec.Builder.addOptionalGeneratedAnnotation(config: CodeGenConfig): TypeSpec.Builder =
+    apply {
+        if (config.generateGeneratedAnnotation) {
+            generatedAnnotation()?.also { addAnnotation(it) }
+        }
+    }

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinUnionTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinUnionTypeGenerator.kt
@@ -38,6 +38,7 @@ class KotlinUnionTypeGenerator(private val config: CodeGenConfig) {
         }
 
         val interfaceBuilder = TypeSpec.interfaceBuilder(definition.name)
+            .addOptionalGeneratedAnnotation(config)
 
         val memberTypes = definition.memberTypes.plus(extensions.flatMap { it.memberTypes }).asSequence()
             .filterIsInstance<TypeName>()

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin2/GenerateKotlin2ClientTypes.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin2/GenerateKotlin2ClientTypes.kt
@@ -22,6 +22,7 @@ import com.netflix.graphql.dgs.codegen.CodeGenConfig
 import com.netflix.graphql.dgs.codegen.GraphQLProjection
 import com.netflix.graphql.dgs.codegen.filterSkipped
 import com.netflix.graphql.dgs.codegen.generators.kotlin.ReservedKeywordFilter
+import com.netflix.graphql.dgs.codegen.generators.kotlin.addOptionalGeneratedAnnotation
 import com.netflix.graphql.dgs.codegen.generators.shared.SchemaExtensionsUtils
 import com.netflix.graphql.dgs.codegen.generators.shared.excludeSchemaTypeExtension
 import com.netflix.graphql.dgs.codegen.shouldSkip
@@ -135,6 +136,7 @@ fun generateKotlin2ClientTypes(
 
             // create the projection class
             val typeSpec = TypeSpec.classBuilder(typeName)
+                .addOptionalGeneratedAnnotation(config)
                 .superclass(GraphQLProjection::class)
                 // we can't ask for `__typename` on a `Subscription` object
                 .apply {
@@ -167,6 +169,7 @@ fun generateKotlin2ClientTypes(
                 .plus(extensionTypes.flatMap { it.memberTypes })
 
             val typeSpec = TypeSpec.classBuilder(typeName)
+                .addOptionalGeneratedAnnotation(config)
                 .superclass(GraphQLProjection::class)
                 .addFunctions(
                     implementations.map { subclass ->
@@ -183,6 +186,7 @@ fun generateKotlin2ClientTypes(
     val topLevelTypes = typeLookup.operations.filterKeys { typeLookup.objectTypeNames.contains(it) }
 
     val clientSpec = TypeSpec.objectBuilder("DgsClient")
+        .addOptionalGeneratedAnnotation(config)
         .addFunctions(
             topLevelTypes.map { (type, op) ->
 

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin2/GenerateKotlin2DataTypes.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin2/GenerateKotlin2DataTypes.kt
@@ -22,6 +22,7 @@ import com.netflix.graphql.dgs.codegen.CodeGenConfig
 import com.netflix.graphql.dgs.codegen.filterSkipped
 import com.netflix.graphql.dgs.codegen.generators.kotlin.ReservedKeywordFilter
 import com.netflix.graphql.dgs.codegen.generators.kotlin.addControlFlow
+import com.netflix.graphql.dgs.codegen.generators.kotlin.addOptionalGeneratedAnnotation
 import com.netflix.graphql.dgs.codegen.generators.kotlin.disableJsonTypeInfoAnnotation
 import com.netflix.graphql.dgs.codegen.generators.kotlin.jsonBuilderAnnotation
 import com.netflix.graphql.dgs.codegen.generators.kotlin.jsonDeserializeAnnotation
@@ -112,6 +113,7 @@ fun generateKotlin2DataTypes(
             // create a builder for this class; default to lambda that throws if accessed
             val builderClassName = ClassName(config.packageNameTypes, typeDefinition.name, "Builder")
             val builder = TypeSpec.classBuilder("Builder")
+                .addOptionalGeneratedAnnotation(config)
                 .addAnnotation(jsonBuilderAnnotation())
                 .addAnnotation(jsonIgnorePropertiesAnnotation("__typename"))
                 // add a backing property for each field
@@ -150,6 +152,7 @@ fun generateKotlin2DataTypes(
 
             // create the data class
             val typeSpec = TypeSpec.classBuilder(typeDefinition.name)
+                .addOptionalGeneratedAnnotation(config)
                 // add docs if available
                 .apply {
                     if (typeDefinition.description != null) {

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin2/GenerateKotlin2EnumTypes.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin2/GenerateKotlin2EnumTypes.kt
@@ -20,6 +20,7 @@ package com.netflix.graphql.dgs.codegen.generators.kotlin2
 
 import com.netflix.graphql.dgs.codegen.CodeGenConfig
 import com.netflix.graphql.dgs.codegen.generators.kotlin.addEnumConstants
+import com.netflix.graphql.dgs.codegen.generators.kotlin.addOptionalGeneratedAnnotation
 import com.netflix.graphql.dgs.codegen.generators.kotlin.sanitizeKdoc
 import com.netflix.graphql.dgs.codegen.generators.shared.SchemaExtensionsUtils.findEnumExtensions
 import com.netflix.graphql.dgs.codegen.generators.shared.excludeSchemaTypeExtension
@@ -54,6 +55,7 @@ fun generateKotlin2EnumTypes(
 
             // create the enum class
             val enumSpec = TypeSpec.classBuilder(enumDefinition.name)
+                .addOptionalGeneratedAnnotation(config)
                 .addModifiers(KModifier.ENUM)
                 // add docs if available
                 .apply {
@@ -65,6 +67,7 @@ fun generateKotlin2EnumTypes(
                 .addEnumConstants(
                     fields.map { field ->
                         TypeSpec.enumBuilder(field.name)
+                            .addOptionalGeneratedAnnotation(config)
                             .apply {
                                 if (field.description != null) {
                                     addKdoc("%L", field.description.sanitizeKdoc())

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin2/GenerateKotlin2InputTypes.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin2/GenerateKotlin2InputTypes.kt
@@ -21,6 +21,7 @@ package com.netflix.graphql.dgs.codegen.generators.kotlin2
 import com.netflix.graphql.dgs.codegen.CodeGenConfig
 import com.netflix.graphql.dgs.codegen.GraphQLInput
 import com.netflix.graphql.dgs.codegen.generators.kotlin.ReservedKeywordFilter
+import com.netflix.graphql.dgs.codegen.generators.kotlin.addOptionalGeneratedAnnotation
 import com.netflix.graphql.dgs.codegen.generators.kotlin.sanitizeKdoc
 import com.netflix.graphql.dgs.codegen.generators.shared.SchemaExtensionsUtils.findInputExtensions
 import com.netflix.graphql.dgs.codegen.generators.shared.excludeSchemaTypeExtension
@@ -69,6 +70,7 @@ fun generateKotlin2InputTypes(
 
             // create the input class
             val typeSpec = TypeSpec.classBuilder(typeName)
+                .addOptionalGeneratedAnnotation(config)
                 // add docs if available
                 .apply {
                     if (inputDefinition.description != null) {

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin2/GenerateKotlin2Interfaces.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin2/GenerateKotlin2Interfaces.kt
@@ -20,6 +20,7 @@ package com.netflix.graphql.dgs.codegen.generators.kotlin2
 
 import com.netflix.graphql.dgs.codegen.CodeGenConfig
 import com.netflix.graphql.dgs.codegen.filterSkipped
+import com.netflix.graphql.dgs.codegen.generators.kotlin.addOptionalGeneratedAnnotation
 import com.netflix.graphql.dgs.codegen.generators.kotlin.jsonSubTypesAnnotation
 import com.netflix.graphql.dgs.codegen.generators.kotlin.jsonTypeInfoAnnotation
 import com.netflix.graphql.dgs.codegen.generators.kotlin.sanitizeKdoc
@@ -80,6 +81,7 @@ fun generateKotlin2Interfaces(
 
             // create the interface
             val interfaceSpec = TypeSpec.interfaceBuilder(interfaceDefinition.name)
+                .addOptionalGeneratedAnnotation(config)
                 .addModifiers(KModifier.SEALED)
                 // add docs if available
                 .apply {
@@ -142,6 +144,7 @@ fun generateKotlin2Interfaces(
 
             // create the interface
             val interfaceSpec = TypeSpec.interfaceBuilder(unionDefinition.name)
+                .addOptionalGeneratedAnnotation(config)
                 .addModifiers(KModifier.SEALED)
                 // add docs if available
                 .apply {

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/shared/SharedTypeUtils.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/shared/SharedTypeUtils.kt
@@ -22,6 +22,7 @@ import com.netflix.graphql.dgs.codegen.generators.kotlin2.logger
 import graphql.language.Document
 import graphql.language.ScalarTypeDefinition
 import graphql.language.StringValue
+import java.time.Instant
 
 internal sealed class GenericSymbol(open val index: Int) {
     class OpenBracket(str: String, startFrom: Int = 0) : GenericSymbol(str.indexOf("<", startFrom))
@@ -155,3 +156,12 @@ internal fun findSchemaTypeMapping(document: Document, typeName: String): String
     }
     return null
 }
+
+internal val generatedAnnotationClassName: String? = runCatching {
+    Class.forName("javax.annotation.processing.Generated").canonicalName
+}.getOrElse {
+    runCatching {
+        Class.forName("javax.annotation.Generated").canonicalName
+    }.getOrNull()
+}
+internal val generatedDate: String = Instant.now().toString()

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
@@ -2906,7 +2906,7 @@ It takes a title and such.
     }
 
     @Test
-    fun generateSourceWithGeneratedAnnotation(){
+    fun generateSourceWithGeneratedAnnotation() {
         val schema = """
             type Query {
                 employees(filter:EmployeeFilterInput) : [Person]
@@ -2938,8 +2938,8 @@ It takes a title and such.
                 schemas = setOf(schema),
                 packageName = basePackageName,
                 language = Language.JAVA,
-                generateGeneratedAnnotation = true,
-                generateClientApi = true,
+                addGeneratedAnnotation = true,
+                generateClientApi = true
             )
         ).generate()
 

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
@@ -2904,4 +2904,53 @@ It takes a title and such.
             arguments("java.util.Map<String,String,>")
         )
     }
+
+    @Test
+    fun generateSourceWithGeneratedAnnotation(){
+        val schema = """
+            type Query {
+                employees(filter:EmployeeFilterInput) : [Person]
+            }
+
+            interface Person {
+                firstname: String
+                lastname: String
+            }
+
+            type Employee implements Person {
+                firstname: String
+                lastname: String
+                company: String
+            }
+            enum EmployeeTypes {
+                ENGINEER
+                MANAGER
+                DIRECTOR
+            }
+            
+            input EmployeeFilterInput {
+                rank: String
+            }
+        """.trimIndent()
+
+        val codeGenResult = CodeGen(
+            CodeGenConfig(
+                schemas = setOf(schema),
+                packageName = basePackageName,
+                language = Language.JAVA,
+                generateGeneratedAnnotation = true,
+                generateClientApi = true,
+            )
+        ).generate()
+
+        with(codeGenResult) {
+            javaDataTypes.assertJavaGeneratedAnnotation()
+            javaInterfaces.assertJavaGeneratedAnnotation()
+            javaConstants.assertJavaGeneratedAnnotation()
+            javaEnumTypes.assertJavaGeneratedAnnotation()
+            javaQueryTypes.assertJavaGeneratedAnnotation()
+            clientProjections.assertJavaGeneratedAnnotation()
+        }
+        assertCompilesJava(codeGenResult)
+    }
 }

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
@@ -2704,7 +2704,7 @@ It takes a title and such.
     }
 
     @Test
-    fun generateSourceWithGeneratedAnnotation(){
+    fun generateSourceWithGeneratedAnnotation() {
         val schema = """
             type Query {
                 employees(filter:EmployeeFilterInput) : [Person]
@@ -2736,8 +2736,8 @@ It takes a title and such.
                 schemas = setOf(schema),
                 packageName = basePackageName,
                 language = Language.KOTLIN,
-                generateGeneratedAnnotation = true,
-                generateClientApi = true,
+                addGeneratedAnnotation = true,
+                generateClientApi = true
             )
         ).generate()
 

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
@@ -2702,4 +2702,53 @@ It takes a title and such.
 
         assertCompilesJava(codeGenResult.javaQueryTypes)
     }
+
+    @Test
+    fun generateSourceWithGeneratedAnnotation(){
+        val schema = """
+            type Query {
+                employees(filter:EmployeeFilterInput) : [Person]
+            }
+
+            interface Person {
+                firstname: String
+                lastname: String
+            }
+
+            type Employee implements Person {
+                firstname: String
+                lastname: String
+                company: String
+            }
+            enum EmployeeTypes {
+                ENGINEER
+                MANAGER
+                DIRECTOR
+            }
+            
+            input EmployeeFilterInput {
+                rank: String
+            }
+        """.trimIndent()
+
+        val codeGenResult = CodeGen(
+            CodeGenConfig(
+                schemas = setOf(schema),
+                packageName = basePackageName,
+                language = Language.KOTLIN,
+                generateGeneratedAnnotation = true,
+                generateClientApi = true,
+            )
+        ).generate()
+
+        with(codeGenResult) {
+            kotlinDataTypes.assertKotlinGeneratedAnnotation()
+            kotlinInterfaces.assertKotlinGeneratedAnnotation()
+            kotlinConstants.assertKotlinGeneratedAnnotation()
+            kotlinEnumTypes.assertKotlinGeneratedAnnotation()
+            javaQueryTypes.assertJavaGeneratedAnnotation()
+            clientProjections.assertJavaGeneratedAnnotation()
+        }
+        assertCompilesKotlin(codeGenResult)
+    }
 }

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/TestUtils.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/TestUtils.kt
@@ -21,6 +21,7 @@ package com.netflix.graphql.dgs.codegen
 import com.google.testing.compile.Compilation
 import com.google.testing.compile.CompilationSubject
 import com.google.testing.compile.Compiler.javac
+import com.netflix.graphql.dgs.codegen.generators.shared.generatedDate
 import com.squareup.javapoet.JavaFile
 import com.squareup.kotlinpoet.FileSpec
 import org.assertj.core.api.Assertions.assertThat
@@ -110,6 +111,30 @@ fun Compilation.toClassLoader(): ClassLoader {
 fun <T> invokeMethod(method: Method, target: Any, vararg args: Any): T {
     val result = ReflectionUtils.invokeMethod(method, target, *args)
     return result as T
+}
+
+fun List<FileSpec>.assertKotlinGeneratedAnnotation() = apply {
+    assertThat(this).isNotEmpty
+    forEach {
+        assertThat(it.toString())
+            .contains(
+                "@Generated(",
+                "value = [\"${CodeGen::class.qualifiedName}\"]",
+                "date = \"$generatedDate\""
+            )
+    }
+}
+
+fun List<JavaFile>.assertJavaGeneratedAnnotation() = apply {
+    assertThat(this).isNotEmpty
+    forEach {
+        assertThat(it.toString())
+            .contains(
+                "@Generated(",
+                "value = \"${CodeGen::class.qualifiedName}\"",
+                "date = \"$generatedDate\""
+            )
+    }
 }
 
 const val basePackageName = "com.netflix.graphql.dgs.codegen.tests.generated"

--- a/graphql-dgs-codegen-gradle/src/main/kotlin/com/netflix/graphql/dgs/codegen/gradle/GenerateJavaTask.kt
+++ b/graphql-dgs-codegen-gradle/src/main/kotlin/com/netflix/graphql/dgs/codegen/gradle/GenerateJavaTask.kt
@@ -129,6 +129,9 @@ open class GenerateJavaTask : DefaultTask() {
     @Input
     var snakeCaseConstantNames = false
 
+    @Input
+    var generateGeneratedAnnotation = false
+
     @TaskAction
     fun generate() {
         val schemaPaths = schemaPaths.map { Paths.get(it.toString()).toFile() }.sorted().toSet()
@@ -168,7 +171,8 @@ open class GenerateJavaTask : DefaultTask() {
             maxProjectionDepth = maxProjectionDepth,
             kotlinAllFieldsOptional = kotlinAllFieldsOptional,
             snakeCaseConstantNames = snakeCaseConstantNames,
-            implementSerializable = implementSerializable
+            implementSerializable = implementSerializable,
+            generateGeneratedAnnotation = generateGeneratedAnnotation
         )
 
         logger.info("Codegen config: {}", config)

--- a/graphql-dgs-codegen-gradle/src/main/kotlin/com/netflix/graphql/dgs/codegen/gradle/GenerateJavaTask.kt
+++ b/graphql-dgs-codegen-gradle/src/main/kotlin/com/netflix/graphql/dgs/codegen/gradle/GenerateJavaTask.kt
@@ -130,7 +130,7 @@ open class GenerateJavaTask : DefaultTask() {
     var snakeCaseConstantNames = false
 
     @Input
-    var generateGeneratedAnnotation = false
+    var addGeneratedAnnotation = false
 
     @TaskAction
     fun generate() {
@@ -172,7 +172,7 @@ open class GenerateJavaTask : DefaultTask() {
             kotlinAllFieldsOptional = kotlinAllFieldsOptional,
             snakeCaseConstantNames = snakeCaseConstantNames,
             implementSerializable = implementSerializable,
-            generateGeneratedAnnotation = generateGeneratedAnnotation
+            addGeneratedAnnotation = addGeneratedAnnotation
         )
 
         logger.info("Codegen config: {}", config)


### PR DESCRIPTION
Following the request in https://github.com/Netflix/dgs-codegen/issues/420 and discussion in https://github.com/Netflix/dgs-framework/discussions/1147, this PR provides an option to generate `@Generated` annotation  over the generated code (both for Java and Kotlin code generators).

The code will detect which `@Generated` annotation should be used (`javax.annotation.Generated` for JVM <= 8 or `javax.annotation.processing.Generated` for JVM >= 9) and will add that for every relevant TypeSpec (classes, data classes, objects, interfaces, enums, etc). The annotation will contain the generation timestamp, and the code generator name will be `com.netflix.graphql.dgs.codegen.CodeGen`, as the [@Generated spec requires](https://docs.oracle.com/javase/9/docs/api/javax/annotation/processing/Generated.html)

The Java and Kotlin unit tests will use a schema to generate all relevant types, and will verify they: a) have the `@Generated` annotation; and b) can get compiled properly with the annotation present.