### PR TITLE
make `kotlinAllFieldsOptional` not affect generated *input* types, only output ones

### DIFF
--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinDataTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinDataTypeGenerator.kt
@@ -86,10 +86,10 @@ class KotlinInputTypeGenerator(config: CodeGenConfig, document: Document) :
             .map {
                 val type = typeUtils.findReturnType(it.type)
                 val defaultValue = it.defaultValue?.let { value -> generateCode(value, type) }
-                Field(name = it.name, type = type, nullable = typeUtils.isNullable(it.type), default = defaultValue, description = it.description)
+                Field(name = it.name, type = type, nullable = it.type !is NonNullType, default = defaultValue, description = it.description)
             }.plus(
                 extensions.flatMap { it.inputValueDefinitions }.map {
-                    Field(name = it.name, type = typeUtils.findReturnType(it.type), nullable = typeUtils.isNullable(it.type), default = null, description = it.description)
+                    Field(name = it.name, type = typeUtils.findReturnType(it.type), nullable = it.type !is NonNullType, default = null, description = it.description)
                 }
             )
         val interfaces = emptyList<Type<*>>()

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
@@ -254,6 +254,32 @@ class KotlinCodeGenTest {
     }
 
     @Test
+    fun `input type with kotlinAllFieldsOptional setting`() {
+        val schema = """
+            input PersonUpdate {
+                 id: ID!
+                 name: String
+            }
+        """.trimIndent()
+
+        val result = CodeGen(
+            CodeGenConfig(
+                schemas = setOf(schema),
+                packageName = basePackageName,
+                language = Language.KOTLIN,
+                kotlinAllFieldsOptional = true
+            )
+        ).generate()
+        val dataTypes = result.kotlinDataTypes
+
+        val type = dataTypes[0].members[0] as TypeSpec
+        assertThat(type.propertySpecs[0].type.isNullable).isFalse // id: ID!
+        assertThat(type.propertySpecs[1].type.isNullable).isTrue // name: String
+
+        assertCompilesKotlin(dataTypes)
+    }
+
+    @Test
     fun `interface classes are not generated with generateDataTypes setting set to false`() {
         val schema = """
             interface Person {


### PR DESCRIPTION
This makes sense, because the 'all fields optional' feature is powerful when deciding whether to inline properties or resolve them dynamically through @DgsData. But the nullability is unwanted for 'input' types specifically. It makes more sense to have parsed input types respect the nullability declarations in the schema﻿.

More info in the issue: https://github.com/Netflix/dgs-codegen/issues/448
