### PR TITLE
Added custom @Generated annotation

### DIFF
--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
@@ -35,11 +35,8 @@ import com.squareup.javapoet.AnnotationSpec
 import com.squareup.javapoet.ClassName
 import com.squareup.javapoet.JavaFile
 import com.squareup.javapoet.TypeSpec
-import com.squareup.kotlinpoet.AnnotationSpec as KAnnotationSpec
-import com.squareup.kotlinpoet.ClassName as KClassName
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.KModifier
-import com.squareup.kotlinpoet.TypeSpec as KTypeSpec
 import graphql.language.*
 import graphql.parser.InvalidSyntaxException
 import graphql.parser.MultiSourceReader
@@ -51,6 +48,9 @@ import java.lang.annotation.RetentionPolicy
 import java.nio.file.Path
 import java.nio.file.Paths
 import javax.lang.model.element.Modifier
+import com.squareup.kotlinpoet.AnnotationSpec as KAnnotationSpec
+import com.squareup.kotlinpoet.ClassName as KClassName
+import com.squareup.kotlinpoet.TypeSpec as KTypeSpec
 
 class CodeGen(private val config: CodeGenConfig) {
 

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ConstantsGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ConstantsGenerator.kt
@@ -125,6 +125,7 @@ class ConstantsGenerator(private val config: CodeGenConfig, private val document
 
         return TypeSpec
             .classBuilder(className)
+            .addOptionalGeneratedAnnotation(config)
             .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
     }
 

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/DataTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/DataTypeGenerator.kt
@@ -406,6 +406,7 @@ abstract class BaseDataTypeGenerator(
         val builderType =
             TypeSpec
                 .classBuilder("Builder")
+                .addOptionalGeneratedAnnotation(config)
                 .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
                 .addMethod(buildMethod)
 

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinDataTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinDataTypeGenerator.kt
@@ -229,7 +229,7 @@ abstract class AbstractKotlinDataTypeGenerator(
         }
 
         kotlinType.primaryConstructor(funConstructorBuilder.build())
-        kotlinType.addType(TypeSpec.companionObjectBuilder().build())
+        kotlinType.addType(TypeSpec.companionObjectBuilder().addOptionalGeneratedAnnotation(config).build())
 
         val typeSpec = kotlinType.build()
 

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinEnumTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinEnumTypeGenerator.kt
@@ -56,7 +56,7 @@ class KotlinEnumTypeGenerator(private val config: CodeGenConfig) {
             }
         }
 
-        kotlinType.addType(TypeSpec.companionObjectBuilder().build())
+        kotlinType.addType(TypeSpec.companionObjectBuilder().addOptionalGeneratedAnnotation(config).build())
 
         val typeSpec = kotlinType.build()
         val fileSpec = FileSpec.builder(getPackageName(), typeSpec.name!!).addType(typeSpec).build()

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinInterfaceTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinInterfaceTypeGenerator.kt
@@ -95,7 +95,7 @@ class KotlinInterfaceTypeGenerator(private val config: CodeGenConfig, private va
             interfaceBuilder.addAnnotation(jsonSubTypesAnnotation(implementations))
         }
 
-        interfaceBuilder.addType(TypeSpec.companionObjectBuilder().build())
+        interfaceBuilder.addType(TypeSpec.companionObjectBuilder().addOptionalGeneratedAnnotation(config).build())
 
         val fileSpec = FileSpec.get(packageName, interfaceBuilder.build())
         return CodeGenResult(kotlinInterfaces = listOf(fileSpec))

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinUnionTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinUnionTypeGenerator.kt
@@ -50,7 +50,7 @@ class KotlinUnionTypeGenerator(private val config: CodeGenConfig) {
             interfaceBuilder.addAnnotation(jsonSubTypesAnnotation(memberTypes))
         }
 
-        interfaceBuilder.addType(TypeSpec.companionObjectBuilder().build())
+        interfaceBuilder.addType(TypeSpec.companionObjectBuilder().addOptionalGeneratedAnnotation(config).build())
 
         val fileSpec = FileSpec.get(packageName, interfaceBuilder.build())
         return CodeGenResult(kotlinInterfaces = listOf(fileSpec))

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin2/GenerateKotlin2DataTypes.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin2/GenerateKotlin2DataTypes.kt
@@ -90,6 +90,7 @@ fun generateKotlin2DataTypes(
 
             // create a companion object to store defaults for each field
             val companionObject = TypeSpec.companionObjectBuilder()
+                .addOptionalGeneratedAnnotation(config)
                 // add a default lambda for each field that throws if accessed
                 .addProperties(
                     fields.map { field ->

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
@@ -22,6 +22,7 @@ import com.netflix.graphql.dgs.codegen.generators.java.disableJsonTypeInfoAnnota
 import com.squareup.javapoet.ClassName
 import com.squareup.javapoet.JavaFile
 import com.squareup.javapoet.ParameterizedTypeName
+import com.squareup.javapoet.TypeSpec
 import com.squareup.javapoet.WildcardTypeName
 import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
@@ -2943,14 +2944,12 @@ It takes a title and such.
             )
         ).generate()
 
-        with(codeGenResult) {
-            javaDataTypes.assertJavaGeneratedAnnotation()
-            javaInterfaces.assertJavaGeneratedAnnotation()
-            javaConstants.assertJavaGeneratedAnnotation()
-            javaEnumTypes.assertJavaGeneratedAnnotation()
-            javaQueryTypes.assertJavaGeneratedAnnotation()
-            clientProjections.assertJavaGeneratedAnnotation()
-        }
+        val (generatedAnnotationFile, allSources) = codeGenResult.javaSources()
+            .partition { it.typeSpec.name == "Generated" && it.typeSpec.kind == TypeSpec.Kind.ANNOTATION }
+
+        allSources.assertJavaGeneratedAnnotation()
+        assertThat(generatedAnnotationFile.single().toString())
+            .contains("java.lang.annotation.Retention", "RetentionPolicy.CLASS")
         assertCompilesJava(codeGenResult)
     }
 }

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
@@ -2741,14 +2741,15 @@ It takes a title and such.
             )
         ).generate()
 
-        with(codeGenResult) {
-            kotlinDataTypes.assertKotlinGeneratedAnnotation()
-            kotlinInterfaces.assertKotlinGeneratedAnnotation()
-            kotlinConstants.assertKotlinGeneratedAnnotation()
-            kotlinEnumTypes.assertKotlinGeneratedAnnotation()
-            javaQueryTypes.assertJavaGeneratedAnnotation()
-            clientProjections.assertJavaGeneratedAnnotation()
-        }
+        val (generatedAnnotationFile, allKotlinSources) = codeGenResult.kotlinSources()
+            .partition { it.name == "Generated" }
+
+        allKotlinSources.assertKotlinGeneratedAnnotation()
+        codeGenResult.javaSources().assertJavaGeneratedAnnotation()
+
+        assertThat(generatedAnnotationFile.single().toString())
+            .contains("@Retention(value = AnnotationRetention.BINARY)")
+
         assertCompilesKotlin(codeGenResult)
     }
 }

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/TestUtils.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/TestUtils.kt
@@ -26,10 +26,7 @@ import com.squareup.javapoet.AnnotationSpec
 import com.squareup.javapoet.ClassName
 import com.squareup.javapoet.JavaFile
 import com.squareup.javapoet.TypeSpec
-import com.squareup.kotlinpoet.AnnotationSpec as KAnnotationSpec
-import com.squareup.kotlinpoet.ClassName as KClassName
 import com.squareup.kotlinpoet.FileSpec
-import com.squareup.kotlinpoet.TypeSpec as KTypeSpec
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.cli.common.ExitCode
 import org.jetbrains.kotlin.cli.common.arguments.K2JVMCompilerArguments
@@ -43,6 +40,9 @@ import java.lang.reflect.Method
 import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.io.path.createDirectories
+import com.squareup.kotlinpoet.AnnotationSpec as KAnnotationSpec
+import com.squareup.kotlinpoet.ClassName as KClassName
+import com.squareup.kotlinpoet.TypeSpec as KTypeSpec
 
 fun assertCompilesJava(codeGenResult: CodeGenResult): Compilation {
     return assertCompilesJava(

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/TestUtils.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/TestUtils.kt
@@ -21,9 +21,15 @@ package com.netflix.graphql.dgs.codegen
 import com.google.testing.compile.Compilation
 import com.google.testing.compile.CompilationSubject
 import com.google.testing.compile.Compiler.javac
-import com.netflix.graphql.dgs.codegen.generators.shared.generatedDate
+import com.netflix.graphql.dgs.codegen.generators.shared.generatedAnnotationClassName
+import com.squareup.javapoet.AnnotationSpec
+import com.squareup.javapoet.ClassName
 import com.squareup.javapoet.JavaFile
+import com.squareup.javapoet.TypeSpec
+import com.squareup.kotlinpoet.AnnotationSpec as KAnnotationSpec
+import com.squareup.kotlinpoet.ClassName as KClassName
 import com.squareup.kotlinpoet.FileSpec
+import com.squareup.kotlinpoet.TypeSpec as KTypeSpec
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.cli.common.ExitCode
 import org.jetbrains.kotlin.cli.common.arguments.K2JVMCompilerArguments
@@ -113,29 +119,50 @@ fun <T> invokeMethod(method: Method, target: Any, vararg args: Any): T {
     return result as T
 }
 
-fun List<FileSpec>.assertKotlinGeneratedAnnotation() = apply {
-    assertThat(this).isNotEmpty
-    forEach {
-        assertThat(it.toString())
-            .contains(
-                "@Generated(",
-                "value = [\"${CodeGen::class.qualifiedName}\"]",
-                "date = \"$generatedDate\""
-            )
-    }
+fun List<FileSpec>.assertKotlinGeneratedAnnotation() = onEach {
+    it.members
+        .filterIsInstance(KTypeSpec::class.java)
+        .forEach { typeSpec -> typeSpec.assertKotlinGeneratedAnnotation(it) }
 }
 
-fun List<JavaFile>.assertJavaGeneratedAnnotation() = apply {
-    assertThat(this).isNotEmpty
-    forEach {
-        assertThat(it.toString())
-            .contains(
-                "@Generated(",
-                "value = \"${CodeGen::class.qualifiedName}\"",
-                "date = \"$generatedDate\""
-            )
-    }
+fun List<JavaFile>.assertJavaGeneratedAnnotation() = onEach {
+    it.typeSpec.assertJavaGeneratedAnnotation()
 }
+
+fun KTypeSpec.assertKotlinGeneratedAnnotation(fileSpec: FileSpec) {
+    val generatedSpec = annotationSpecs
+        .firstOrNull { it.canonicalName() == "$basePackageName.Generated" }
+    assertThat(generatedSpec)
+        .`as`("@Generated annotation exists in %s at %s", this, fileSpec)
+        .isNotNull
+
+    val javaxGeneratedSpec =
+        annotationSpecs.firstOrNull { it.canonicalName() == generatedAnnotationClassName }
+    assertThat(javaxGeneratedSpec)
+        .`as`("$generatedAnnotationClassName annotation exists in %s at %s", this, fileSpec)
+        .isNotNull
+
+    typeSpecs.forEach { it.assertKotlinGeneratedAnnotation(fileSpec) }
+}
+
+fun TypeSpec.assertJavaGeneratedAnnotation() {
+    val generatedSpec = annotations
+        .firstOrNull { it.canonicalName() == "$basePackageName.Generated" }
+    assertThat(generatedSpec)
+        .`as`("@Generated annotation exists in %s", this)
+        .isNotNull
+
+    val javaxGeneratedSpec =
+        annotations.firstOrNull { it.canonicalName() == generatedAnnotationClassName }
+    assertThat(javaxGeneratedSpec)
+        .`as`("$generatedAnnotationClassName annotation exists in %s", this)
+        .isNotNull
+
+    this.typeSpecs.forEach { it.assertJavaGeneratedAnnotation() }
+}
+
+fun AnnotationSpec.canonicalName(): String = (type as ClassName).canonicalName()
+fun KAnnotationSpec.canonicalName() = (typeName as KClassName).canonicalName
 
 const val basePackageName = "com.netflix.graphql.dgs.codegen.tests.generated"
 const val typesPackageName = "$basePackageName.types"


### PR DESCRIPTION
In this PR, which follows https://github.com/Netflix/dgs-codegen/pull/424 (and https://github.com/Netflix/dgs-framework/discussions/1147#discussioncomment-3354730), I'm adding a custom @Generated method. It appears that in order for Jacoco to ignore code annotated with @Generated, the annotation must have a CLASS/RUNTIME retention, and the javax.annotation.Generated are SOURCE retention.

In this PR the --add-generated-annotation flag will create a custom @Generated annotation with the CLASS retention, and will annotate all generated code with that annotation.

The PR also uses a more solid testing strategy, which verifies the generated AST (and not just the generated text), to catch cases where multiple classes that require annotation are stored in a single file.