### PR TITLE
Support type mapping when implementing an interface

### DIFF
--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/Kotlin2CodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/Kotlin2CodeGenTest.kt
@@ -55,6 +55,9 @@ class Kotlin2CodeGenTest {
                         "DateTime" to "java.time.OffsetDateTime",
                         "PageInfo" to "graphql.relay.PageInfo"
                     )
+                    "dataClassWithMappedInterfaces" -> mapOf(
+                        "Node" to "com.netflix.graphql.dgs.codegen.fixtures.Node"
+                    )
                     else -> emptyMap()
                 }
             )

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithMappedInterfaces/expected/DgsClient.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithMappedInterfaces/expected/DgsClient.kt
@@ -1,0 +1,11 @@
+package com.netflix.graphql.dgs.codegen.cases.dataClassWithMappedInterfaces.expected
+
+import com.netflix.graphql.dgs.codegen.GraphQLProjection
+import com.netflix.graphql.dgs.codegen.cases.dataClassWithMappedInterfaces.expected.client.QueryProjection
+import graphql.language.OperationDefinition
+import kotlin.String
+
+public object DgsClient {
+  public fun buildQuery(_projection: QueryProjection.() -> QueryProjection): String =
+      GraphQLProjection.asQuery(OperationDefinition.Operation.QUERY, QueryProjection(), _projection)
+}

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithMappedInterfaces/expected/DgsConstants.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithMappedInterfaces/expected/DgsConstants.kt
@@ -1,0 +1,31 @@
+package com.netflix.graphql.dgs.codegen.cases.dataClassWithMappedInterfaces.expected
+
+import kotlin.String
+
+public object DgsConstants {
+  public const val QUERY_TYPE: String = "Query"
+
+  public object QUERY {
+    public const val TYPE_NAME: String = "Query"
+
+    public const val Products: String = "products"
+  }
+
+  public object PRODUCT {
+    public const val TYPE_NAME: String = "Product"
+
+    public const val Id: String = "id"
+  }
+
+  public object NODE {
+    public const val TYPE_NAME: String = "Node"
+
+    public const val Id: String = "id"
+  }
+
+  public object ENTITY {
+    public const val TYPE_NAME: String = "Entity"
+
+    public const val Id: String = "id"
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithMappedInterfaces/expected/client/EntityProjection.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithMappedInterfaces/expected/client/EntityProjection.kt
@@ -1,0 +1,16 @@
+package com.netflix.graphql.dgs.codegen.cases.dataClassWithMappedInterfaces.expected.client
+
+import com.netflix.graphql.dgs.codegen.GraphQLProjection
+
+public class EntityProjection : GraphQLProjection() {
+  public val id: EntityProjection
+    get() {
+      field("id")
+      return this
+    }
+
+  public fun onProduct(_projection: ProductProjection.() -> ProductProjection): EntityProjection {
+    fragment("Product", ProductProjection(), _projection)
+    return this
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithMappedInterfaces/expected/client/NodeProjection.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithMappedInterfaces/expected/client/NodeProjection.kt
@@ -1,0 +1,21 @@
+package com.netflix.graphql.dgs.codegen.cases.dataClassWithMappedInterfaces.expected.client
+
+import com.netflix.graphql.dgs.codegen.GraphQLProjection
+
+public class NodeProjection : GraphQLProjection() {
+  public val id: NodeProjection
+    get() {
+      field("id")
+      return this
+    }
+
+  public fun onEntity(_projection: EntityProjection.() -> EntityProjection): NodeProjection {
+    fragment("Entity", EntityProjection(), _projection)
+    return this
+  }
+
+  public fun onProduct(_projection: ProductProjection.() -> ProductProjection): NodeProjection {
+    fragment("Product", ProductProjection(), _projection)
+    return this
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithMappedInterfaces/expected/client/ProductProjection.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithMappedInterfaces/expected/client/ProductProjection.kt
@@ -1,0 +1,11 @@
+package com.netflix.graphql.dgs.codegen.cases.dataClassWithMappedInterfaces.expected.client
+
+import com.netflix.graphql.dgs.codegen.GraphQLProjection
+
+public class ProductProjection : GraphQLProjection() {
+  public val id: ProductProjection
+    get() {
+      field("id")
+      return this
+    }
+}

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithMappedInterfaces/expected/client/QueryProjection.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithMappedInterfaces/expected/client/QueryProjection.kt
@@ -1,0 +1,10 @@
+package com.netflix.graphql.dgs.codegen.cases.dataClassWithMappedInterfaces.expected.client
+
+import com.netflix.graphql.dgs.codegen.GraphQLProjection
+
+public class QueryProjection : GraphQLProjection() {
+  public fun products(_projection: ProductProjection.() -> ProductProjection): QueryProjection {
+    field("products", ProductProjection(), _projection)
+    return this
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithMappedInterfaces/expected/types/Entity.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithMappedInterfaces/expected/types/Entity.kt
@@ -1,0 +1,22 @@
+package com.netflix.graphql.dgs.codegen.cases.dataClassWithMappedInterfaces.expected.types
+
+import com.fasterxml.jackson.`annotation`.JsonSubTypes
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import com.netflix.graphql.dgs.codegen.fixtures.Node
+import kotlin.String
+import kotlin.Suppress
+import kotlin.jvm.JvmName
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "__typename",
+)
+@JsonSubTypes(value = [
+  JsonSubTypes.Type(value = Product::class, name = "Product")
+])
+public sealed interface Entity : Node {
+  @Suppress("INAPPLICABLE_JVM_NAME")
+  @get:JvmName("getId")
+  public override val id: String
+}

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithMappedInterfaces/expected/types/Product.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithMappedInterfaces/expected/types/Product.kt
@@ -1,0 +1,46 @@
+package com.netflix.graphql.dgs.codegen.cases.dataClassWithMappedInterfaces.expected.types
+
+import com.fasterxml.jackson.`annotation`.JsonIgnoreProperties
+import com.fasterxml.jackson.`annotation`.JsonProperty
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import com.fasterxml.jackson.databind.`annotation`.JsonDeserialize
+import com.fasterxml.jackson.databind.`annotation`.JsonPOJOBuilder
+import com.netflix.graphql.dgs.codegen.fixtures.Node
+import java.lang.IllegalStateException
+import kotlin.String
+import kotlin.Suppress
+import kotlin.jvm.JvmName
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
+@JsonDeserialize(builder = Product.Builder::class)
+public class Product(
+  id: () -> String = idDefault,
+) : Entity, Node {
+  private val _id: () -> String = id
+
+  @Suppress("INAPPLICABLE_JVM_NAME")
+  @get:JvmName("getId")
+  public override val id: String
+    get() = _id.invoke()
+
+  public companion object {
+    private val idDefault: () -> String = 
+        { throw IllegalStateException("Field `id` was not requested") }
+
+  }
+
+  @JsonPOJOBuilder
+  @JsonIgnoreProperties("__typename")
+  public class Builder {
+    private var id: () -> String = idDefault
+
+    @JsonProperty("id")
+    public fun withId(id: String): Builder = this.apply {
+      this.id = { id }
+    }
+
+    public fun build() = Product(
+      id = id,
+    )
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithMappedInterfaces/expected/types/Query.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithMappedInterfaces/expected/types/Query.kt
@@ -1,0 +1,43 @@
+package com.netflix.graphql.dgs.codegen.cases.dataClassWithMappedInterfaces.expected.types
+
+import com.fasterxml.jackson.`annotation`.JsonIgnoreProperties
+import com.fasterxml.jackson.`annotation`.JsonProperty
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import com.fasterxml.jackson.databind.`annotation`.JsonDeserialize
+import com.fasterxml.jackson.databind.`annotation`.JsonPOJOBuilder
+import java.lang.IllegalStateException
+import kotlin.collections.List
+import kotlin.jvm.JvmName
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
+@JsonDeserialize(builder = Query.Builder::class)
+public class Query(
+  products: () -> List<Product?>? = productsDefault,
+) {
+  private val _products: () -> List<Product?>? = products
+
+  @get:JvmName("getProducts")
+  public val products: List<Product?>?
+    get() = _products.invoke()
+
+  public companion object {
+    private val productsDefault: () -> List<Product?>? = 
+        { throw IllegalStateException("Field `products` was not requested") }
+
+  }
+
+  @JsonPOJOBuilder
+  @JsonIgnoreProperties("__typename")
+  public class Builder {
+    private var products: () -> List<Product?>? = productsDefault
+
+    @JsonProperty("products")
+    public fun withProducts(products: List<Product?>?): Builder = this.apply {
+      this.products = { products }
+    }
+
+    public fun build() = Query(
+      products = products,
+    )
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithMappedInterfaces/schema.graphql
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithMappedInterfaces/schema.graphql
@@ -1,0 +1,15 @@
+type Query {
+    products: [Product]
+}
+
+interface Node {
+    id: ID!
+}
+
+interface Entity implements Node {
+    id: ID!
+}
+
+type Product implements Entity & Node {
+    id: ID!
+}

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/fixtures/Node.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/fixtures/Node.kt
@@ -1,0 +1,23 @@
+/*
+ *
+ *  Copyright 2020 Netflix, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package com.netflix.graphql.dgs.codegen.fixtures
+
+interface Node {
+    val id: String
+}

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/DataTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/DataTypeGenerator.kt
@@ -282,7 +282,7 @@ abstract class BaseDataTypeGenerator(
             .addModifiers(Modifier.PUBLIC)
 
         superInterfaces.forEach {
-            javaType.addSuperinterface(typeUtils.findKtInterfaceName((it as TypeName).name, packageName))
+            javaType.addSuperinterface(typeUtils.findJavaInterfaceName((it as TypeName).name, packageName))
         }
 
         fields.forEach {

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/DataTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/DataTypeGenerator.kt
@@ -282,7 +282,7 @@ abstract class BaseDataTypeGenerator(
             .addModifiers(Modifier.PUBLIC)
 
         superInterfaces.forEach {
-            javaType.addSuperinterface(ClassName.get(packageName, (it as TypeName).name))
+            javaType.addSuperinterface(typeUtils.findKtInterfaceName((it as TypeName).name, packageName))
         }
 
         fields.forEach {

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/InterfaceGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/InterfaceGenerator.kt
@@ -59,7 +59,7 @@ class InterfaceGenerator(private val config: CodeGenConfig, private val document
         definition.implements
             .filterIsInstance<TypeName>()
             .forEach {
-                javaType.addSuperinterface(typeUtils.findKtInterfaceName(it.name, packageName))
+                javaType.addSuperinterface(typeUtils.findJavaInterfaceName(it.name, packageName))
             }
 
         val mergedFieldDefinitions = definition.fieldDefinitions + extensions.flatMap { it.fieldDefinitions }

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/InterfaceGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/InterfaceGenerator.kt
@@ -59,7 +59,7 @@ class InterfaceGenerator(private val config: CodeGenConfig, private val document
         definition.implements
             .filterIsInstance<TypeName>()
             .forEach {
-                javaType.addSuperinterface(ClassName.get(packageName, it.name))
+                javaType.addSuperinterface(typeUtils.findKtInterfaceName(it.name, packageName))
             }
 
         val mergedFieldDefinitions = definition.fieldDefinitions + extensions.flatMap { it.fieldDefinitions }

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/TypeUtils.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/TypeUtils.kt
@@ -115,7 +115,7 @@ class TypeUtils(private val packageName: String, private val config: CodeGenConf
     /**
      * Takes a GQL interface type name and returns the appropriate kotlin type given all of the mappings defined in the schema and config
      */
-    fun findKtInterfaceName(interfaceName: String, packageName: String): JavaTypeName {
+    fun findJavaInterfaceName(interfaceName: String, packageName: String): JavaTypeName {
         // check config
         if (interfaceName in config.typeMapping) {
             val mappedType = config.typeMapping.getValue(interfaceName)

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/TypeUtils.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/TypeUtils.kt
@@ -112,6 +112,30 @@ class TypeUtils(private val packageName: String, private val config: CodeGenConf
         return NodeTraverser().postOrder(visitor, fieldType) as JavaTypeName
     }
 
+    /**
+     * Takes a GQL interface type name and returns the appropriate kotlin type given all of the mappings defined in the schema and config
+     */
+    fun findKtInterfaceName(interfaceName: String, packageName: String): JavaTypeName {
+        // check config
+        if (interfaceName in config.typeMapping) {
+            val mappedType = config.typeMapping.getValue(interfaceName)
+
+            return parseMappedType(
+                mappedType = mappedType,
+                toTypeName = String::toTypeName,
+                parameterize = { current ->
+                    ParameterizedTypeName.get(
+                        current.first as ClassName,
+                        *current.second.toTypedArray()
+                    )
+                },
+                onCloseBracketCallBack = { current, typeString -> current.second.add(typeString.toTypeName(true)) }
+            )
+        }
+
+        return ClassName.get(packageName, interfaceName)
+    }
+
     private fun unboxType(typeName: JavaTypeName): JavaTypeName {
         return if (typeName.isBoxedPrimitive) {
             typeName.unbox()

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinDataTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinDataTypeGenerator.kt
@@ -263,7 +263,7 @@ abstract class AbstractKotlinDataTypeGenerator(
         val interfaceTypes = interfaces + unionTypes
         interfaceTypes.forEach {
             if (it is NamedNode<*>) {
-                kotlinType.addSuperinterface(ClassName.bestGuess("${getPackageName()}.${it.name}"))
+                kotlinType.addSuperinterface(typeUtils.findKtInterfaceName(it.name, getPackageName()))
             }
         }
 

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinInterfaceTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinInterfaceTypeGenerator.kt
@@ -54,7 +54,7 @@ class KotlinInterfaceTypeGenerator(private val config: CodeGenConfig, private va
 
         superInterfacesNames(definition)
             .forEach {
-                interfaceBuilder.addSuperinterface(ClassName(packageName, it))
+                interfaceBuilder.addSuperinterface(typeUtils.findKtInterfaceName(it, packageName))
             }
 
         val mergedFieldDefinitions = definition.fieldDefinitions + extensions.flatMap { it.fieldDefinitions }

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin2/GenerateKotlin2DataTypes.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin2/GenerateKotlin2DataTypes.kt
@@ -174,7 +174,7 @@ fun generateKotlin2DataTypes(
                 .addType(builder)
                 // add interfaces to implement
                 .addSuperinterfaces(
-                    superInterfaces.map { ClassName.bestGuess("${config.packageNameTypes}.$it") }
+                    superInterfaces.map { typeLookup.findKtInterfaceName(it, config.packageNameTypes) }
                 )
                 // add a constructor with a supplier for every field
                 .primaryConstructor(

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin2/GenerateKotlin2Interfaces.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin2/GenerateKotlin2Interfaces.kt
@@ -100,7 +100,7 @@ fun generateKotlin2Interfaces(
                 }
                 // add interfaces to implement
                 .addSuperinterfaces(
-                    implementedInterfaces.map { ClassName(config.packageNameTypes, it) }
+                    implementedInterfaces.map { typeLookup.findKtInterfaceName(it, config.packageNameTypes) }
                 )
                 // add fields, overriding if needed
                 .addProperties(

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin2/Kotlin2TypeLookup.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin2/Kotlin2TypeLookup.kt
@@ -244,6 +244,19 @@ class Kotlin2TypeLookup(
         return NodeTraverser().postOrder(visitor, fieldType) as KtTypeName
     }
 
+    /**
+     * Takes a GQL interface type name and returns the appropriate kotlin type given all of the mappings defined in the schema and config
+     */
+    fun findKtInterfaceName(interfaceName: String, packageName: String): KtTypeName {
+        // check config
+        val mappedType = mappedTypes[interfaceName]
+        if (mappedType != null) {
+            return mappedType
+        }
+
+        return "$packageName.$interfaceName".toKtTypeName()
+    }
+
     private fun findKtTypeName(typeName: TypeName, packageName: String): KtTypeName {
         // check config
         val mappedType = mappedTypes[typeName.name]


### PR DESCRIPTION
> 👋🏼 @paulbakker @srinivasankavitha hope y'all are well!

We are in the process of migrating our monolith DGS app into a more federated architecture but using Gradle modules instead of services + a gateway. We want to have the organization think in a federated manner without going through the added headache of a router + registry when it isn't needed at this point in our GraphQL adoption journey. So far everything has worked pretty well but we recently hit a snag when trying to extend or return types across module boundaries.

Given two modules:

*products-module*
```graphql
type Product implements Node {
  id: ID!
  cost: Number
}
```

*reviews-module*
```graphql
type Review implements Node {
  id: ID!
  score: Number
}

extend type Product implements Node {
  id: ID!
  reviews: [Review]
}
```

When we write the resolver for review historically we would write it like this:

```kotlin
// in the review-module
@DgsComponent
class ProductResolver {
    @DgsData(parentType = DgsConstants.PRODUCT.TYPE_NAME)
    fun reviews(dfe: DgsDataFetchingEnvironment): CompletableFuture<List<Review>?> {
        val product = dfe.getSource<Product>()

        return fetchReviewsForProduct(product.id)
    }
}
```

As we have been extracting modules, this creates a class cast exception because the parent `Product` is from `products-module` so it has `id` and `score` which is incompatible with the `reviews-module` version which has `id` and an optional `reviews`.

Instead, we would like to restrict the contract across modules to be just the keys (aka `@keys` from federation) which is just the `id` from `Node` in this case.

In order to do this, we have a common `Node` interface which all shared types implement but dgs-codegen currently does not support sharing a common interface via type mapping. Instead, it creates a new `Node` type within each module so we can not down cast to the root `Node`. Instead, we would like to write a resolver like this:

```kotlin
// in the review-module
@DgsComponent
class ProductResolver {
    @DgsData(parentType = DgsConstants.PRODUCT.TYPE_NAME)
    fun reviews(dfe: DgsDataFetchingEnvironment): CompletableFuture<List<Review>?> {
        val node = dfe.getSource<Node>()

        return fetchReviewsForProduct(node.id)
    }
}
```

In order to do this, we need dgs-codegen to follow typeMappings in the config for types and interfaces which implement interfaces. This PR enables that 🎉 
