### PR TITLE
Iiea 10491 (#3)

### DIFF
--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
@@ -462,6 +462,8 @@ data class CodeGenConfig(
     val snakeCaseConstantNames: Boolean = false,
     val generateInterfaceSetters: Boolean = true,
     val includeImports: Map<String, String> = emptyMap(),
+    val includeEnumImports: Map<String, Map<String, String>> = emptyMap(),
+    val generateCustomAnnotations: Boolean = false,
     var javaGenerateAllConstructor: Boolean = true,
     val implementSerializable: Boolean = false,
     val addGeneratedAnnotation: Boolean = false

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/DataTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/DataTypeGenerator.kt
@@ -21,6 +21,7 @@ package com.netflix.graphql.dgs.codegen.generators.java
 import com.netflix.graphql.dgs.codegen.CodeGenConfig
 import com.netflix.graphql.dgs.codegen.CodeGenResult
 import com.netflix.graphql.dgs.codegen.filterSkipped
+import com.netflix.graphql.dgs.codegen.generators.shared.ParserConstants
 import com.netflix.graphql.dgs.codegen.shouldSkip
 import com.squareup.javapoet.*
 import graphql.language.*
@@ -88,7 +89,7 @@ class DataTypeGenerator(config: CodeGenConfig, document: Document) : BaseDataTyp
                         typeUtils.findReturnType(it.type, useInterfaceType),
                         overrideGetter = overrideGetter,
                         description = it.description,
-                        directives = it.directives.map { directive -> directive.name }
+                        directives = it.directives
                     )
                 }
                 .plus(
@@ -98,12 +99,12 @@ class DataTypeGenerator(config: CodeGenConfig, document: Document) : BaseDataTyp
                             typeUtils.findReturnType(it.type, useInterfaceType),
                             overrideGetter = overrideGetter,
                             description = it.description,
-                            directives = it.directives.map { directive -> directive.name }
+                            directives = it.directives
                         )
                     }
                 )
 
-            return generate(name, unionTypes + implements, fieldDefinitions, definition.description)
+            return generate(name, unionTypes + implements, fieldDefinitions, definition.description, definition.directives)
                 .merge(interfaceCodeGenResult)
         }
 
@@ -151,14 +152,14 @@ class InputTypeGenerator(config: CodeGenConfig, document: Document) : BaseDataTy
                 type = typeUtils.findReturnType(it.type),
                 initialValue = defaultValue,
                 description = it.description,
-                directives = it.directives.map { directive -> directive.name }
+                directives = it.directives
             )
         }.plus(extensions.flatMap { it.inputValueDefinitions }.map { Field(it.name, typeUtils.findReturnType(it.type)) })
-        return generate(name, emptyList(), fieldDefinitions, definition.description)
+        return generate(name, emptyList(), fieldDefinitions, definition.description, definition.directives)
     }
 }
 
-internal data class Field(val name: String, val type: com.squareup.javapoet.TypeName, val initialValue: CodeBlock? = null, val overrideGetter: Boolean = false, val interfaceType: com.squareup.javapoet.TypeName? = null, val description: Description? = null, val directives: List<String> = listOf<String>())
+internal data class Field(val name: String, val type: com.squareup.javapoet.TypeName, val initialValue: CodeBlock? = null, val overrideGetter: Boolean = false, val interfaceType: com.squareup.javapoet.TypeName? = null, val description: Description? = null, val directives: List<Directive> = listOf())
 
 abstract class BaseDataTypeGenerator(
     internal val packageName: String,
@@ -167,11 +168,52 @@ abstract class BaseDataTypeGenerator(
 ) {
     internal val typeUtils = TypeUtils(packageName, config, document)
 
+    /**
+     * Creates an argument map of the input Arguments
+     */
+    private fun createArgumentMap(directive: Directive): MutableMap<String, Value<Value<*>>> {
+        return directive.arguments.fold(mutableMapOf()) { argMap, argument ->
+            argMap[argument.name] = argument.value
+            argMap
+        }
+    }
+
+    /**
+     * Applies directives like customAnnotation
+     */
+    private fun applyDirectives(directives: List<Directive>): Pair<MutableList<AnnotationSpec>, String?> {
+        var commentFormat: String? = null
+        return Pair(
+            directives.fold(mutableListOf()) { annotations, directive ->
+                val argumentMap = createArgumentMap(directive)
+                if (directive.name == ParserConstants.CUSTOM_ANNOTATION && config.generateCustomAnnotations) {
+                    annotations.add(customAnnotation(argumentMap, config))
+                }
+                if (directive.name == ParserConstants.DEPRECATED) {
+                    annotations.add(deprecatedAnnotation())
+                    if (argumentMap.containsKey(ParserConstants.REASON)) {
+                        val reason: String = (argumentMap[ParserConstants.REASON] as StringValue).value
+                        val replace = reason.substringAfter(ParserConstants.REPLACE_WITH_STR, "")
+                        commentFormat = reason.substringBefore(ParserConstants.REPLACE_WITH_STR)
+                        if (replace.isNotEmpty()) {
+                            commentFormat = "@deprecated ${reason.substringBefore(ParserConstants.REPLACE_WITH_STR)}. Replaced by $replace"
+                        }
+                    } else {
+                        throw IllegalArgumentException("Deprecated requires an argument `${ParserConstants.REASON}`")
+                    }
+                }
+                annotations
+            },
+            commentFormat
+        )
+    }
+
     internal fun generate(
         name: String,
         interfaces: List<String>,
         fields: List<Field>,
-        description: Description? = null
+        description: Description? = null,
+        directives: List<Directive> = emptyList()
     ): CodeGenResult {
         val javaType = TypeSpec.classBuilder(name)
             .addOptionalGeneratedAnnotation(config)
@@ -183,6 +225,14 @@ abstract class BaseDataTypeGenerator(
 
         if (description != null) {
             javaType.addJavadoc(description.sanitizeJavaDoc())
+        }
+
+        if (directives.isNotEmpty()) {
+            val (annotations, comments) = applyDirectives(directives)
+            javaType.addAnnotations(annotations)
+            if (!comments.isNullOrBlank()) {
+                javaType.addJavadoc("\$L", comments)
+            }
         }
 
         interfaces.forEach {
@@ -288,7 +338,7 @@ abstract class BaseDataTypeGenerator(
         val methodBuilder = MethodSpec.methodBuilder("toString").addAnnotation(Override::class.java).addModifiers(Modifier.PUBLIC).returns(String::class.java)
         val toStringBody = StringBuilder("return \"${javaType.build().name}{\" + ")
         fieldDefinitions.forEachIndexed { index, field ->
-            val fieldValueStatement = if (field.directives.contains("sensitive")) "\"*****\"" else ReservedKeywordSanitizer.sanitize(field.name)
+            val fieldValueStatement = if (field.directives.stream().anyMatch { it -> it.name.equals("sensitive") }) "\"*****\"" else ReservedKeywordSanitizer.sanitize(field.name)
             toStringBody.append(
                 """
                 "${field.name}='" + $fieldValueStatement + "'${if (index < fieldDefinitions.size - 1) "," else ""}" +
@@ -338,6 +388,14 @@ abstract class BaseDataTypeGenerator(
                 .initializer(fieldDefinition.initialValue)
         } else {
             FieldSpec.builder(returnType, ReservedKeywordSanitizer.sanitize(fieldDefinition.name)).addModifiers(Modifier.PRIVATE)
+        }
+
+        if (fieldDefinition.directives.isNotEmpty()) {
+            val (annotations, comments) = applyDirectives(fieldDefinition.directives)
+            fieldBuilder.addAnnotations(annotations)
+            if (!comments.isNullOrBlank()) {
+                fieldBuilder.addJavadoc("\$L", comments)
+            }
         }
 
         if (fieldDefinition.description != null) {

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/EntitiesRepresentationTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/EntitiesRepresentationTypeGenerator.kt
@@ -107,7 +107,8 @@ class EntitiesRepresentationTypeGenerator(
             name = representationName,
             interfaces = emptyList(),
             fields = fieldDefinitions.plus(typeName),
-            description = null
+            description = null,
+            directives = emptyList()
         )
         generatedRepresentations[representationName] = typeUtils.qualifyName(representationName)
         // Merge all results.

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/JavaPoetUtils.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/JavaPoetUtils.kt
@@ -22,15 +22,29 @@ import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonTypeInfo
 import com.netflix.graphql.dgs.codegen.CodeGen
 import com.netflix.graphql.dgs.codegen.CodeGenConfig
+import com.netflix.graphql.dgs.codegen.generators.shared.PackageParserUtil
+import com.netflix.graphql.dgs.codegen.generators.shared.ParserConstants
 import com.netflix.graphql.dgs.codegen.generators.shared.generatedAnnotationClassName
 import com.netflix.graphql.dgs.codegen.generators.shared.generatedDate
 import com.squareup.javapoet.AnnotationSpec
 import com.squareup.javapoet.ClassName
+import com.squareup.javapoet.CodeBlock
 import com.squareup.javapoet.TypeName
 import com.squareup.javapoet.TypeSpec
 import com.squareup.javapoet.WildcardTypeName
 import graphql.introspection.Introspection.TypeNameMetaFieldDef
+import graphql.language.ArrayValue
+import graphql.language.BooleanValue
 import graphql.language.Description
+import graphql.language.EnumValue
+import graphql.language.FloatValue
+import graphql.language.IntValue
+import graphql.language.NullValue
+import graphql.language.ObjectField
+import graphql.language.ObjectValue
+import graphql.language.StringValue
+import graphql.language.Value
+import java.lang.IllegalArgumentException
 
 /**
  * Generate a [JsonTypeInfo] annotation, which allows for Jackson
@@ -44,6 +58,14 @@ import graphql.language.Description
  *   property = "__typename")
  * ```
  */
+
+/**
+ * Adds @Deprecated annotation
+ */
+fun deprecatedAnnotation(): AnnotationSpec {
+    return AnnotationSpec.builder(java.lang.Deprecated::class.java).build()
+}
+
 fun jsonTypeInfoAnnotation(): AnnotationSpec {
     return AnnotationSpec.builder(JsonTypeInfo::class.java)
         .addMember("use", "\$T.\$L", JsonTypeInfo.Id::class.java, JsonTypeInfo.Id.NAME.name)
@@ -150,6 +172,57 @@ fun TypeSpec.Builder.addOptionalGeneratedAnnotation(config: CodeGenConfig): Type
         if (config.addGeneratedAnnotation) {
             generatedAnnotation(config.packageName).forEach { addAnnotation(it) }
         }
+    }
+
+/**
+ * Creates custom annotation from arguments
+ * name -> Name of the class to be annotated. It will contain className with oor without the package name (Mandatory)
+ * type -> The type of operation intended with this annotation. This value is also used to look up if there is any default packages associated with this annotation in the config
+ * inputs -> These are the input parameters needed for the annotation. If empty no inputs will be present for the annotation
+ */
+fun customAnnotation(annotationArgumentMap: MutableMap<String, Value<Value<*>>>, config: CodeGenConfig): AnnotationSpec {
+    if (annotationArgumentMap.isEmpty() || !annotationArgumentMap.containsKey(ParserConstants.NAME) || annotationArgumentMap[ParserConstants.NAME] is NullValue || (annotationArgumentMap[ParserConstants.NAME] as StringValue).value.isEmpty()) {
+        throw IllegalArgumentException("Invalid annotate directive")
+    }
+    val (packageName, simpleName) = PackageParserUtil.getAnnotationPackage(
+        config,
+        (annotationArgumentMap[ParserConstants.NAME] as StringValue).value,
+        if (annotationArgumentMap.containsKey(ParserConstants.TYPE) && annotationArgumentMap[ParserConstants.TYPE] !is NullValue) (annotationArgumentMap[ParserConstants.TYPE] as StringValue).value else null
+    )
+    val className = ClassName.get(packageName, simpleName)
+    val annotation: AnnotationSpec.Builder = AnnotationSpec.builder(className)
+    if (annotationArgumentMap.containsKey(ParserConstants.INPUTS)) {
+        val objectFields: List<ObjectField> = (annotationArgumentMap[ParserConstants.INPUTS] as ObjectValue).objectFields
+        for (objectField in objectFields) {
+            val codeBlock: CodeBlock = generateCode(
+                objectField.value,
+                PackageParserUtil.getEnumPackage(config, (annotationArgumentMap[ParserConstants.NAME] as StringValue).value, objectField.name)
+            )
+            annotation.addMember(objectField.name, codeBlock)
+        }
+    }
+    return annotation.build()
+}
+
+/**
+ * Generates the code block containing the parameters of an annotation in the format value
+ */
+private fun generateCode(value: Value<Value<*>>, packageName: String = ""): CodeBlock =
+    when (value) {
+        is BooleanValue -> CodeBlock.of("\$L", (value as BooleanValue).isValue)
+        is IntValue -> CodeBlock.of("\$L", (value as IntValue).value)
+        is StringValue -> CodeBlock.of("\$S", (value as StringValue).value)
+        is FloatValue -> CodeBlock.of("\$L", (value as FloatValue).value)
+        // In an enum value the prefix/type (key in the parameters map for the enum) is used to get the package name from the config
+        // Limitation: Since it uses the enum key to lookup the package from the configs. 2 enums using different packages cannot have the same keys.
+        is EnumValue -> CodeBlock.of(
+            "\$T",
+            ClassName.get(packageName, (value as EnumValue).name)
+        )
+        is ArrayValue ->
+            if ((value as ArrayValue).values.isEmpty()) CodeBlock.of("[]")
+            else CodeBlock.of("[\$L]", (value as ArrayValue).values.joinToString { v -> generateCode(value = v, if (v is EnumValue) packageName else "").toString() })
+        else -> CodeBlock.of("\$L", value)
     }
 
 private fun typeClassBestGuess(name: String): TypeName {

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinDataTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinDataTypeGenerator.kt
@@ -22,6 +22,7 @@ import com.netflix.graphql.dgs.codegen.CodeGenConfig
 import com.netflix.graphql.dgs.codegen.CodeGenResult
 import com.netflix.graphql.dgs.codegen.filterSkipped
 import com.netflix.graphql.dgs.codegen.generators.java.InputTypeGenerator
+import com.netflix.graphql.dgs.codegen.generators.shared.ParserConstants
 import com.netflix.graphql.dgs.codegen.shouldSkip
 import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.BOOLEAN
@@ -139,20 +140,6 @@ abstract class AbstractKotlinDataTypeGenerator(
     )
 
     /**
-     * Applies the directives on a field
-     */
-    private fun applyDirectives(directives: List<Directive>, parameterSpec: ParameterSpec.Builder) {
-        parameterSpec.addAnnotations(applyDirectives(directives))
-    }
-
-    /**
-     * Applies the directives on a graphQL input or type
-     */
-    private fun applyDirectives(directives: List<Directive>, typeSpec: TypeSpec.Builder) {
-        typeSpec.addAnnotations(applyDirectives(directives))
-    }
-
-    /**
      * Creates an argument map of the input Arguments
      */
     private fun createArgumentMap(directive: Directive): MutableMap<String, Value<Value<*>>> {
@@ -207,7 +194,7 @@ abstract class AbstractKotlinDataTypeGenerator(
         }
 
         if (directives.isNotEmpty()) {
-            applyDirectives(directives, kotlinType)
+            kotlinType.addAnnotations(applyDirectives(directives))
         }
 
         val funConstructorBuilder = FunSpec.constructorBuilder()
@@ -221,7 +208,7 @@ abstract class AbstractKotlinDataTypeGenerator(
                     .addAnnotation(jsonPropertyAnnotation(field.name))
 
             if (field.directives.isNotEmpty()) {
-                applyDirectives(field.directives, parameterSpec)
+                parameterSpec.addAnnotations(applyDirectives(field.directives))
             }
 
             if (field.default != null) {

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/shared/PackageParserUtil.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/shared/PackageParserUtil.kt
@@ -1,0 +1,52 @@
+/*
+ *
+ *  Copyright 2020 Netflix, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package com.netflix.graphql.dgs.codegen.generators.shared
+
+import com.netflix.graphql.dgs.codegen.CodeGenConfig
+
+class PackageParserUtil {
+
+    companion object {
+        /**
+         * Retrieves the package value in the directive.
+         * If not present uses the default package in the config for that particular type of annotation.
+         * If neither of them are supplied the package name will be an empty String
+         * Also parses the  simpleName/className from the name argument in the directive
+         */
+        fun getAnnotationPackage(config: CodeGenConfig, name: String, type: String? = null): Pair<String, String> {
+            var packageName = name.substringBeforeLast(".", "")
+            packageName =
+                if (packageName.isEmpty() && type != null) config.includeImports.getOrDefault(type, "") else packageName
+            return packageName to name.substringAfterLast(".")
+        }
+
+        /**
+         * This function is used to get the enum package value  from the configuration
+         * It is stored in the configuration as follows
+         * mapOf(annotationName to mapOf(enumType to enumPackageName)
+         * If no key is found in the configuration an empty string is returned
+         */
+        fun getEnumPackage(config: CodeGenConfig, annotationName: String, enumType: String): String {
+            return config.includeEnumImports[annotationName]?.getOrDefault(
+                enumType,
+                ""
+            ) ?: ""
+        }
+    }
+}

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/shared/ParserConstants.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/shared/ParserConstants.kt
@@ -1,0 +1,33 @@
+/*
+ *
+ *  Copyright 2020 Netflix, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package com.netflix.graphql.dgs.codegen.generators.shared
+
+object ParserConstants {
+    const val ASSIGNMENT_OPERATOR = " = "
+    const val TYPE = "type"
+    const val NAME = "name"
+    const val REASON = "reason"
+    const val CUSTOM_ANNOTATION = "annotate"
+    const val DEPRECATED = "deprecated"
+    const val INPUTS = "inputs"
+    const val REPLACE_WITH_STR = ", replace with "
+    const val MESSAGE = "message"
+    const val REPLACE_WITH = "replaceWith"
+    const val REPLACE_WITH_CLASS = "ReplaceWith"
+}


### PR DESCRIPTION
@srinivasankavitha As per the comment in the [PR](https://github.com/Netflix/dgs-codegen/pull/386), added implementation for java side as well. This includes all the annotation features that are currently available to generate kotlin POJOs.

Added 2 more features to the custom annotations:
- enable/disable custom annotations. Default value is false
Example:
   `<generateCustomAnnotations>true</generateCustomAnnotations>`
- In order to make the enum package mapping in the annotations more distinct, have introduced includeEnumImports which uses the annotationName and enumType to map the enum packages

Example:
**graphql**
```
type Person @annotate(name: "ValidPerson", type: "validator", inputs: {types: [HUSBAND, WIFE]}) {
    name: String @annotate(name: "com.test.anotherValidator.ValidName")
}
```

 **Mapping in pom**
```
<ValidPerson>
    <types>com.enums</types>
</ValidPerson>
```

**Class generated**
```
package com.netflix.graphql.dgs.codegen.tests.generated.types;

import com.test.anotherValidator.ValidName;
import com.test.validator.ValidPerson;
import java.lang.Object;
import java.lang.Override;
import java.lang.String;

@ValidPerson(
    types = [com.enums.HUSBAND, com.enums.WIFE]
)
public class Person {
  @ValidName
  private String name;

  public Person() {
  }

  public Person(String name) {
    this.name = name;
  }

  public String getName() {
    return name;
  }

  public void setName(String name) {
    this.name = name;
  }

  @Override
  public String toString() {
    return "Person{" + "name='" + name + "'" +"}";
  }

  @Override
  public boolean equals(Object o) {
    if (this == o) return true;
        if (o == null || getClass() != o.getClass()) return false;
        Person that = (Person) o;
        return java.util.Objects.equals(name, that.name);
  }

  @Override
  public int hashCode() {
    return java.util.Objects.hash(name);
  }
}
```

The kotlin equivalent of these 2 features will be raised shortly.



* IIEA-10491 Updated the java part to support custom annotations

* IIEA-10491 Updated UT

* IIEA-10491 Added UT for  when custom annotations are disbaled

* IIEA-10491 Fixed imports

* IIEA-10491 Reverted import

* IIEA-10491 Moved ParserConstants to shared package

* IIEA-10491 Fixed lint error

* IIEA-10491 Added import in kotlin generator

Co-authored-by: Lakshmi Vijayachandran <lakshmi_vijayachandran@intuit.com>