### PR TITLE
Scan specified JARs for schema and generate code, if schema is available

### DIFF
--- a/graphql-dgs-codegen-gradle/src/main/kotlin/com/netflix/graphql/dgs/codegen/gradle/CodegenPlugin.kt
+++ b/graphql-dgs-codegen-gradle/src/main/kotlin/com/netflix/graphql/dgs/codegen/gradle/CodegenPlugin.kt
@@ -47,6 +47,9 @@ class CodegenPlugin : Plugin<Project> {
         val outputDir = generateJavaTaskProvider.map(GenerateJavaTask::getOutputDir)
         mainSourceSet.java.srcDirs(project.files(outputDir).builtBy(generateJavaTaskProvider))
 
+        project.configurations.create("dgsCodegen")
+        project.configurations.findByName("dgsCodegen")?.isCanBeResolved = true
+
         project.afterEvaluate { p ->
             if (extensions.clientCoreConventionsEnabled.getOrElse(true)) {
                 logger.info("Applying CodegenPlugin Client Utils conventions.")

--- a/graphql-dgs-codegen-gradle/src/main/kotlin/com/netflix/graphql/dgs/codegen/gradle/GenerateJavaTask.kt
+++ b/graphql-dgs-codegen-gradle/src/main/kotlin/com/netflix/graphql/dgs/codegen/gradle/GenerateJavaTask.kt
@@ -38,9 +38,6 @@ open class GenerateJavaTask : DefaultTask() {
     var schemaPaths = mutableListOf<Any>("${project.projectDir}/src/main/resources/schema")
 
     @Input
-    var schemaJarsFromDependencies = mutableListOf<String>()
-
-    @Input
     var packageName = "com.netflix.dgs.codegen.generated"
 
     @Input


### PR DESCRIPTION
This allows us to generate schemas from JAR files that are present in the `dgsCodegen` scoped config of the project that applies the plugin.  The plugin will identify the dependency, look for schema files under META-INF and read the files for generating data types.
Users can specify this in their dependency block in `build.gradle` as follows:
```
dependencies {
    ...
    dgsCodegen 'com.netflix.graphql.dgs:some-dependency:1.0.0'
}

```