### PR TITLE
Use an explicit JVM generated name for all kotlin2 data classes

### DIFF
--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/constantsForInputTypes/expected/types/Person.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/constantsForInputTypes/expected/types/Person.kt
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.`annotation`.JsonDeserialize
 import com.fasterxml.jackson.databind.`annotation`.JsonPOJOBuilder
 import java.lang.IllegalStateException
 import kotlin.String
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 @JsonDeserialize(builder = Person.Builder::class)
@@ -18,9 +19,11 @@ public class Person(
 
   private val _lastname: () -> String? = lastname
 
+  @get:JvmName("getFirstname")
   public val firstname: String?
     get() = _firstname.invoke()
 
+  @get:JvmName("getLastname")
   public val lastname: String?
     get() = _lastname.invoke()
 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/constantsForInputTypes/expected/types/Query.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/constantsForInputTypes/expected/types/Query.kt
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.`annotation`.JsonDeserialize
 import com.fasterxml.jackson.databind.`annotation`.JsonPOJOBuilder
 import java.lang.IllegalStateException
 import kotlin.collections.List
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 @JsonDeserialize(builder = Query.Builder::class)
@@ -15,6 +16,7 @@ public class Query(
 ) {
   private val _people: () -> List<Person?>? = people
 
+  @get:JvmName("getPeople")
   public val people: List<Person?>?
     get() = _people.invoke()
 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/constantsWithExtendedInputTypes/expected/types/Person.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/constantsWithExtendedInputTypes/expected/types/Person.kt
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.`annotation`.JsonDeserialize
 import com.fasterxml.jackson.databind.`annotation`.JsonPOJOBuilder
 import java.lang.IllegalStateException
 import kotlin.String
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 @JsonDeserialize(builder = Person.Builder::class)
@@ -18,9 +19,11 @@ public class Person(
 
   private val _lastname: () -> String? = lastname
 
+  @get:JvmName("getFirstname")
   public val firstname: String?
     get() = _firstname.invoke()
 
+  @get:JvmName("getLastname")
   public val lastname: String?
     get() = _lastname.invoke()
 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/constantsWithExtendedInputTypes/expected/types/Query.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/constantsWithExtendedInputTypes/expected/types/Query.kt
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.`annotation`.JsonDeserialize
 import com.fasterxml.jackson.databind.`annotation`.JsonPOJOBuilder
 import java.lang.IllegalStateException
 import kotlin.collections.List
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 @JsonDeserialize(builder = Query.Builder::class)
@@ -15,6 +16,7 @@ public class Query(
 ) {
   private val _people: () -> List<Person?>? = people
 
+  @get:JvmName("getPeople")
   public val people: List<Person?>?
     get() = _people.invoke()
 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/constantsWithExtendedInterface/expected/types/Person.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/constantsWithExtendedInterface/expected/types/Person.kt
@@ -3,6 +3,8 @@ package com.netflix.graphql.dgs.codegen.cases.constantsWithExtendedInterface.exp
 import com.fasterxml.jackson.`annotation`.JsonTypeInfo
 import kotlin.Int
 import kotlin.String
+import kotlin.Suppress
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(
   use = JsonTypeInfo.Id.NAME,
@@ -10,9 +12,15 @@ import kotlin.String
   property = "__typename",
 )
 public sealed interface Person {
+  @Suppress("INAPPLICABLE_JVM_NAME")
+  @get:JvmName("getFirstname")
   public val firstname: String
 
+  @Suppress("INAPPLICABLE_JVM_NAME")
+  @get:JvmName("getLastname")
   public val lastname: String?
 
+  @Suppress("INAPPLICABLE_JVM_NAME")
+  @get:JvmName("getAge")
   public val age: Int?
 }

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/constantsWithExtendedInterface/expected/types/Query.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/constantsWithExtendedInterface/expected/types/Query.kt
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.`annotation`.JsonDeserialize
 import com.fasterxml.jackson.databind.`annotation`.JsonPOJOBuilder
 import java.lang.IllegalStateException
 import kotlin.collections.List
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 @JsonDeserialize(builder = Query.Builder::class)
@@ -15,6 +16,7 @@ public class Query(
 ) {
   private val _people: () -> List<Person?>? = people
 
+  @get:JvmName("getPeople")
   public val people: List<Person?>?
     get() = _people.invoke()
 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/constantsWithExtendedQuery/expected/types/Person.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/constantsWithExtendedQuery/expected/types/Person.kt
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.`annotation`.JsonDeserialize
 import com.fasterxml.jackson.databind.`annotation`.JsonPOJOBuilder
 import java.lang.IllegalStateException
 import kotlin.String
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 @JsonDeserialize(builder = Person.Builder::class)
@@ -18,9 +19,11 @@ public class Person(
 
   private val _lastname: () -> String? = lastname
 
+  @get:JvmName("getFirstname")
   public val firstname: String?
     get() = _firstname.invoke()
 
+  @get:JvmName("getLastname")
   public val lastname: String?
     get() = _lastname.invoke()
 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/constantsWithExtendedQuery/expected/types/Query.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/constantsWithExtendedQuery/expected/types/Query.kt
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.`annotation`.JsonDeserialize
 import com.fasterxml.jackson.databind.`annotation`.JsonPOJOBuilder
 import java.lang.IllegalStateException
 import kotlin.collections.List
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 @JsonDeserialize(builder = Query.Builder::class)
@@ -18,9 +19,11 @@ public class Query(
 
   private val _friends: () -> List<Person?>? = friends
 
+  @get:JvmName("getPeople")
   public val people: List<Person?>?
     get() = _people.invoke()
 
+  @get:JvmName("getFriends")
   public val friends: List<Person?>?
     get() = _friends.invoke()
 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/constantsWithExtendedTypes/expected/types/Person.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/constantsWithExtendedTypes/expected/types/Person.kt
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.`annotation`.JsonDeserialize
 import com.fasterxml.jackson.databind.`annotation`.JsonPOJOBuilder
 import java.lang.IllegalStateException
 import kotlin.String
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 @JsonDeserialize(builder = Person.Builder::class)
@@ -21,12 +22,15 @@ public class Person(
 
   private val _email: () -> String? = email
 
+  @get:JvmName("getFirstname")
   public val firstname: String?
     get() = _firstname.invoke()
 
+  @get:JvmName("getLastname")
   public val lastname: String?
     get() = _lastname.invoke()
 
+  @get:JvmName("getEmail")
   public val email: String?
     get() = _email.invoke()
 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/constantsWithExtendedTypes/expected/types/Query.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/constantsWithExtendedTypes/expected/types/Query.kt
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.`annotation`.JsonDeserialize
 import com.fasterxml.jackson.databind.`annotation`.JsonPOJOBuilder
 import java.lang.IllegalStateException
 import kotlin.collections.List
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 @JsonDeserialize(builder = Query.Builder::class)
@@ -15,6 +16,7 @@ public class Query(
 ) {
   private val _people: () -> List<Person?>? = people
 
+  @get:JvmName("getPeople")
   public val people: List<Person?>?
     get() = _people.invoke()
 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassDocs/expected/types/Movie.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassDocs/expected/types/Movie.kt
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.`annotation`.JsonDeserialize
 import com.fasterxml.jackson.databind.`annotation`.JsonPOJOBuilder
 import java.lang.IllegalStateException
 import kotlin.String
+import kotlin.jvm.JvmName
 
 /**
  * Movies are fun to watch.
@@ -19,6 +20,7 @@ public class Movie(
 ) {
   private val _title: () -> String? = title
 
+  @get:JvmName("getTitle")
   public val title: String?
     get() = _title.invoke()
 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassDocs/expected/types/Query.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassDocs/expected/types/Query.kt
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.`annotation`.JsonTypeInfo
 import com.fasterxml.jackson.databind.`annotation`.JsonDeserialize
 import com.fasterxml.jackson.databind.`annotation`.JsonPOJOBuilder
 import java.lang.IllegalStateException
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 @JsonDeserialize(builder = Query.Builder::class)
@@ -14,6 +15,7 @@ public class Query(
 ) {
   private val _search: () -> Movie? = search
 
+  @get:JvmName("getSearch")
   public val search: Movie?
     get() = _search.invoke()
 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassFieldDocs/expected/types/Movie.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassFieldDocs/expected/types/Movie.kt
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.`annotation`.JsonDeserialize
 import com.fasterxml.jackson.databind.`annotation`.JsonPOJOBuilder
 import java.lang.IllegalStateException
 import kotlin.String
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 @JsonDeserialize(builder = Movie.Builder::class)
@@ -18,6 +19,7 @@ public class Movie(
   /**
    * The original, non localized title with some specials characters : %!({[*$,.:;.
    */
+  @get:JvmName("getTitle")
   public val title: String?
     get() = _title.invoke()
 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassFieldDocs/expected/types/Query.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassFieldDocs/expected/types/Query.kt
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.`annotation`.JsonTypeInfo
 import com.fasterxml.jackson.databind.`annotation`.JsonDeserialize
 import com.fasterxml.jackson.databind.`annotation`.JsonPOJOBuilder
 import java.lang.IllegalStateException
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 @JsonDeserialize(builder = Query.Builder::class)
@@ -14,6 +15,7 @@ public class Query(
 ) {
   private val _search: () -> Movie? = search
 
+  @get:JvmName("getSearch")
   public val search: Movie?
     get() = _search.invoke()
 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWIthNoFields/expected/types/Query.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWIthNoFields/expected/types/Query.kt
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.`annotation`.JsonTypeInfo
 import com.fasterxml.jackson.databind.`annotation`.JsonDeserialize
 import com.fasterxml.jackson.databind.`annotation`.JsonPOJOBuilder
 import java.lang.IllegalStateException
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 @JsonDeserialize(builder = Query.Builder::class)
@@ -14,6 +15,7 @@ public class Query(
 ) {
   private val _me: () -> Person? = me
 
+  @get:JvmName("getMe")
   public val me: Person?
     get() = _me.invoke()
 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithBooleanField/expected/DgsClient.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithBooleanField/expected/DgsClient.kt
@@ -1,0 +1,11 @@
+package com.netflix.graphql.dgs.codegen.cases.dataClassWithBooleanField.expected
+
+import com.netflix.graphql.dgs.codegen.GraphQLProjection
+import com.netflix.graphql.dgs.codegen.cases.dataClassWithBooleanField.expected.client.QueryProjection
+import graphql.language.OperationDefinition
+import kotlin.String
+
+public object DgsClient {
+  public fun buildQuery(_projection: QueryProjection.() -> QueryProjection): String =
+      GraphQLProjection.asQuery(OperationDefinition.Operation.QUERY, QueryProjection(), _projection)
+}

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithBooleanField/expected/DgsConstants.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithBooleanField/expected/DgsConstants.kt
@@ -1,0 +1,19 @@
+package com.netflix.graphql.dgs.codegen.cases.dataClassWithBooleanField.expected
+
+import kotlin.String
+
+public object DgsConstants {
+  public const val QUERY_TYPE: String = "Query"
+
+  public object QUERY {
+    public const val TYPE_NAME: String = "Query"
+
+    public const val Test: String = "test"
+  }
+
+  public object REQUIREDTESTTYPE {
+    public const val TYPE_NAME: String = "RequiredTestType"
+
+    public const val IsRequired: String = "isRequired"
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithBooleanField/expected/client/QueryProjection.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithBooleanField/expected/client/QueryProjection.kt
@@ -1,0 +1,11 @@
+package com.netflix.graphql.dgs.codegen.cases.dataClassWithBooleanField.expected.client
+
+import com.netflix.graphql.dgs.codegen.GraphQLProjection
+
+public class QueryProjection : GraphQLProjection() {
+  public fun test(_projection: RequiredTestTypeProjection.() -> RequiredTestTypeProjection):
+      QueryProjection {
+    field("test", RequiredTestTypeProjection(), _projection)
+    return this
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithBooleanField/expected/client/RequiredTestTypeProjection.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithBooleanField/expected/client/RequiredTestTypeProjection.kt
@@ -1,0 +1,11 @@
+package com.netflix.graphql.dgs.codegen.cases.dataClassWithBooleanField.expected.client
+
+import com.netflix.graphql.dgs.codegen.GraphQLProjection
+
+public class RequiredTestTypeProjection : GraphQLProjection() {
+  public val isRequired: RequiredTestTypeProjection
+    get() {
+      field("isRequired")
+      return this
+    }
+}

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithBooleanField/expected/types/Query.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithBooleanField/expected/types/Query.kt
@@ -1,0 +1,42 @@
+package com.netflix.graphql.dgs.codegen.cases.dataClassWithBooleanField.expected.types
+
+import com.fasterxml.jackson.`annotation`.JsonIgnoreProperties
+import com.fasterxml.jackson.`annotation`.JsonProperty
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import com.fasterxml.jackson.databind.`annotation`.JsonDeserialize
+import com.fasterxml.jackson.databind.`annotation`.JsonPOJOBuilder
+import java.lang.IllegalStateException
+import kotlin.jvm.JvmName
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
+@JsonDeserialize(builder = Query.Builder::class)
+public class Query(
+  test: () -> RequiredTestType? = testDefault,
+) {
+  private val _test: () -> RequiredTestType? = test
+
+  @get:JvmName("getTest")
+  public val test: RequiredTestType?
+    get() = _test.invoke()
+
+  public companion object {
+    private val testDefault: () -> RequiredTestType? = 
+        { throw IllegalStateException("Field `test` was not requested") }
+
+  }
+
+  @JsonPOJOBuilder
+  @JsonIgnoreProperties("__typename")
+  public class Builder {
+    private var test: () -> RequiredTestType? = testDefault
+
+    @JsonProperty("test")
+    public fun withTest(test: RequiredTestType?): Builder = this.apply {
+      this.test = { test }
+    }
+
+    public fun build() = Query(
+      test = test,
+    )
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithBooleanField/expected/types/RequiredTestType.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithBooleanField/expected/types/RequiredTestType.kt
@@ -1,0 +1,43 @@
+package com.netflix.graphql.dgs.codegen.cases.dataClassWithBooleanField.expected.types
+
+import com.fasterxml.jackson.`annotation`.JsonIgnoreProperties
+import com.fasterxml.jackson.`annotation`.JsonProperty
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import com.fasterxml.jackson.databind.`annotation`.JsonDeserialize
+import com.fasterxml.jackson.databind.`annotation`.JsonPOJOBuilder
+import java.lang.IllegalStateException
+import kotlin.Boolean
+import kotlin.jvm.JvmName
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
+@JsonDeserialize(builder = RequiredTestType.Builder::class)
+public class RequiredTestType(
+  isRequired: () -> Boolean = isRequiredDefault,
+) {
+  private val _isRequired: () -> Boolean = isRequired
+
+  @get:JvmName("getIsRequired")
+  public val isRequired: Boolean
+    get() = _isRequired.invoke()
+
+  public companion object {
+    private val isRequiredDefault: () -> Boolean = 
+        { throw IllegalStateException("Field `isRequired` was not requested") }
+
+  }
+
+  @JsonPOJOBuilder
+  @JsonIgnoreProperties("__typename")
+  public class Builder {
+    private var isRequired: () -> Boolean = isRequiredDefault
+
+    @JsonProperty("isRequired")
+    public fun withIsRequired(isRequired: Boolean): Builder = this.apply {
+      this.isRequired = { isRequired }
+    }
+
+    public fun build() = RequiredTestType(
+      isRequired = isRequired,
+    )
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithBooleanField/schema.graphql
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithBooleanField/schema.graphql
@@ -1,0 +1,7 @@
+type Query {
+  test: RequiredTestType
+}
+
+type RequiredTestType {
+  isRequired: Boolean!
+}

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithDeclaredScalars/expected/types/Entity.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithDeclaredScalars/expected/types/Entity.kt
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.`annotation`.JsonPOJOBuilder
 import java.lang.IllegalStateException
 import java.time.OffsetDateTime
 import kotlin.Long
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 @JsonDeserialize(builder = Entity.Builder::class)
@@ -19,9 +20,11 @@ public class Entity(
 
   private val _dateTime: () -> OffsetDateTime? = dateTime
 
+  @get:JvmName("getLong")
   public val long: Long?
     get() = _long.invoke()
 
+  @get:JvmName("getDateTime")
   public val dateTime: OffsetDateTime?
     get() = _dateTime.invoke()
 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithDeclaredScalars/expected/types/EntityConnection.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithDeclaredScalars/expected/types/EntityConnection.kt
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.`annotation`.JsonDeserialize
 import com.fasterxml.jackson.databind.`annotation`.JsonPOJOBuilder
 import java.lang.IllegalStateException
 import kotlin.collections.List
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 @JsonDeserialize(builder = EntityConnection.Builder::class)
@@ -18,9 +19,11 @@ public class EntityConnection(
 
   private val _edges: () -> List<EntityEdge?>? = edges
 
+  @get:JvmName("getPageInfo")
   public val pageInfo: PageInfo
     get() = _pageInfo.invoke()
 
+  @get:JvmName("getEdges")
   public val edges: List<EntityEdge?>?
     get() = _edges.invoke()
 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithDeclaredScalars/expected/types/EntityEdge.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithDeclaredScalars/expected/types/EntityEdge.kt
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.`annotation`.JsonDeserialize
 import com.fasterxml.jackson.databind.`annotation`.JsonPOJOBuilder
 import java.lang.IllegalStateException
 import kotlin.String
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 @JsonDeserialize(builder = EntityEdge.Builder::class)
@@ -18,9 +19,11 @@ public class EntityEdge(
 
   private val _node: () -> Entity? = node
 
+  @get:JvmName("getCursor")
   public val cursor: String
     get() = _cursor.invoke()
 
+  @get:JvmName("getNode")
   public val node: Entity?
     get() = _node.invoke()
 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithDeclaredScalars/expected/types/PageInfo.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithDeclaredScalars/expected/types/PageInfo.kt
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.`annotation`.JsonPOJOBuilder
 import java.lang.IllegalStateException
 import kotlin.Boolean
 import kotlin.String
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 @JsonDeserialize(builder = PageInfo.Builder::class)
@@ -25,15 +26,19 @@ public class PageInfo(
 
   private val _hasPreviousPage: () -> Boolean = hasPreviousPage
 
+  @get:JvmName("getStartCursor")
   public val startCursor: String?
     get() = _startCursor.invoke()
 
+  @get:JvmName("getEndCursor")
   public val endCursor: String?
     get() = _endCursor.invoke()
 
+  @get:JvmName("getHasNextPage")
   public val hasNextPage: Boolean
     get() = _hasNextPage.invoke()
 
+  @get:JvmName("getHasPreviousPage")
   public val hasPreviousPage: Boolean
     get() = _hasPreviousPage.invoke()
 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithDeclaredScalars/expected/types/Query.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithDeclaredScalars/expected/types/Query.kt
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.`annotation`.JsonDeserialize
 import com.fasterxml.jackson.databind.`annotation`.JsonPOJOBuilder
 import java.lang.IllegalStateException
 import kotlin.collections.List
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 @JsonDeserialize(builder = Query.Builder::class)
@@ -18,9 +19,11 @@ public class Query(
 
   private val _entityConnection: () -> EntityConnection? = entityConnection
 
+  @get:JvmName("getEntity")
   public val entity: List<Entity?>?
     get() = _entity.invoke()
 
+  @get:JvmName("getEntityConnection")
   public val entityConnection: EntityConnection?
     get() = _entityConnection.invoke()
 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithDeeplyNestedComplexField/expected/types/Car.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithDeeplyNestedComplexField/expected/types/Car.kt
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.`annotation`.JsonDeserialize
 import com.fasterxml.jackson.databind.`annotation`.JsonPOJOBuilder
 import java.lang.IllegalStateException
 import kotlin.String
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 @JsonDeserialize(builder = Car.Builder::class)
@@ -21,12 +22,15 @@ public class Car(
 
   private val _engine: () -> Engine? = engine
 
+  @get:JvmName("getMake")
   public val make: String?
     get() = _make.invoke()
 
+  @get:JvmName("getModel")
   public val model: String?
     get() = _model.invoke()
 
+  @get:JvmName("getEngine")
   public val engine: Engine?
     get() = _engine.invoke()
 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithDeeplyNestedComplexField/expected/types/Engine.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithDeeplyNestedComplexField/expected/types/Engine.kt
@@ -9,6 +9,7 @@ import java.lang.IllegalStateException
 import kotlin.Double
 import kotlin.Int
 import kotlin.String
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 @JsonDeserialize(builder = Engine.Builder::class)
@@ -26,15 +27,19 @@ public class Engine(
 
   private val _performance: () -> Performance? = performance
 
+  @get:JvmName("getType")
   public val type: String?
     get() = _type.invoke()
 
+  @get:JvmName("getBhp")
   public val bhp: Int?
     get() = _bhp.invoke()
 
+  @get:JvmName("getSize")
   public val size: Double?
     get() = _size.invoke()
 
+  @get:JvmName("getPerformance")
   public val performance: Performance?
     get() = _performance.invoke()
 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithDeeplyNestedComplexField/expected/types/Performance.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithDeeplyNestedComplexField/expected/types/Performance.kt
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.`annotation`.JsonDeserialize
 import com.fasterxml.jackson.databind.`annotation`.JsonPOJOBuilder
 import java.lang.IllegalStateException
 import kotlin.Double
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 @JsonDeserialize(builder = Performance.Builder::class)
@@ -18,9 +19,11 @@ public class Performance(
 
   private val _quarterMile: () -> Double? = quarterMile
 
+  @get:JvmName("getZeroToSixty")
   public val zeroToSixty: Double?
     get() = _zeroToSixty.invoke()
 
+  @get:JvmName("getQuarterMile")
   public val quarterMile: Double?
     get() = _quarterMile.invoke()
 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithDeeplyNestedComplexField/expected/types/Query.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithDeeplyNestedComplexField/expected/types/Query.kt
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.`annotation`.JsonDeserialize
 import com.fasterxml.jackson.databind.`annotation`.JsonPOJOBuilder
 import java.lang.IllegalStateException
 import kotlin.collections.List
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 @JsonDeserialize(builder = Query.Builder::class)
@@ -15,6 +16,7 @@ public class Query(
 ) {
   private val _cars: () -> List<Car?>? = cars
 
+  @get:JvmName("getCars")
   public val cars: List<Car?>?
     get() = _cars.invoke()
 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithExtendedInterface/expected/types/Person.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithExtendedInterface/expected/types/Person.kt
@@ -3,6 +3,8 @@ package com.netflix.graphql.dgs.codegen.cases.dataClassWithExtendedInterface.exp
 import com.fasterxml.jackson.`annotation`.JsonTypeInfo
 import kotlin.Int
 import kotlin.String
+import kotlin.Suppress
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(
   use = JsonTypeInfo.Id.NAME,
@@ -10,9 +12,15 @@ import kotlin.String
   property = "__typename",
 )
 public sealed interface Person {
+  @Suppress("INAPPLICABLE_JVM_NAME")
+  @get:JvmName("getFirstname")
   public val firstname: String
 
+  @Suppress("INAPPLICABLE_JVM_NAME")
+  @get:JvmName("getLastname")
   public val lastname: String?
 
+  @Suppress("INAPPLICABLE_JVM_NAME")
+  @get:JvmName("getAge")
   public val age: Int?
 }

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithExtendedInterface/expected/types/Query.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithExtendedInterface/expected/types/Query.kt
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.`annotation`.JsonDeserialize
 import com.fasterxml.jackson.databind.`annotation`.JsonPOJOBuilder
 import java.lang.IllegalStateException
 import kotlin.collections.List
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 @JsonDeserialize(builder = Query.Builder::class)
@@ -15,6 +16,7 @@ public class Query(
 ) {
   private val _people: () -> List<Person?>? = people
 
+  @get:JvmName("getPeople")
   public val people: List<Person?>?
     get() = _people.invoke()
 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithInterface/expected/types/Employee.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithInterface/expected/types/Employee.kt
@@ -7,6 +7,8 @@ import com.fasterxml.jackson.databind.`annotation`.JsonDeserialize
 import com.fasterxml.jackson.databind.`annotation`.JsonPOJOBuilder
 import java.lang.IllegalStateException
 import kotlin.String
+import kotlin.Suppress
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 @JsonDeserialize(builder = Employee.Builder::class)
@@ -21,12 +23,17 @@ public class Employee(
 
   private val _company: () -> String? = company
 
+  @Suppress("INAPPLICABLE_JVM_NAME")
+  @get:JvmName("getFirstname")
   public override val firstname: String?
     get() = _firstname.invoke()
 
+  @Suppress("INAPPLICABLE_JVM_NAME")
+  @get:JvmName("getLastname")
   public override val lastname: String?
     get() = _lastname.invoke()
 
+  @get:JvmName("getCompany")
   public val company: String?
     get() = _company.invoke()
 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithInterface/expected/types/Person.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithInterface/expected/types/Person.kt
@@ -3,6 +3,8 @@ package com.netflix.graphql.dgs.codegen.cases.dataClassWithInterface.expected.ty
 import com.fasterxml.jackson.`annotation`.JsonSubTypes
 import com.fasterxml.jackson.`annotation`.JsonTypeInfo
 import kotlin.String
+import kotlin.Suppress
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(
   use = JsonTypeInfo.Id.NAME,
@@ -13,7 +15,11 @@ import kotlin.String
   JsonSubTypes.Type(value = Employee::class, name = "Employee")
 ])
 public sealed interface Person {
+  @Suppress("INAPPLICABLE_JVM_NAME")
+  @get:JvmName("getFirstname")
   public val firstname: String?
 
+  @Suppress("INAPPLICABLE_JVM_NAME")
+  @get:JvmName("getLastname")
   public val lastname: String?
 }

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithInterface/expected/types/Query.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithInterface/expected/types/Query.kt
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.`annotation`.JsonDeserialize
 import com.fasterxml.jackson.databind.`annotation`.JsonPOJOBuilder
 import java.lang.IllegalStateException
 import kotlin.collections.List
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 @JsonDeserialize(builder = Query.Builder::class)
@@ -15,6 +16,7 @@ public class Query(
 ) {
   private val _people: () -> List<Person?>? = people
 
+  @get:JvmName("getPeople")
   public val people: List<Person?>?
     get() = _people.invoke()
 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithInterfaceInheritance/expected/types/Employee.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithInterfaceInheritance/expected/types/Employee.kt
@@ -3,6 +3,8 @@ package com.netflix.graphql.dgs.codegen.cases.dataClassWithInterfaceInheritance.
 import com.fasterxml.jackson.`annotation`.JsonSubTypes
 import com.fasterxml.jackson.`annotation`.JsonTypeInfo
 import kotlin.String
+import kotlin.Suppress
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(
   use = JsonTypeInfo.Id.NAME,
@@ -13,9 +15,15 @@ import kotlin.String
   JsonSubTypes.Type(value = Talent::class, name = "Talent")
 ])
 public sealed interface Employee : Person {
+  @Suppress("INAPPLICABLE_JVM_NAME")
+  @get:JvmName("getFirstname")
   public override val firstname: String
 
+  @Suppress("INAPPLICABLE_JVM_NAME")
+  @get:JvmName("getLastname")
   public override val lastname: String?
 
+  @Suppress("INAPPLICABLE_JVM_NAME")
+  @get:JvmName("getCompany")
   public val company: String?
 }

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithInterfaceInheritance/expected/types/Person.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithInterfaceInheritance/expected/types/Person.kt
@@ -2,6 +2,8 @@ package com.netflix.graphql.dgs.codegen.cases.dataClassWithInterfaceInheritance.
 
 import com.fasterxml.jackson.`annotation`.JsonTypeInfo
 import kotlin.String
+import kotlin.Suppress
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(
   use = JsonTypeInfo.Id.NAME,
@@ -9,7 +11,11 @@ import kotlin.String
   property = "__typename",
 )
 public sealed interface Person {
+  @Suppress("INAPPLICABLE_JVM_NAME")
+  @get:JvmName("getFirstname")
   public val firstname: String
 
+  @Suppress("INAPPLICABLE_JVM_NAME")
+  @get:JvmName("getLastname")
   public val lastname: String?
 }

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithInterfaceInheritance/expected/types/Query.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithInterfaceInheritance/expected/types/Query.kt
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.`annotation`.JsonDeserialize
 import com.fasterxml.jackson.databind.`annotation`.JsonPOJOBuilder
 import java.lang.IllegalStateException
 import kotlin.collections.List
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 @JsonDeserialize(builder = Query.Builder::class)
@@ -15,6 +16,7 @@ public class Query(
 ) {
   private val _people: () -> List<Person?>? = people
 
+  @get:JvmName("getPeople")
   public val people: List<Person?>?
     get() = _people.invoke()
 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithInterfaceInheritance/expected/types/Talent.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithInterfaceInheritance/expected/types/Talent.kt
@@ -7,6 +7,8 @@ import com.fasterxml.jackson.databind.`annotation`.JsonDeserialize
 import com.fasterxml.jackson.databind.`annotation`.JsonPOJOBuilder
 import java.lang.IllegalStateException
 import kotlin.String
+import kotlin.Suppress
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 @JsonDeserialize(builder = Talent.Builder::class)
@@ -24,15 +26,22 @@ public class Talent(
 
   private val _imdbProfile: () -> String? = imdbProfile
 
+  @Suppress("INAPPLICABLE_JVM_NAME")
+  @get:JvmName("getFirstname")
   public override val firstname: String
     get() = _firstname.invoke()
 
+  @Suppress("INAPPLICABLE_JVM_NAME")
+  @get:JvmName("getLastname")
   public override val lastname: String?
     get() = _lastname.invoke()
 
+  @Suppress("INAPPLICABLE_JVM_NAME")
+  @get:JvmName("getCompany")
   public override val company: String?
     get() = _company.invoke()
 
+  @get:JvmName("getImdbProfile")
   public val imdbProfile: String?
     get() = _imdbProfile.invoke()
 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithListProperties/expected/types/Person.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithListProperties/expected/types/Person.kt
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.`annotation`.JsonPOJOBuilder
 import java.lang.IllegalStateException
 import kotlin.String
 import kotlin.collections.List
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 @JsonDeserialize(builder = Person.Builder::class)
@@ -19,9 +20,11 @@ public class Person(
 
   private val _email: () -> List<String?>? = email
 
+  @get:JvmName("getName")
   public val name: String?
     get() = _name.invoke()
 
+  @get:JvmName("getEmail")
   public val email: List<String?>?
     get() = _email.invoke()
 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithListProperties/expected/types/Query.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithListProperties/expected/types/Query.kt
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.`annotation`.JsonDeserialize
 import com.fasterxml.jackson.databind.`annotation`.JsonPOJOBuilder
 import java.lang.IllegalStateException
 import kotlin.collections.List
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 @JsonDeserialize(builder = Query.Builder::class)
@@ -15,6 +16,7 @@ public class Query(
 ) {
   private val _people: () -> List<Person?>? = people
 
+  @get:JvmName("getPeople")
   public val people: List<Person?>?
     get() = _people.invoke()
 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithMappedTypes/expected/types/Entity.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithMappedTypes/expected/types/Entity.kt
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.`annotation`.JsonPOJOBuilder
 import java.lang.IllegalStateException
 import java.time.OffsetDateTime
 import kotlin.Long
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 @JsonDeserialize(builder = Entity.Builder::class)
@@ -19,9 +20,11 @@ public class Entity(
 
   private val _dateTime: () -> OffsetDateTime? = dateTime
 
+  @get:JvmName("getLong")
   public val long: Long?
     get() = _long.invoke()
 
+  @get:JvmName("getDateTime")
   public val dateTime: OffsetDateTime?
     get() = _dateTime.invoke()
 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithMappedTypes/expected/types/EntityConnection.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithMappedTypes/expected/types/EntityConnection.kt
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.`annotation`.JsonPOJOBuilder
 import graphql.relay.PageInfo
 import java.lang.IllegalStateException
 import kotlin.collections.List
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 @JsonDeserialize(builder = EntityConnection.Builder::class)
@@ -19,9 +20,11 @@ public class EntityConnection(
 
   private val _edges: () -> List<EntityEdge?>? = edges
 
+  @get:JvmName("getPageInfo")
   public val pageInfo: PageInfo
     get() = _pageInfo.invoke()
 
+  @get:JvmName("getEdges")
   public val edges: List<EntityEdge?>?
     get() = _edges.invoke()
 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithMappedTypes/expected/types/EntityEdge.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithMappedTypes/expected/types/EntityEdge.kt
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.`annotation`.JsonDeserialize
 import com.fasterxml.jackson.databind.`annotation`.JsonPOJOBuilder
 import java.lang.IllegalStateException
 import kotlin.String
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 @JsonDeserialize(builder = EntityEdge.Builder::class)
@@ -18,9 +19,11 @@ public class EntityEdge(
 
   private val _node: () -> Entity? = node
 
+  @get:JvmName("getCursor")
   public val cursor: String
     get() = _cursor.invoke()
 
+  @get:JvmName("getNode")
   public val node: Entity?
     get() = _node.invoke()
 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithMappedTypes/expected/types/Query.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithMappedTypes/expected/types/Query.kt
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.`annotation`.JsonDeserialize
 import com.fasterxml.jackson.databind.`annotation`.JsonPOJOBuilder
 import java.lang.IllegalStateException
 import kotlin.collections.List
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 @JsonDeserialize(builder = Query.Builder::class)
@@ -18,9 +19,11 @@ public class Query(
 
   private val _entityConnection: () -> EntityConnection? = entityConnection
 
+  @get:JvmName("getEntity")
   public val entity: List<Entity?>?
     get() = _entity.invoke()
 
+  @get:JvmName("getEntityConnection")
   public val entityConnection: EntityConnection?
     get() = _entityConnection.invoke()
 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithNonNullableAndInterface/expected/types/Employee.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithNonNullableAndInterface/expected/types/Employee.kt
@@ -7,6 +7,8 @@ import com.fasterxml.jackson.databind.`annotation`.JsonDeserialize
 import com.fasterxml.jackson.databind.`annotation`.JsonPOJOBuilder
 import java.lang.IllegalStateException
 import kotlin.String
+import kotlin.Suppress
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 @JsonDeserialize(builder = Employee.Builder::class)
@@ -21,12 +23,18 @@ public class Employee(
 
   private val _company: () -> String? = company
 
+  @Suppress("INAPPLICABLE_JVM_NAME")
+  @get:JvmName("getFirstname")
   public override val firstname: String
     get() = _firstname.invoke()
 
+  @Suppress("INAPPLICABLE_JVM_NAME")
+  @get:JvmName("getLastname")
   public override val lastname: String
     get() = _lastname.invoke()
 
+  @Suppress("INAPPLICABLE_JVM_NAME")
+  @get:JvmName("getCompany")
   public override val company: String?
     get() = _company.invoke()
 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithNonNullableAndInterface/expected/types/Person.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithNonNullableAndInterface/expected/types/Person.kt
@@ -3,6 +3,8 @@ package com.netflix.graphql.dgs.codegen.cases.dataClassWithNonNullableAndInterfa
 import com.fasterxml.jackson.`annotation`.JsonSubTypes
 import com.fasterxml.jackson.`annotation`.JsonTypeInfo
 import kotlin.String
+import kotlin.Suppress
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(
   use = JsonTypeInfo.Id.NAME,
@@ -13,9 +15,15 @@ import kotlin.String
   JsonSubTypes.Type(value = Employee::class, name = "Employee")
 ])
 public sealed interface Person {
+  @Suppress("INAPPLICABLE_JVM_NAME")
+  @get:JvmName("getFirstname")
   public val firstname: String
 
+  @Suppress("INAPPLICABLE_JVM_NAME")
+  @get:JvmName("getLastname")
   public val lastname: String
 
+  @Suppress("INAPPLICABLE_JVM_NAME")
+  @get:JvmName("getCompany")
   public val company: String?
 }

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithNonNullableAndInterface/expected/types/Query.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithNonNullableAndInterface/expected/types/Query.kt
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.`annotation`.JsonDeserialize
 import com.fasterxml.jackson.databind.`annotation`.JsonPOJOBuilder
 import java.lang.IllegalStateException
 import kotlin.collections.List
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 @JsonDeserialize(builder = Query.Builder::class)
@@ -15,6 +16,7 @@ public class Query(
 ) {
   private val _people: () -> List<Person?>? = people
 
+  @get:JvmName("getPeople")
   public val people: List<Person?>?
     get() = _people.invoke()
 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithNonNullableComplexType/expected/types/MyType.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithNonNullableComplexType/expected/types/MyType.kt
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.`annotation`.JsonTypeInfo
 import com.fasterxml.jackson.databind.`annotation`.JsonDeserialize
 import com.fasterxml.jackson.databind.`annotation`.JsonPOJOBuilder
 import java.lang.IllegalStateException
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 @JsonDeserialize(builder = MyType.Builder::class)
@@ -14,6 +15,7 @@ public class MyType(
 ) {
   private val _other: () -> OtherType = other
 
+  @get:JvmName("getOther")
   public val other: OtherType
     get() = _other.invoke()
 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithNonNullableComplexType/expected/types/OtherType.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithNonNullableComplexType/expected/types/OtherType.kt
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.`annotation`.JsonDeserialize
 import com.fasterxml.jackson.databind.`annotation`.JsonPOJOBuilder
 import java.lang.IllegalStateException
 import kotlin.String
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 @JsonDeserialize(builder = OtherType.Builder::class)
@@ -15,6 +16,7 @@ public class OtherType(
 ) {
   private val _name: () -> String = name
 
+  @get:JvmName("getName")
   public val name: String
     get() = _name.invoke()
 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithNonNullableListOfNullableValues/expected/types/Person.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithNonNullableListOfNullableValues/expected/types/Person.kt
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.`annotation`.JsonPOJOBuilder
 import java.lang.IllegalStateException
 import kotlin.String
 import kotlin.collections.List
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 @JsonDeserialize(builder = Person.Builder::class)
@@ -19,9 +20,11 @@ public class Person(
 
   private val _email: () -> List<String?> = email
 
+  @get:JvmName("getName")
   public val name: String
     get() = _name.invoke()
 
+  @get:JvmName("getEmail")
   public val email: List<String?>
     get() = _email.invoke()
 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithNonNullableListOfNullableValues/expected/types/Query.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithNonNullableListOfNullableValues/expected/types/Query.kt
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.`annotation`.JsonDeserialize
 import com.fasterxml.jackson.databind.`annotation`.JsonPOJOBuilder
 import java.lang.IllegalStateException
 import kotlin.collections.List
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 @JsonDeserialize(builder = Query.Builder::class)
@@ -15,6 +16,7 @@ public class Query(
 ) {
   private val _people: () -> List<Person?>? = people
 
+  @get:JvmName("getPeople")
   public val people: List<Person?>?
     get() = _people.invoke()
 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithNonNullablePrimitive/expected/types/MyType.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithNonNullablePrimitive/expected/types/MyType.kt
@@ -9,6 +9,7 @@ import java.lang.IllegalStateException
 import kotlin.Boolean
 import kotlin.Double
 import kotlin.Int
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 @JsonDeserialize(builder = MyType.Builder::class)
@@ -23,12 +24,15 @@ public class MyType(
 
   private val _floaty: () -> Double = floaty
 
+  @get:JvmName("getCount")
   public val count: Int
     get() = _count.invoke()
 
+  @get:JvmName("getTruth")
   public val truth: Boolean
     get() = _truth.invoke()
 
+  @get:JvmName("getFloaty")
   public val floaty: Double
     get() = _floaty.invoke()
 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithNonNullablePrimitiveInList/expected/types/MyType.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithNonNullablePrimitiveInList/expected/types/MyType.kt
@@ -10,6 +10,7 @@ import kotlin.Boolean
 import kotlin.Double
 import kotlin.Int
 import kotlin.collections.List
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 @JsonDeserialize(builder = MyType.Builder::class)
@@ -24,12 +25,15 @@ public class MyType(
 
   private val _floaty: () -> List<Double>? = floaty
 
+  @get:JvmName("getCount")
   public val count: List<Int>?
     get() = _count.invoke()
 
+  @get:JvmName("getTruth")
   public val truth: List<Boolean>?
     get() = _truth.invoke()
 
+  @get:JvmName("getFloaty")
   public val floaty: List<Double>?
     get() = _floaty.invoke()
 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithNonNullableProperties/expected/types/Person.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithNonNullableProperties/expected/types/Person.kt
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.`annotation`.JsonPOJOBuilder
 import java.lang.IllegalStateException
 import kotlin.String
 import kotlin.collections.List
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 @JsonDeserialize(builder = Person.Builder::class)
@@ -19,9 +20,11 @@ public class Person(
 
   private val _email: () -> List<String> = email
 
+  @get:JvmName("getName")
   public val name: String
     get() = _name.invoke()
 
+  @get:JvmName("getEmail")
   public val email: List<String>
     get() = _email.invoke()
 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithNonNullableProperties/expected/types/Query.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithNonNullableProperties/expected/types/Query.kt
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.`annotation`.JsonDeserialize
 import com.fasterxml.jackson.databind.`annotation`.JsonPOJOBuilder
 import java.lang.IllegalStateException
 import kotlin.collections.List
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 @JsonDeserialize(builder = Query.Builder::class)
@@ -15,6 +16,7 @@ public class Query(
 ) {
   private val _people: () -> List<Person>? = people
 
+  @get:JvmName("getPeople")
   public val people: List<Person>?
     get() = _people.invoke()
 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithNullablePrimitive/expected/types/MyType.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithNullablePrimitive/expected/types/MyType.kt
@@ -9,6 +9,7 @@ import java.lang.IllegalStateException
 import kotlin.Boolean
 import kotlin.Double
 import kotlin.Int
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 @JsonDeserialize(builder = MyType.Builder::class)
@@ -23,12 +24,15 @@ public class MyType(
 
   private val _floaty: () -> Double? = floaty
 
+  @get:JvmName("getCount")
   public val count: Int?
     get() = _count.invoke()
 
+  @get:JvmName("getTruth")
   public val truth: Boolean?
     get() = _truth.invoke()
 
+  @get:JvmName("getFloaty")
   public val floaty: Double?
     get() = _floaty.invoke()
 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithRecursiveField/expected/types/Person.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithRecursiveField/expected/types/Person.kt
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.`annotation`.JsonPOJOBuilder
 import java.lang.IllegalStateException
 import kotlin.String
 import kotlin.collections.List
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 @JsonDeserialize(builder = Person.Builder::class)
@@ -22,12 +23,15 @@ public class Person(
 
   private val _friends: () -> List<Person?>? = friends
 
+  @get:JvmName("getFirstname")
   public val firstname: String?
     get() = _firstname.invoke()
 
+  @get:JvmName("getLastname")
   public val lastname: String?
     get() = _lastname.invoke()
 
+  @get:JvmName("getFriends")
   public val friends: List<Person?>?
     get() = _friends.invoke()
 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithRecursiveField/expected/types/Query.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithRecursiveField/expected/types/Query.kt
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.`annotation`.JsonDeserialize
 import com.fasterxml.jackson.databind.`annotation`.JsonPOJOBuilder
 import java.lang.IllegalStateException
 import kotlin.collections.List
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 @JsonDeserialize(builder = Query.Builder::class)
@@ -15,6 +16,7 @@ public class Query(
 ) {
   private val _people: () -> List<Person?>? = people
 
+  @get:JvmName("getPeople")
   public val people: List<Person?>?
     get() = _people.invoke()
 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithStringProperties/expected/types/Person.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithStringProperties/expected/types/Person.kt
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.`annotation`.JsonDeserialize
 import com.fasterxml.jackson.databind.`annotation`.JsonPOJOBuilder
 import java.lang.IllegalStateException
 import kotlin.String
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 @JsonDeserialize(builder = Person.Builder::class)
@@ -18,9 +19,11 @@ public class Person(
 
   private val _lastname: () -> String? = lastname
 
+  @get:JvmName("getFirstname")
   public val firstname: String?
     get() = _firstname.invoke()
 
+  @get:JvmName("getLastname")
   public val lastname: String?
     get() = _lastname.invoke()
 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithStringProperties/expected/types/Query.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithStringProperties/expected/types/Query.kt
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.`annotation`.JsonDeserialize
 import com.fasterxml.jackson.databind.`annotation`.JsonPOJOBuilder
 import java.lang.IllegalStateException
 import kotlin.collections.List
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 @JsonDeserialize(builder = Query.Builder::class)
@@ -15,6 +16,7 @@ public class Query(
 ) {
   private val _people: () -> List<Person?>? = people
 
+  @get:JvmName("getPeople")
   public val people: List<Person?>?
     get() = _people.invoke()
 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/enum/expected/types/Query.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/enum/expected/types/Query.kt
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.`annotation`.JsonDeserialize
 import com.fasterxml.jackson.databind.`annotation`.JsonPOJOBuilder
 import java.lang.IllegalStateException
 import kotlin.collections.List
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 @JsonDeserialize(builder = Query.Builder::class)
@@ -15,6 +16,7 @@ public class Query(
 ) {
   private val _types: () -> List<EmployeeTypes?>? = types
 
+  @get:JvmName("getTypes")
   public val types: List<EmployeeTypes?>?
     get() = _types.invoke()
 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/enumWithExtendedType/expected/types/Query.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/enumWithExtendedType/expected/types/Query.kt
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.`annotation`.JsonDeserialize
 import com.fasterxml.jackson.databind.`annotation`.JsonPOJOBuilder
 import java.lang.IllegalStateException
 import kotlin.collections.List
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 @JsonDeserialize(builder = Query.Builder::class)
@@ -15,6 +16,7 @@ public class Query(
 ) {
   private val _types: () -> List<EmployeeTypes?>? = types
 
+  @get:JvmName("getTypes")
   public val types: List<EmployeeTypes?>?
     get() = _types.invoke()
 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/input/expected/types/Query.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/input/expected/types/Query.kt
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.`annotation`.JsonPOJOBuilder
 import java.lang.IllegalStateException
 import kotlin.String
 import kotlin.collections.List
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 @JsonDeserialize(builder = Query.Builder::class)
@@ -16,6 +17,7 @@ public class Query(
 ) {
   private val _movies: () -> List<String?>? = movies
 
+  @get:JvmName("getMovies")
   public val movies: List<String?>?
     get() = _movies.invoke()
 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/inputWithExtendedType/expected/types/Query.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/inputWithExtendedType/expected/types/Query.kt
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.`annotation`.JsonPOJOBuilder
 import java.lang.IllegalStateException
 import kotlin.String
 import kotlin.collections.List
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 @JsonDeserialize(builder = Query.Builder::class)
@@ -16,6 +17,7 @@ public class Query(
 ) {
   private val _movies: () -> List<String?>? = movies
 
+  @get:JvmName("getMovies")
   public val movies: List<String?>?
     get() = _movies.invoke()
 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/interfaceClassWithInterfaceFields/expected/types/Bird.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/interfaceClassWithInterfaceFields/expected/types/Bird.kt
@@ -7,7 +7,9 @@ import com.fasterxml.jackson.databind.`annotation`.JsonDeserialize
 import com.fasterxml.jackson.databind.`annotation`.JsonPOJOBuilder
 import java.lang.IllegalStateException
 import kotlin.String
+import kotlin.Suppress
 import kotlin.collections.List
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 @JsonDeserialize(builder = Bird.Builder::class)
@@ -31,21 +33,33 @@ public class Bird(
 
   private val _parents: () -> List<Bird?>? = parents
 
+  @Suppress("INAPPLICABLE_JVM_NAME")
+  @get:JvmName("getId")
   public override val id: String
     get() = _id.invoke()
 
+  @Suppress("INAPPLICABLE_JVM_NAME")
+  @get:JvmName("getName")
   public override val name: String?
     get() = _name.invoke()
 
+  @Suppress("INAPPLICABLE_JVM_NAME")
+  @get:JvmName("getAddress")
   public override val address: List<String>
     get() = _address.invoke()
 
+  @Suppress("INAPPLICABLE_JVM_NAME")
+  @get:JvmName("getMother")
   public override val mother: Bird
     get() = _mother.invoke()
 
+  @Suppress("INAPPLICABLE_JVM_NAME")
+  @get:JvmName("getFather")
   public override val father: Bird?
     get() = _father.invoke()
 
+  @Suppress("INAPPLICABLE_JVM_NAME")
+  @get:JvmName("getParents")
   public override val parents: List<Bird?>?
     get() = _parents.invoke()
 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/interfaceClassWithInterfaceFields/expected/types/Dog.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/interfaceClassWithInterfaceFields/expected/types/Dog.kt
@@ -7,7 +7,9 @@ import com.fasterxml.jackson.databind.`annotation`.JsonDeserialize
 import com.fasterxml.jackson.databind.`annotation`.JsonPOJOBuilder
 import java.lang.IllegalStateException
 import kotlin.String
+import kotlin.Suppress
 import kotlin.collections.List
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 @JsonDeserialize(builder = Dog.Builder::class)
@@ -31,21 +33,33 @@ public class Dog(
 
   private val _parents: () -> List<Dog?>? = parents
 
+  @Suppress("INAPPLICABLE_JVM_NAME")
+  @get:JvmName("getId")
   public override val id: String
     get() = _id.invoke()
 
+  @Suppress("INAPPLICABLE_JVM_NAME")
+  @get:JvmName("getName")
   public override val name: String?
     get() = _name.invoke()
 
+  @Suppress("INAPPLICABLE_JVM_NAME")
+  @get:JvmName("getAddress")
   public override val address: List<String>
     get() = _address.invoke()
 
+  @Suppress("INAPPLICABLE_JVM_NAME")
+  @get:JvmName("getMother")
   public override val mother: Dog
     get() = _mother.invoke()
 
+  @Suppress("INAPPLICABLE_JVM_NAME")
+  @get:JvmName("getFather")
   public override val father: Dog?
     get() = _father.invoke()
 
+  @Suppress("INAPPLICABLE_JVM_NAME")
+  @get:JvmName("getParents")
   public override val parents: List<Dog?>?
     get() = _parents.invoke()
 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/interfaceClassWithInterfaceFields/expected/types/Pet.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/interfaceClassWithInterfaceFields/expected/types/Pet.kt
@@ -3,7 +3,9 @@ package com.netflix.graphql.dgs.codegen.cases.interfaceClassWithInterfaceFields.
 import com.fasterxml.jackson.`annotation`.JsonSubTypes
 import com.fasterxml.jackson.`annotation`.JsonTypeInfo
 import kotlin.String
+import kotlin.Suppress
 import kotlin.collections.List
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(
   use = JsonTypeInfo.Id.NAME,
@@ -15,15 +17,27 @@ import kotlin.collections.List
   JsonSubTypes.Type(value = Bird::class, name = "Bird")
 ])
 public sealed interface Pet {
+  @Suppress("INAPPLICABLE_JVM_NAME")
+  @get:JvmName("getId")
   public val id: String
 
+  @Suppress("INAPPLICABLE_JVM_NAME")
+  @get:JvmName("getName")
   public val name: String?
 
+  @Suppress("INAPPLICABLE_JVM_NAME")
+  @get:JvmName("getAddress")
   public val address: List<String>
 
+  @Suppress("INAPPLICABLE_JVM_NAME")
+  @get:JvmName("getMother")
   public val mother: Pet
 
+  @Suppress("INAPPLICABLE_JVM_NAME")
+  @get:JvmName("getFather")
   public val father: Pet?
 
+  @Suppress("INAPPLICABLE_JVM_NAME")
+  @get:JvmName("getParents")
   public val parents: List<Pet?>?
 }

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/interfaceClassWithInterfaceFieldsOfDifferentType/expected/types/Diet.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/interfaceClassWithInterfaceFieldsOfDifferentType/expected/types/Diet.kt
@@ -3,6 +3,8 @@ package com.netflix.graphql.dgs.codegen.cases.interfaceClassWithInterfaceFieldsO
 import com.fasterxml.jackson.`annotation`.JsonSubTypes
 import com.fasterxml.jackson.`annotation`.JsonTypeInfo
 import kotlin.String
+import kotlin.Suppress
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(
   use = JsonTypeInfo.Id.NAME,
@@ -13,5 +15,7 @@ import kotlin.String
   JsonSubTypes.Type(value = Vegetarian::class, name = "Vegetarian")
 ])
 public sealed interface Diet {
+  @Suppress("INAPPLICABLE_JVM_NAME")
+  @get:JvmName("getCalories")
   public val calories: String?
 }

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/interfaceClassWithInterfaceFieldsOfDifferentType/expected/types/Dog.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/interfaceClassWithInterfaceFieldsOfDifferentType/expected/types/Dog.kt
@@ -7,6 +7,8 @@ import com.fasterxml.jackson.databind.`annotation`.JsonDeserialize
 import com.fasterxml.jackson.databind.`annotation`.JsonPOJOBuilder
 import java.lang.IllegalStateException
 import kotlin.String
+import kotlin.Suppress
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 @JsonDeserialize(builder = Dog.Builder::class)
@@ -18,9 +20,13 @@ public class Dog(
 
   private val _diet: () -> Vegetarian? = diet
 
+  @Suppress("INAPPLICABLE_JVM_NAME")
+  @get:JvmName("getName")
   public override val name: String?
     get() = _name.invoke()
 
+  @Suppress("INAPPLICABLE_JVM_NAME")
+  @get:JvmName("getDiet")
   public override val diet: Vegetarian?
     get() = _diet.invoke()
 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/interfaceClassWithInterfaceFieldsOfDifferentType/expected/types/Pet.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/interfaceClassWithInterfaceFieldsOfDifferentType/expected/types/Pet.kt
@@ -3,6 +3,8 @@ package com.netflix.graphql.dgs.codegen.cases.interfaceClassWithInterfaceFieldsO
 import com.fasterxml.jackson.`annotation`.JsonSubTypes
 import com.fasterxml.jackson.`annotation`.JsonTypeInfo
 import kotlin.String
+import kotlin.Suppress
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(
   use = JsonTypeInfo.Id.NAME,
@@ -13,7 +15,11 @@ import kotlin.String
   JsonSubTypes.Type(value = Dog::class, name = "Dog")
 ])
 public sealed interface Pet {
+  @Suppress("INAPPLICABLE_JVM_NAME")
+  @get:JvmName("getName")
   public val name: String?
 
+  @Suppress("INAPPLICABLE_JVM_NAME")
+  @get:JvmName("getDiet")
   public val diet: Diet?
 }

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/interfaceClassWithInterfaceFieldsOfDifferentType/expected/types/Vegetarian.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/interfaceClassWithInterfaceFieldsOfDifferentType/expected/types/Vegetarian.kt
@@ -7,7 +7,9 @@ import com.fasterxml.jackson.databind.`annotation`.JsonDeserialize
 import com.fasterxml.jackson.databind.`annotation`.JsonPOJOBuilder
 import java.lang.IllegalStateException
 import kotlin.String
+import kotlin.Suppress
 import kotlin.collections.List
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 @JsonDeserialize(builder = Vegetarian.Builder::class)
@@ -19,9 +21,12 @@ public class Vegetarian(
 
   private val _vegetables: () -> List<String?>? = vegetables
 
+  @Suppress("INAPPLICABLE_JVM_NAME")
+  @get:JvmName("getCalories")
   public override val calories: String?
     get() = _calories.invoke()
 
+  @get:JvmName("getVegetables")
   public val vegetables: List<String?>?
     get() = _vegetables.invoke()
 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/interfaceClassWithNonNullableFields/expected/types/Employee.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/interfaceClassWithNonNullableFields/expected/types/Employee.kt
@@ -7,6 +7,8 @@ import com.fasterxml.jackson.databind.`annotation`.JsonDeserialize
 import com.fasterxml.jackson.databind.`annotation`.JsonPOJOBuilder
 import java.lang.IllegalStateException
 import kotlin.String
+import kotlin.Suppress
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 @JsonDeserialize(builder = Employee.Builder::class)
@@ -21,12 +23,17 @@ public class Employee(
 
   private val _company: () -> String? = company
 
+  @Suppress("INAPPLICABLE_JVM_NAME")
+  @get:JvmName("getFirstname")
   public override val firstname: String
     get() = _firstname.invoke()
 
+  @Suppress("INAPPLICABLE_JVM_NAME")
+  @get:JvmName("getLastname")
   public override val lastname: String?
     get() = _lastname.invoke()
 
+  @get:JvmName("getCompany")
   public val company: String?
     get() = _company.invoke()
 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/interfaceClassWithNonNullableFields/expected/types/Person.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/interfaceClassWithNonNullableFields/expected/types/Person.kt
@@ -3,6 +3,8 @@ package com.netflix.graphql.dgs.codegen.cases.interfaceClassWithNonNullableField
 import com.fasterxml.jackson.`annotation`.JsonSubTypes
 import com.fasterxml.jackson.`annotation`.JsonTypeInfo
 import kotlin.String
+import kotlin.Suppress
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(
   use = JsonTypeInfo.Id.NAME,
@@ -13,7 +15,11 @@ import kotlin.String
   JsonSubTypes.Type(value = Employee::class, name = "Employee")
 ])
 public sealed interface Person {
+  @Suppress("INAPPLICABLE_JVM_NAME")
+  @get:JvmName("getFirstname")
   public val firstname: String
 
+  @Suppress("INAPPLICABLE_JVM_NAME")
+  @get:JvmName("getLastname")
   public val lastname: String?
 }

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/interfaceClassWithNonNullableFields/expected/types/Query.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/interfaceClassWithNonNullableFields/expected/types/Query.kt
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.`annotation`.JsonDeserialize
 import com.fasterxml.jackson.databind.`annotation`.JsonPOJOBuilder
 import java.lang.IllegalStateException
 import kotlin.collections.List
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 @JsonDeserialize(builder = Query.Builder::class)
@@ -15,6 +16,7 @@ public class Query(
 ) {
   private val _people: () -> List<Person?>? = people
 
+  @get:JvmName("getPeople")
   public val people: List<Person?>?
     get() = _people.invoke()
 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/interfaceDocs/expected/types/Titled.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/interfaceDocs/expected/types/Titled.kt
@@ -2,6 +2,8 @@ package com.netflix.graphql.dgs.codegen.cases.interfaceDocs.expected.types
 
 import com.fasterxml.jackson.`annotation`.JsonTypeInfo
 import kotlin.String
+import kotlin.Suppress
+import kotlin.jvm.JvmName
 
 /**
  * Anything with a title!
@@ -12,5 +14,7 @@ import kotlin.String
   property = "__typename",
 )
 public sealed interface Titled {
+  @Suppress("INAPPLICABLE_JVM_NAME")
+  @get:JvmName("getTitle")
   public val title: String?
 }

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/interfaceFieldsDocs/expected/types/Titled.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/interfaceFieldsDocs/expected/types/Titled.kt
@@ -2,6 +2,8 @@ package com.netflix.graphql.dgs.codegen.cases.interfaceFieldsDocs.expected.types
 
 import com.fasterxml.jackson.`annotation`.JsonTypeInfo
 import kotlin.String
+import kotlin.Suppress
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(
   use = JsonTypeInfo.Id.NAME,
@@ -12,5 +14,7 @@ public sealed interface Titled {
   /**
    * The original, non localized title.
    */
+  @Suppress("INAPPLICABLE_JVM_NAME")
+  @get:JvmName("getTitle")
   public val title: String?
 }

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/interfaceWithInterfaceInheritance/expected/types/Fruit.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/interfaceWithInterfaceInheritance/expected/types/Fruit.kt
@@ -1,7 +1,9 @@
 package com.netflix.graphql.dgs.codegen.cases.interfaceWithInterfaceInheritance.expected.types
 
 import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.Suppress
 import kotlin.collections.List
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(
   use = JsonTypeInfo.Id.NAME,
@@ -9,5 +11,7 @@ import kotlin.collections.List
   property = "__typename",
 )
 public sealed interface Fruit {
+  @Suppress("INAPPLICABLE_JVM_NAME")
+  @get:JvmName("getSeeds")
   public val seeds: List<Seed?>?
 }

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/interfaceWithInterfaceInheritance/expected/types/Query.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/interfaceWithInterfaceInheritance/expected/types/Query.kt
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.`annotation`.JsonDeserialize
 import com.fasterxml.jackson.databind.`annotation`.JsonPOJOBuilder
 import java.lang.IllegalStateException
 import kotlin.collections.List
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 @JsonDeserialize(builder = Query.Builder::class)
@@ -15,6 +16,7 @@ public class Query(
 ) {
   private val _fruits: () -> List<Fruit?>? = fruits
 
+  @get:JvmName("getFruits")
   public val fruits: List<Fruit?>?
     get() = _fruits.invoke()
 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/interfaceWithInterfaceInheritance/expected/types/Seed.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/interfaceWithInterfaceInheritance/expected/types/Seed.kt
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.`annotation`.JsonDeserialize
 import com.fasterxml.jackson.databind.`annotation`.JsonPOJOBuilder
 import java.lang.IllegalStateException
 import kotlin.String
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 @JsonDeserialize(builder = Seed.Builder::class)
@@ -15,6 +16,7 @@ public class Seed(
 ) {
   private val _name: () -> String? = name
 
+  @get:JvmName("getName")
   public val name: String?
     get() = _name.invoke()
 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/interfaceWithInterfaceInheritance/expected/types/StoneFruit.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/interfaceWithInterfaceInheritance/expected/types/StoneFruit.kt
@@ -2,7 +2,9 @@ package com.netflix.graphql.dgs.codegen.cases.interfaceWithInterfaceInheritance.
 
 import com.fasterxml.jackson.`annotation`.JsonTypeInfo
 import kotlin.Boolean
+import kotlin.Suppress
 import kotlin.collections.List
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(
   use = JsonTypeInfo.Id.NAME,
@@ -10,7 +12,11 @@ import kotlin.collections.List
   property = "__typename",
 )
 public sealed interface StoneFruit : Fruit {
+  @Suppress("INAPPLICABLE_JVM_NAME")
+  @get:JvmName("getSeeds")
   public override val seeds: List<Seed?>?
 
+  @Suppress("INAPPLICABLE_JVM_NAME")
+  @get:JvmName("getFuzzy")
   public val fuzzy: Boolean?
 }

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/projectionWithEnum/expected/types/Query.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/projectionWithEnum/expected/types/Query.kt
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.`annotation`.JsonDeserialize
 import com.fasterxml.jackson.databind.`annotation`.JsonPOJOBuilder
 import java.lang.IllegalStateException
 import kotlin.collections.List
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 @JsonDeserialize(builder = Query.Builder::class)
@@ -18,9 +19,11 @@ public class Query(
 
   private val _es: () -> List<E?>? = es
 
+  @get:JvmName("getE")
   public val e: E?
     get() = _e.invoke()
 
+  @get:JvmName("getEs")
   public val es: List<E?>?
     get() = _es.invoke()
 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/projectionWithNestedInputs/expected/types/Query.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/projectionWithNestedInputs/expected/types/Query.kt
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.`annotation`.JsonDeserialize
 import com.fasterxml.jackson.databind.`annotation`.JsonPOJOBuilder
 import java.lang.IllegalStateException
 import kotlin.String
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 @JsonDeserialize(builder = Query.Builder::class)
@@ -18,9 +19,11 @@ public class Query(
 
   private val _q2: () -> String? = q2
 
+  @get:JvmName("getQ1")
   public val q1: String?
     get() = _q1.invoke()
 
+  @get:JvmName("getQ2")
   public val q2: String?
     get() = _q2.invoke()
 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/projectionWithPrimitiveAndArgs/expected/types/Query.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/projectionWithPrimitiveAndArgs/expected/types/Query.kt
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.`annotation`.JsonDeserialize
 import com.fasterxml.jackson.databind.`annotation`.JsonPOJOBuilder
 import java.lang.IllegalStateException
 import kotlin.String
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 @JsonDeserialize(builder = Query.Builder::class)
@@ -15,6 +16,7 @@ public class Query(
 ) {
   private val _string: () -> String? = string
 
+  @get:JvmName("getString")
   public val string: String?
     get() = _string.invoke()
 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/projectionWithPrimitives/expected/types/Query.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/projectionWithPrimitives/expected/types/Query.kt
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.`annotation`.JsonPOJOBuilder
 import java.lang.IllegalStateException
 import kotlin.String
 import kotlin.collections.List
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 @JsonDeserialize(builder = Query.Builder::class)
@@ -19,9 +20,11 @@ public class Query(
 
   private val _strings: () -> List<String?>? = strings
 
+  @get:JvmName("getString")
   public val string: String?
     get() = _string.invoke()
 
+  @get:JvmName("getStrings")
   public val strings: List<String?>?
     get() = _strings.invoke()
 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/projectionWithType/expected/types/Employee.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/projectionWithType/expected/types/Employee.kt
@@ -7,6 +7,8 @@ import com.fasterxml.jackson.databind.`annotation`.JsonDeserialize
 import com.fasterxml.jackson.databind.`annotation`.JsonPOJOBuilder
 import java.lang.IllegalStateException
 import kotlin.String
+import kotlin.Suppress
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 @JsonDeserialize(builder = Employee.Builder::class)
@@ -18,9 +20,12 @@ public class Employee(
 
   private val _company: () -> String? = company
 
+  @Suppress("INAPPLICABLE_JVM_NAME")
+  @get:JvmName("getFirstname")
   public override val firstname: String?
     get() = _firstname.invoke()
 
+  @get:JvmName("getCompany")
   public val company: String?
     get() = _company.invoke()
 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/projectionWithType/expected/types/Person.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/projectionWithType/expected/types/Person.kt
@@ -3,6 +3,8 @@ package com.netflix.graphql.dgs.codegen.cases.projectionWithType.expected.types
 import com.fasterxml.jackson.`annotation`.JsonSubTypes
 import com.fasterxml.jackson.`annotation`.JsonTypeInfo
 import kotlin.String
+import kotlin.Suppress
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(
   use = JsonTypeInfo.Id.NAME,
@@ -13,5 +15,7 @@ import kotlin.String
   JsonSubTypes.Type(value = Employee::class, name = "Employee")
 ])
 public sealed interface Person {
+  @Suppress("INAPPLICABLE_JVM_NAME")
+  @get:JvmName("getFirstname")
   public val firstname: String?
 }

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/projectionWithType/expected/types/Query.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/projectionWithType/expected/types/Query.kt
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.`annotation`.JsonDeserialize
 import com.fasterxml.jackson.databind.`annotation`.JsonPOJOBuilder
 import java.lang.IllegalStateException
 import kotlin.collections.List
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 @JsonDeserialize(builder = Query.Builder::class)
@@ -18,9 +19,11 @@ public class Query(
 
   private val _people: () -> List<Person?>? = people
 
+  @get:JvmName("getPerson")
   public val person: Person?
     get() = _person.invoke()
 
+  @get:JvmName("getPeople")
   public val people: List<Person?>?
     get() = _people.invoke()
 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/projectionWithTypeAndArgs/expected/types/Employee.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/projectionWithTypeAndArgs/expected/types/Employee.kt
@@ -7,6 +7,8 @@ import com.fasterxml.jackson.databind.`annotation`.JsonDeserialize
 import com.fasterxml.jackson.databind.`annotation`.JsonPOJOBuilder
 import java.lang.IllegalStateException
 import kotlin.String
+import kotlin.Suppress
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 @JsonDeserialize(builder = Employee.Builder::class)
@@ -18,9 +20,12 @@ public class Employee(
 
   private val _company: () -> String? = company
 
+  @Suppress("INAPPLICABLE_JVM_NAME")
+  @get:JvmName("getFirstname")
   public override val firstname: String?
     get() = _firstname.invoke()
 
+  @get:JvmName("getCompany")
   public val company: String?
     get() = _company.invoke()
 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/projectionWithTypeAndArgs/expected/types/Person.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/projectionWithTypeAndArgs/expected/types/Person.kt
@@ -3,6 +3,8 @@ package com.netflix.graphql.dgs.codegen.cases.projectionWithTypeAndArgs.expected
 import com.fasterxml.jackson.`annotation`.JsonSubTypes
 import com.fasterxml.jackson.`annotation`.JsonTypeInfo
 import kotlin.String
+import kotlin.Suppress
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(
   use = JsonTypeInfo.Id.NAME,
@@ -13,5 +15,7 @@ import kotlin.String
   JsonSubTypes.Type(value = Employee::class, name = "Employee")
 ])
 public sealed interface Person {
+  @Suppress("INAPPLICABLE_JVM_NAME")
+  @get:JvmName("getFirstname")
   public val firstname: String?
 }

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/projectionWithTypeAndArgs/expected/types/Query.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/projectionWithTypeAndArgs/expected/types/Query.kt
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.`annotation`.JsonTypeInfo
 import com.fasterxml.jackson.databind.`annotation`.JsonDeserialize
 import com.fasterxml.jackson.databind.`annotation`.JsonPOJOBuilder
 import java.lang.IllegalStateException
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 @JsonDeserialize(builder = Query.Builder::class)
@@ -14,6 +15,7 @@ public class Query(
 ) {
   private val _person: () -> Person? = person
 
+  @get:JvmName("getPerson")
   public val person: Person?
     get() = _person.invoke()
 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/projectionWithUnion/expected/types/Employee.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/projectionWithUnion/expected/types/Employee.kt
@@ -7,6 +7,8 @@ import com.fasterxml.jackson.databind.`annotation`.JsonDeserialize
 import com.fasterxml.jackson.databind.`annotation`.JsonPOJOBuilder
 import java.lang.IllegalStateException
 import kotlin.String
+import kotlin.Suppress
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 @JsonDeserialize(builder = Employee.Builder::class)
@@ -18,9 +20,12 @@ public class Employee(
 
   private val _company: () -> String? = company
 
+  @Suppress("INAPPLICABLE_JVM_NAME")
+  @get:JvmName("getFirstname")
   public override val firstname: String?
     get() = _firstname.invoke()
 
+  @get:JvmName("getCompany")
   public val company: String?
     get() = _company.invoke()
 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/projectionWithUnion/expected/types/Person.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/projectionWithUnion/expected/types/Person.kt
@@ -3,6 +3,8 @@ package com.netflix.graphql.dgs.codegen.cases.projectionWithUnion.expected.types
 import com.fasterxml.jackson.`annotation`.JsonSubTypes
 import com.fasterxml.jackson.`annotation`.JsonTypeInfo
 import kotlin.String
+import kotlin.Suppress
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(
   use = JsonTypeInfo.Id.NAME,
@@ -13,5 +15,7 @@ import kotlin.String
   JsonSubTypes.Type(value = Employee::class, name = "Employee")
 ])
 public sealed interface Person {
+  @Suppress("INAPPLICABLE_JVM_NAME")
+  @get:JvmName("getFirstname")
   public val firstname: String?
 }

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/projectionWithUnion/expected/types/Query.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/projectionWithUnion/expected/types/Query.kt
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.`annotation`.JsonDeserialize
 import com.fasterxml.jackson.databind.`annotation`.JsonPOJOBuilder
 import java.lang.IllegalStateException
 import kotlin.collections.List
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 @JsonDeserialize(builder = Query.Builder::class)
@@ -18,9 +19,11 @@ public class Query(
 
   private val _us: () -> List<U?>? = us
 
+  @get:JvmName("getU")
   public val u: U?
     get() = _u.invoke()
 
+  @get:JvmName("getUs")
   public val us: List<U?>?
     get() = _us.invoke()
 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/skipCodegenOnFields/expected/types/Person.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/skipCodegenOnFields/expected/types/Person.kt
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.`annotation`.JsonDeserialize
 import com.fasterxml.jackson.databind.`annotation`.JsonPOJOBuilder
 import java.lang.IllegalStateException
 import kotlin.String
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 @JsonDeserialize(builder = Person.Builder::class)
@@ -15,6 +16,7 @@ public class Person(
 ) {
   private val _name: () -> String? = name
 
+  @get:JvmName("getName")
   public val name: String?
     get() = _name.invoke()
 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/skipCodegenOnInterfaceFields/expected/types/Person.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/skipCodegenOnInterfaceFields/expected/types/Person.kt
@@ -2,6 +2,8 @@ package com.netflix.graphql.dgs.codegen.cases.skipCodegenOnInterfaceFields.expec
 
 import com.fasterxml.jackson.`annotation`.JsonTypeInfo
 import kotlin.String
+import kotlin.Suppress
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(
   use = JsonTypeInfo.Id.NAME,
@@ -9,5 +11,7 @@ import kotlin.String
   property = "__typename",
 )
 public sealed interface Person {
+  @Suppress("INAPPLICABLE_JVM_NAME")
+  @get:JvmName("getName")
   public val name: String?
 }

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/skipCodegenOnTypes/expected/types/Person.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/skipCodegenOnTypes/expected/types/Person.kt
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.`annotation`.JsonDeserialize
 import com.fasterxml.jackson.databind.`annotation`.JsonPOJOBuilder
 import java.lang.IllegalStateException
 import kotlin.String
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 @JsonDeserialize(builder = Person.Builder::class)
@@ -15,6 +16,7 @@ public class Person(
 ) {
   private val _name: () -> String? = name
 
+  @get:JvmName("getName")
   public val name: String?
     get() = _name.invoke()
 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/union/expected/types/Actor.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/union/expected/types/Actor.kt
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.`annotation`.JsonDeserialize
 import com.fasterxml.jackson.databind.`annotation`.JsonPOJOBuilder
 import java.lang.IllegalStateException
 import kotlin.String
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 @JsonDeserialize(builder = Actor.Builder::class)
@@ -15,6 +16,7 @@ public class Actor(
 ) : SearchResult {
   private val _name: () -> String? = name
 
+  @get:JvmName("getName")
   public val name: String?
     get() = _name.invoke()
 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/union/expected/types/Movie.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/union/expected/types/Movie.kt
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.`annotation`.JsonDeserialize
 import com.fasterxml.jackson.databind.`annotation`.JsonPOJOBuilder
 import java.lang.IllegalStateException
 import kotlin.String
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 @JsonDeserialize(builder = Movie.Builder::class)
@@ -15,6 +16,7 @@ public class Movie(
 ) : SearchResult {
   private val _title: () -> String? = title
 
+  @get:JvmName("getTitle")
   public val title: String?
     get() = _title.invoke()
 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/union/expected/types/Query.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/union/expected/types/Query.kt
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.`annotation`.JsonDeserialize
 import com.fasterxml.jackson.databind.`annotation`.JsonPOJOBuilder
 import java.lang.IllegalStateException
 import kotlin.collections.List
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 @JsonDeserialize(builder = Query.Builder::class)
@@ -15,6 +16,7 @@ public class Query(
 ) {
   private val _search: () -> List<SearchResult?>? = search
 
+  @get:JvmName("getSearch")
   public val search: List<SearchResult?>?
     get() = _search.invoke()
 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/unionTypesWithoutInterfaceCanDeserialize/expected/types/Droid.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/unionTypesWithoutInterfaceCanDeserialize/expected/types/Droid.kt
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.`annotation`.JsonDeserialize
 import com.fasterxml.jackson.databind.`annotation`.JsonPOJOBuilder
 import java.lang.IllegalStateException
 import kotlin.String
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 @JsonDeserialize(builder = Droid.Builder::class)
@@ -21,12 +22,15 @@ public class Droid(
 
   private val _primaryFunction: () -> String? = primaryFunction
 
+  @get:JvmName("getId")
   public val id: String
     get() = _id.invoke()
 
+  @get:JvmName("getName")
   public val name: String
     get() = _name.invoke()
 
+  @get:JvmName("getPrimaryFunction")
   public val primaryFunction: String?
     get() = _primaryFunction.invoke()
 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/unionTypesWithoutInterfaceCanDeserialize/expected/types/Human.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/unionTypesWithoutInterfaceCanDeserialize/expected/types/Human.kt
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.`annotation`.JsonPOJOBuilder
 import java.lang.IllegalStateException
 import kotlin.Int
 import kotlin.String
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 @JsonDeserialize(builder = Human.Builder::class)
@@ -22,12 +23,15 @@ public class Human(
 
   private val _totalCredits: () -> Int? = totalCredits
 
+  @get:JvmName("getId")
   public val id: String
     get() = _id.invoke()
 
+  @get:JvmName("getName")
   public val name: String
     get() = _name.invoke()
 
+  @get:JvmName("getTotalCredits")
   public val totalCredits: Int?
     get() = _totalCredits.invoke()
 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/unionTypesWithoutInterfaceCanDeserialize/expected/types/Query.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/unionTypesWithoutInterfaceCanDeserialize/expected/types/Query.kt
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.`annotation`.JsonTypeInfo
 import com.fasterxml.jackson.databind.`annotation`.JsonDeserialize
 import com.fasterxml.jackson.databind.`annotation`.JsonPOJOBuilder
 import java.lang.IllegalStateException
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 @JsonDeserialize(builder = Query.Builder::class)
@@ -14,6 +15,7 @@ public class Query(
 ) {
   private val _search: () -> SearchResultPage? = search
 
+  @get:JvmName("getSearch")
   public val search: SearchResultPage?
     get() = _search.invoke()
 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/unionTypesWithoutInterfaceCanDeserialize/expected/types/SearchResultPage.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/unionTypesWithoutInterfaceCanDeserialize/expected/types/SearchResultPage.kt
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.`annotation`.JsonDeserialize
 import com.fasterxml.jackson.databind.`annotation`.JsonPOJOBuilder
 import java.lang.IllegalStateException
 import kotlin.collections.List
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 @JsonDeserialize(builder = SearchResultPage.Builder::class)
@@ -15,6 +16,7 @@ public class SearchResultPage(
 ) {
   private val _items: () -> List<SearchResult?>? = items
 
+  @get:JvmName("getItems")
   public val items: List<SearchResult?>?
     get() = _items.invoke()
 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/unionWithExtendedType/expected/types/Actor.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/unionWithExtendedType/expected/types/Actor.kt
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.`annotation`.JsonDeserialize
 import com.fasterxml.jackson.databind.`annotation`.JsonPOJOBuilder
 import java.lang.IllegalStateException
 import kotlin.String
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 @JsonDeserialize(builder = Actor.Builder::class)
@@ -15,6 +16,7 @@ public class Actor(
 ) : SearchResult {
   private val _name: () -> String? = name
 
+  @get:JvmName("getName")
   public val name: String?
     get() = _name.invoke()
 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/unionWithExtendedType/expected/types/Movie.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/unionWithExtendedType/expected/types/Movie.kt
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.`annotation`.JsonDeserialize
 import com.fasterxml.jackson.databind.`annotation`.JsonPOJOBuilder
 import java.lang.IllegalStateException
 import kotlin.String
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 @JsonDeserialize(builder = Movie.Builder::class)
@@ -15,6 +16,7 @@ public class Movie(
 ) : SearchResult {
   private val _title: () -> String? = title
 
+  @get:JvmName("getTitle")
   public val title: String?
     get() = _title.invoke()
 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/unionWithExtendedType/expected/types/Query.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/unionWithExtendedType/expected/types/Query.kt
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.`annotation`.JsonDeserialize
 import com.fasterxml.jackson.databind.`annotation`.JsonPOJOBuilder
 import java.lang.IllegalStateException
 import kotlin.collections.List
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 @JsonDeserialize(builder = Query.Builder::class)
@@ -15,6 +16,7 @@ public class Query(
 ) {
   private val _search: () -> List<SearchResult?>? = search
 
+  @get:JvmName("getSearch")
   public val search: List<SearchResult?>?
     get() = _search.invoke()
 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/unionWithExtendedType/expected/types/Rating.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/unionWithExtendedType/expected/types/Rating.kt
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.`annotation`.JsonDeserialize
 import com.fasterxml.jackson.databind.`annotation`.JsonPOJOBuilder
 import java.lang.IllegalStateException
 import kotlin.Int
+import kotlin.jvm.JvmName
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 @JsonDeserialize(builder = Rating.Builder::class)
@@ -15,6 +16,7 @@ public class Rating(
 ) : SearchResult {
   private val _stars: () -> Int? = stars
 
+  @get:JvmName("getStars")
   public val stars: Int?
     get() = _stars.invoke()
 

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinPoetUtils.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinPoetUtils.kt
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder
 import com.netflix.graphql.dgs.codegen.CodeGen
 import com.netflix.graphql.dgs.codegen.CodeGenConfig
+import com.netflix.graphql.dgs.codegen.generators.shared.CodeGeneratorUtils.capitalized
 import com.netflix.graphql.dgs.codegen.generators.shared.generatedAnnotationClassName
 import com.netflix.graphql.dgs.codegen.generators.shared.generatedDate
 import com.squareup.kotlinpoet.*
@@ -126,6 +127,36 @@ fun jsonDeserializeAnnotation(builderType: ClassName): AnnotationSpec {
  */
 fun jsonBuilderAnnotation(): AnnotationSpec {
     return AnnotationSpec.builder(JsonPOJOBuilder::class)
+        .build()
+}
+
+/**
+ * Generate a [JvmName] annotation for a kotlin property.
+ *
+ * Example generated annotation:
+ * ```
+ * @JvmName("getIsRequired")
+ * ```
+ */
+fun jvmNameAnnotation(name: String): AnnotationSpec {
+    return AnnotationSpec.builder(JvmName::class)
+        .useSiteTarget(AnnotationSpec.UseSiteTarget.GET)
+        .addMember("%S", "get${name.capitalized()}")
+        .build()
+}
+
+/**
+ * Generate a [Suppress] annotation for a kotlin property.
+ * See: https://youtrack.jetbrains.com/issue/KT-31420
+ *
+ * Example generated annotation:
+ * ```
+ * @Suppress("INAPPLICABLE_JVM_NAME")
+ * ```
+ */
+fun suppressInapplicableJvmNameAnnotation(): AnnotationSpec {
+    return AnnotationSpec.builder(Suppress::class)
+        .addMember("%S", "INAPPLICABLE_JVM_NAME")
         .build()
 }
 

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin2/GenerateKotlin2DataTypes.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin2/GenerateKotlin2DataTypes.kt
@@ -28,7 +28,9 @@ import com.netflix.graphql.dgs.codegen.generators.kotlin.jsonBuilderAnnotation
 import com.netflix.graphql.dgs.codegen.generators.kotlin.jsonDeserializeAnnotation
 import com.netflix.graphql.dgs.codegen.generators.kotlin.jsonIgnorePropertiesAnnotation
 import com.netflix.graphql.dgs.codegen.generators.kotlin.jsonPropertyAnnotation
+import com.netflix.graphql.dgs.codegen.generators.kotlin.jvmNameAnnotation
 import com.netflix.graphql.dgs.codegen.generators.kotlin.sanitizeKdoc
+import com.netflix.graphql.dgs.codegen.generators.kotlin.suppressInapplicableJvmNameAnnotation
 import com.netflix.graphql.dgs.codegen.generators.shared.CodeGeneratorUtils.capitalized
 import com.netflix.graphql.dgs.codegen.generators.shared.SchemaExtensionsUtils.findTypeExtensions
 import com.netflix.graphql.dgs.codegen.generators.shared.excludeSchemaTypeExtension
@@ -215,8 +217,10 @@ fun generateKotlin2DataTypes(
                             .apply {
                                 if (field.name in overrideFields) {
                                     addModifiers(KModifier.OVERRIDE)
+                                    addAnnotation(suppressInapplicableJvmNameAnnotation())
                                 }
                             }
+                            .addAnnotation(jvmNameAnnotation(field.name))
                             .getter(
                                 FunSpec.getterBuilder()
                                     .addStatement("return _${field.name}.invoke()")

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin2/GenerateKotlin2Interfaces.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin2/GenerateKotlin2Interfaces.kt
@@ -23,7 +23,9 @@ import com.netflix.graphql.dgs.codegen.filterSkipped
 import com.netflix.graphql.dgs.codegen.generators.kotlin.addOptionalGeneratedAnnotation
 import com.netflix.graphql.dgs.codegen.generators.kotlin.jsonSubTypesAnnotation
 import com.netflix.graphql.dgs.codegen.generators.kotlin.jsonTypeInfoAnnotation
+import com.netflix.graphql.dgs.codegen.generators.kotlin.jvmNameAnnotation
 import com.netflix.graphql.dgs.codegen.generators.kotlin.sanitizeKdoc
+import com.netflix.graphql.dgs.codegen.generators.kotlin.suppressInapplicableJvmNameAnnotation
 import com.netflix.graphql.dgs.codegen.generators.shared.SchemaExtensionsUtils.findInterfaceExtensions
 import com.netflix.graphql.dgs.codegen.generators.shared.SchemaExtensionsUtils.findUnionExtensions
 import com.netflix.graphql.dgs.codegen.generators.shared.excludeSchemaTypeExtension
@@ -117,6 +119,8 @@ fun generateKotlin2Interfaces(
                                     addModifiers(KModifier.OVERRIDE)
                                 }
                             }
+                            .addAnnotation(suppressInapplicableJvmNameAnnotation())
+                            .addAnnotation(jvmNameAnnotation(field.name))
                             .build()
                     }
                 )


### PR DESCRIPTION
* If a GQL property name starts with `is`, like `isRequired`, graphQL will only look for property names like `isIsRequired` or `getIsRequired`
* This specifies an explicit name for all properties matching the GQL logic
* For interfaces/overridden methods, we must also suppress a warning detailed here: https://youtrack.jetbrains.com/issue/KT-31420