### PR TITLE
IIEA-10827 support class objects as inputs

### DIFF
--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
@@ -472,6 +472,7 @@ data class CodeGenConfig(
     val generateInterfaceSetters: Boolean = true,
     val includeImports: Map<String, String> = emptyMap(),
     val includeEnumImports: Map<String, Map<String, String>> = emptyMap(),
+    val includeClassImports:  Map<String, Map<String, String>> = emptyMap(),
     val generateCustomAnnotations: Boolean = false,
     var javaGenerateAllConstructor: Boolean = true,
     val implementSerializable: Boolean = false,

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/JavaPoetUtils.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/JavaPoetUtils.kt
@@ -195,8 +195,10 @@ fun customAnnotation(annotationArgumentMap: MutableMap<String, Value<Value<*>>>,
         val objectFields: List<ObjectField> = (annotationArgumentMap[ParserConstants.INPUTS] as ObjectValue).objectFields
         for (objectField in objectFields) {
             val codeBlock: CodeBlock = generateCode(
+                config,
                 objectField.value,
-                PackageParserUtil.getEnumPackage(config, (annotationArgumentMap[ParserConstants.NAME] as StringValue).value, objectField.name)
+                (annotationArgumentMap[ParserConstants.NAME] as StringValue).value,
+                objectField.name
             )
             annotation.addMember(objectField.name, codeBlock)
         }
@@ -207,21 +209,31 @@ fun customAnnotation(annotationArgumentMap: MutableMap<String, Value<Value<*>>>,
 /**
  * Generates the code block containing the parameters of an annotation in the format value
  */
-private fun generateCode(value: Value<Value<*>>, packageName: String = ""): CodeBlock =
+private fun generateCode(config: CodeGenConfig, value: Value<Value<*>>, annotationName: String, prefix: String = ""): CodeBlock =
     when (value) {
         is BooleanValue -> CodeBlock.of("\$L", (value as BooleanValue).isValue)
         is IntValue -> CodeBlock.of("\$L", (value as IntValue).value)
-        is StringValue -> CodeBlock.of("\$S", (value as StringValue).value)
+        is StringValue ->
+            // If string ends with .class, treat as class object
+            if ((value as StringValue).value.takeLast(6) == ".class") {
+                val className = (value as StringValue).value.dropLast(6)
+                // Use annotationName and className in the PackagerParserUtil to get Class Package name.
+                CodeBlock.of(
+                    "\$T.class",
+                    ClassName.get(PackageParserUtil.getClassPackage(config, annotationName, className), className)
+                )
+            }
+            else CodeBlock.of("\$S", (value as StringValue).value)
         is FloatValue -> CodeBlock.of("\$L", (value as FloatValue).value)
-        // In an enum value the prefix/type (key in the parameters map for the enum) is used to get the package name from the config
+        // In an enum value the prefix (key in the parameters map for the enum) is used to get the package name from the config
         // Limitation: Since it uses the enum key to lookup the package from the configs. 2 enums using different packages cannot have the same keys.
         is EnumValue -> CodeBlock.of(
             "\$T",
-            ClassName.get(packageName, (value as EnumValue).name)
+            ClassName.get(PackageParserUtil.getEnumPackage(config, annotationName, prefix), (value as EnumValue).name)
         )
         is ArrayValue ->
             if ((value as ArrayValue).values.isEmpty()) CodeBlock.of("[]")
-            else CodeBlock.of("[\$L]", (value as ArrayValue).values.joinToString { v -> generateCode(value = v, if (v is EnumValue) packageName else "").toString() })
+            else CodeBlock.of("[\$L]", (value as ArrayValue).values.joinToString { v -> generateCode(config = config, value = v, annotationName = annotationName, prefix = if (v is EnumValue) prefix else "").toString() })
         else -> CodeBlock.of("\$L", value)
     }
 

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinPoetUtils.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinPoetUtils.kt
@@ -319,17 +319,16 @@ private fun generateCode(config: CodeGenConfig, value: Value<Value<*>>, annotati
     when (value) {
         is BooleanValue -> CodeBlock.of("$prefix%L", (value as BooleanValue).isValue)
         is IntValue -> CodeBlock.of("$prefix%L", (value as IntValue).value)
-        // If string ends with ::class, treat as class object
         is StringValue ->
+            // If string ends with ::class, treat as class object
             if ((value as StringValue).value.takeLast(7) == "::class") {
                 val className = (value as StringValue).value.dropLast(7)
                 CodeBlock.of(
                     "$prefix%T::class",
-                     // Use annotationName in the PackagerParserUtil to get Class Package name.
+                    // Use annotationName and className in the PackagerParserUtil to get Class Package name.
                     ClassName(PackageParserUtil.getClassPackage(config, annotationName, className), className)
                 )
-            } else
-                CodeBlock.of("$prefix%S", (value as StringValue).value)
+            } else CodeBlock.of("$prefix%S", (value as StringValue).value)
         is FloatValue -> CodeBlock.of("$prefix%L", (value as FloatValue).value)
         // In an enum value the prefix/type (key in the parameters map for the enum) is used to get the package name from the config
         // Limitation: Since it uses the enum key to lookup the package from the configs. 2 enums using different packages cannot have the same keys.

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinPoetUtils.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinPoetUtils.kt
@@ -319,7 +319,17 @@ private fun generateCode(config: CodeGenConfig, value: Value<Value<*>>, annotati
     when (value) {
         is BooleanValue -> CodeBlock.of("$prefix%L", (value as BooleanValue).isValue)
         is IntValue -> CodeBlock.of("$prefix%L", (value as IntValue).value)
-        is StringValue -> CodeBlock.of("$prefix%S", (value as StringValue).value)
+        // If string ends with ::class, treat as class object
+        is StringValue ->
+            if ((value as StringValue).value.takeLast(7) == "::class") {
+                val className = (value as StringValue).value.dropLast(7)
+                CodeBlock.of(
+                    "$prefix%T::class",
+                     // Use annotationName in the PackagerParserUtil to get Class Package name.
+                    ClassName(PackageParserUtil.getClassPackage(config, annotationName, className), className)
+                )
+            } else
+                CodeBlock.of("$prefix%S", (value as StringValue).value)
         is FloatValue -> CodeBlock.of("$prefix%L", (value as FloatValue).value)
         // In an enum value the prefix/type (key in the parameters map for the enum) is used to get the package name from the config
         // Limitation: Since it uses the enum key to lookup the package from the configs. 2 enums using different packages cannot have the same keys.

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/shared/PackageParserUtil.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/shared/PackageParserUtil.kt
@@ -27,7 +27,7 @@ class PackageParserUtil {
          * Retrieves the package value in the directive.
          * If not present uses the default package in the config for that particular type of annotation.
          * If neither of them are supplied the package name will be an empty String
-         * Also parses the  simpleName/className from the name argument in the directive
+         * Also parses the simpleName/className from the name argument in the directive
          */
         fun getAnnotationPackage(config: CodeGenConfig, name: String, type: String? = null): Pair<String, String> {
             var packageName = name.substringBeforeLast(".", "")
@@ -45,6 +45,13 @@ class PackageParserUtil {
         fun getEnumPackage(config: CodeGenConfig, annotationName: String, enumType: String): String {
             return config.includeEnumImports[annotationName]?.getOrDefault(
                 enumType,
+                ""
+            ) ?: ""
+        }
+
+        fun getClassPackage(config: CodeGenConfig, annotationName: String, className: String): String {
+            return config.includeClassImports[annotationName]?.getOrDefault(
+                className,
                 ""
             ) ?: ""
         }


### PR DESCRIPTION
**Add support for class objects as inputs for custom annotation.**

Sample graphql

```
type Person @annotate(name: "ValidPerson", type: "validator", inputs: {groups: "BasicValidation::class"}) {
  name: String @annotate(name: "com.test.anotherValidator.ValidName")
}
```
Sample class created

```
package com.netflix.graphql.dgs.codegen.tests.generated.types

import com.fasterxml.jackson.`annotation`.JsonProperty
import com.test.anotherValidator.ValidName
import com.test.validator.ValidPerson
import com.test.validator.groups.BasicValidation
import kotlin.String

@ValidPerson(groups = BasicValidation::class)
public data class Person(
  @JsonProperty("name")
  @ValidName
  public val name: String? = null,
) {
  public companion object
}
```

Sample graphql

```
type Person @annotate(name: "ValidPerson", type: "validator", inputs: {groups: ["BasicValidation::class","AdvanceValidation::class"]}) {
  name: String @annotate(name: "com.test.anotherValidator.ValidName")
}
```

Sample class created
```
package com.netflix.graphql.dgs.codegen.tests.generated.types

import com.fasterxml.jackson.`annotation`.JsonProperty
import com.test.anotherValidator.ValidName
import com.test.validator.ValidPerson
import kotlin.String

@ValidPerson(groups = [com.test.validator.groups.BasicValidation::class, com.test.validator.groups.AdvanceValidation::class])
public data class Person(
  @JsonProperty("name")
  @ValidName
  public val name: String? = null,
) {
  public companion object
}
```