### PR TITLE
IIEA-10827 Add support for class objects as inputs 

### DIFF
--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
@@ -472,6 +472,7 @@ data class CodeGenConfig(
     val generateInterfaceSetters: Boolean = true,
     val includeImports: Map<String, String> = emptyMap(),
     val includeEnumImports: Map<String, Map<String, String>> = emptyMap(),
+    val includeClassImports: Map<String, Map<String, String>> = emptyMap(),
     val generateCustomAnnotations: Boolean = false,
     var javaGenerateAllConstructor: Boolean = true,
     val implementSerializable: Boolean = false,

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/shared/PackageParserUtil.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/shared/PackageParserUtil.kt
@@ -27,7 +27,7 @@ class PackageParserUtil {
          * Retrieves the package value in the directive.
          * If not present uses the default package in the config for that particular type of annotation.
          * If neither of them are supplied the package name will be an empty String
-         * Also parses the  simpleName/className from the name argument in the directive
+         * Also parses the simpleName/className from the name argument in the directive
          */
         fun getAnnotationPackage(config: CodeGenConfig, name: String, type: String? = null): Pair<String, String> {
             var packageName = name.substringBeforeLast(".", "")
@@ -45,6 +45,13 @@ class PackageParserUtil {
         fun getEnumPackage(config: CodeGenConfig, annotationName: String, enumType: String): String {
             return config.includeEnumImports[annotationName]?.getOrDefault(
                 enumType,
+                ""
+            ) ?: ""
+        }
+
+        fun getClassPackage(config: CodeGenConfig, annotationName: String, className: String): String {
+            return config.includeClassImports[annotationName]?.getOrDefault(
+                className,
                 ""
             ) ?: ""
         }

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/shared/ParserConstants.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/shared/ParserConstants.kt
@@ -31,4 +31,6 @@ object ParserConstants {
     const val REPLACE_WITH = "replaceWith"
     const val REPLACE_WITH_CLASS = "ReplaceWith"
     const val SITE_TARGET = "target"
+    const val CLASS_STRING = ".class"
+    const val CLASS_LENGTH = CLASS_STRING.length
 }

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
@@ -3325,6 +3325,157 @@ It takes a title and such.
     }
 
     @Test
+    fun annotateOnTypesWithClassObjects() {
+        val schema = """
+            type Person @annotate(name: "ValidPerson", type: "validator", inputs: {groups: "BasicValidation.class"}) {
+                name: String @annotate(name: "com.test.anotherValidator.ValidName")
+            }
+        """.trimIndent()
+
+        val (dataTypes) = CodeGen(
+            CodeGenConfig(
+                schemas = setOf(schema),
+                packageName = basePackageName,
+                includeImports = mapOf(Pair("validator", "com.test.validator")),
+                includeClassImports = mapOf("ValidPerson" to mapOf(Pair("BasicValidation", "com.test.validator.groups"))),
+                generateCustomAnnotations = true
+            )
+        ).generate()
+
+        assertThat(dataTypes.size).isEqualTo(1)
+        val person = dataTypes.single().typeSpec
+        assertThat(person.name).isEqualTo("Person")
+        assertThat(person.annotations).hasSize(1)
+        assertThat(((person.annotations[0] as AnnotationSpec).type as ClassName).simpleName()).isEqualTo("ValidPerson")
+        assertThat(((person.annotations[0] as AnnotationSpec).type as ClassName).canonicalName()).isEqualTo("com.test.validator.ValidPerson")
+        assertThat((person.annotations[0] as AnnotationSpec).members).hasSize(1)
+        assertThat((person.annotations[0] as AnnotationSpec).members["groups"]).isEqualTo(listOf(CodeBlock.of("\$L", "com.test.validator.groups.BasicValidation.class")))
+        val fields = person.fieldSpecs
+        assertThat(fields).hasSize(1)
+        assertThat(fields[0].annotations).hasSize(1)
+        assertThat(((fields[0].annotations[0] as AnnotationSpec).type as ClassName).simpleName()).isEqualTo("ValidName")
+        assertThat(((fields[0].annotations[0] as AnnotationSpec).type as ClassName).canonicalName()).isEqualTo("com.test.anotherValidator.ValidName")
+    }
+
+    @Test
+    fun annotateOnTypesWithClassObjectsNoMapping() {
+        val schema = """
+            type Person @annotate(name: "ValidPerson", type: "validator", inputs: {groups: "BasicValidation.class"}) {
+                name: String @annotate(name: "com.test.anotherValidator.ValidName")
+            }
+        """.trimIndent()
+
+        val (dataTypes) = CodeGen(
+            CodeGenConfig(
+                schemas = setOf(schema),
+                packageName = basePackageName,
+                includeImports = mapOf(Pair("validator", "com.test.validator")),
+                generateCustomAnnotations = true
+            )
+        ).generate()
+
+        assertThat(dataTypes.size).isEqualTo(1)
+        val person = dataTypes.single().typeSpec
+        assertThat(person.name).isEqualTo("Person")
+        assertThat(person.annotations).hasSize(1)
+        assertThat(((person.annotations[0] as AnnotationSpec).type as ClassName).simpleName()).isEqualTo("ValidPerson")
+        assertThat(((person.annotations[0] as AnnotationSpec).type as ClassName).canonicalName()).isEqualTo("com.test.validator.ValidPerson")
+        assertThat((person.annotations[0] as AnnotationSpec).members).hasSize(1)
+        assertThat((person.annotations[0] as AnnotationSpec).members["groups"]).isEqualTo(listOf(CodeBlock.of("\$S", "BasicValidation.class"))) // treat as string when no mapping is provided
+        val fields = person.fieldSpecs
+        assertThat(fields).hasSize(1)
+        assertThat(fields[0].annotations).hasSize(1)
+        assertThat(((fields[0].annotations[0] as AnnotationSpec).type as ClassName).simpleName()).isEqualTo("ValidName")
+        assertThat(((fields[0].annotations[0] as AnnotationSpec).type as ClassName).canonicalName()).isEqualTo("com.test.anotherValidator.ValidName")
+    }
+
+    @Test
+    fun annotateOnTypesWithListOfClassObjects() {
+        val schema = """
+            type Person @annotate(name: "ValidPerson", type: "validator", inputs: {groups: ["BasicValidation.class","AdvanceValidation.class"]}) {
+                name: String @annotate(name: "com.test.anotherValidator.ValidName")
+            }
+        """.trimIndent()
+
+        val (dataTypes) = CodeGen(
+            CodeGenConfig(
+                schemas = setOf(schema),
+                packageName = basePackageName,
+                includeImports = mapOf(Pair("validator", "com.test.validator")),
+                includeClassImports = mapOf(
+                    "ValidPerson" to mapOf(
+                        Pair("BasicValidation", "com.test.validator.groups"),
+                        Pair("AdvanceValidation", "com.test.validator.groups")
+                    )
+                ),
+                generateCustomAnnotations = true
+            )
+        ).generate()
+
+        assertThat(dataTypes.size).isEqualTo(1)
+        val person = dataTypes.single().typeSpec
+        assertThat(person.name).isEqualTo("Person")
+        assertThat(person.annotations).hasSize(1)
+        assertThat(((person.annotations[0] as AnnotationSpec).type as ClassName).simpleName()).isEqualTo("ValidPerson")
+        assertThat(((person.annotations[0] as AnnotationSpec).type as ClassName).canonicalName()).isEqualTo("com.test.validator.ValidPerson")
+        assertThat((person.annotations[0] as AnnotationSpec).members).hasSize(1)
+        assertThat((person.annotations[0] as AnnotationSpec).members["groups"]).isEqualTo(listOf(CodeBlock.of("[\$L]", "com.test.validator.groups.BasicValidation.class, com.test.validator.groups.AdvanceValidation.class")))
+        val fields = person.fieldSpecs
+        assertThat(fields).hasSize(1)
+        assertThat(fields[0].annotations).hasSize(1)
+        assertThat(((fields[0].annotations[0] as AnnotationSpec).type as ClassName).simpleName()).isEqualTo("ValidName")
+        assertThat(((fields[0].annotations[0] as AnnotationSpec).type as ClassName).canonicalName()).isEqualTo("com.test.anotherValidator.ValidName")
+    }
+
+    @Test
+    fun annotateOnTypesWithMultipleListsOfClassObjects() {
+        val schema = """
+            type Person @annotate(name: "ValidPerson", type: "validator", inputs: {groups: ["BasicValidation.class","AdvanceValidation.class"]}) {
+                name: String @annotate(name: "com.test.anotherValidator.ValidName")
+                type: String @annotate(name: "ValidDateOfBirth", type: "dateOfBirth", inputs: {levels: ["PreliminaryValidation.class","SecondaryValidation.class"]}) 
+            }
+        """.trimIndent()
+
+        val (dataTypes) = CodeGen(
+            CodeGenConfig(
+                schemas = setOf(schema),
+                packageName = basePackageName,
+                includeImports = mapOf(Pair("validator", "com.test.validator"), Pair("dateOfBirth", "com.test.validator.dob")),
+                includeClassImports = mapOf(
+                    "ValidPerson" to mapOf(
+                        Pair("BasicValidation", "com.test.validator.groups"),
+                        Pair("AdvanceValidation", "com.test.validator.groups")
+                    ),
+                    "ValidDateOfBirth" to mapOf(
+                        Pair("PreliminaryValidation", "com.test.validator.dob.levels"),
+                        Pair("SecondaryValidation", "com.test.validator.dob.levels")
+                    )
+                ),
+                generateCustomAnnotations = true
+            )
+        ).generate()
+
+        assertThat(dataTypes.size).isEqualTo(1)
+        val person = dataTypes.single().typeSpec
+        assertThat(person.name).isEqualTo("Person")
+        assertThat(person.annotations).hasSize(1)
+        assertThat(((person.annotations[0] as AnnotationSpec).type as ClassName).simpleName()).isEqualTo("ValidPerson")
+        assertThat(((person.annotations[0] as AnnotationSpec).type as ClassName).canonicalName()).isEqualTo("com.test.validator.ValidPerson")
+        assertThat((person.annotations[0] as AnnotationSpec).members).hasSize(1)
+        assertThat((person.annotations[0] as AnnotationSpec).members["groups"]).isEqualTo(listOf(CodeBlock.of("[\$L]", "com.test.validator.groups.BasicValidation.class, com.test.validator.groups.AdvanceValidation.class")))
+        val fields = person.fieldSpecs
+        assertThat(fields).hasSize(2)
+        assertThat(fields[0].annotations).hasSize(1)
+        assertThat(((fields[0].annotations[0] as AnnotationSpec).type as ClassName).simpleName()).isEqualTo("ValidName")
+        assertThat(((fields[0].annotations[0] as AnnotationSpec).type as ClassName).canonicalName()).isEqualTo("com.test.anotherValidator.ValidName")
+
+        assertThat(fields[1].annotations).hasSize(1)
+        assertThat(((fields[1].annotations[0] as AnnotationSpec).type as ClassName).simpleName()).isEqualTo("ValidDateOfBirth")
+        assertThat(((fields[1].annotations[0] as AnnotationSpec).type as ClassName).canonicalName()).isEqualTo("com.test.validator.dob.ValidDateOfBirth")
+        assertThat((fields[1].annotations[0] as AnnotationSpec).members["levels"]).isEqualTo(listOf(CodeBlock.of("[\$L]", "com.test.validator.dob.levels.PreliminaryValidation.class, com.test.validator.dob.levels.SecondaryValidation.class")))
+    }
+
+    @Test
     fun annotateOnTypesWithEnums() {
         val schema = """
             type Person @annotate(name: "ValidPerson", type: "validator", inputs: {sexType: MALE}) {

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
@@ -2124,6 +2124,166 @@ class KotlinCodeGenTest {
     }
 
     @Test
+    fun annotateOnTypesWithClassObjects() {
+        val schema = """
+            type Person @annotate(name: "ValidPerson", type: "validator", inputs: {groups: "BasicValidation.class"}) {
+                name: String @annotate(name: "com.test.anotherValidator.ValidName")
+            }
+        """.trimIndent()
+
+        val codeGen = CodeGen(
+            CodeGenConfig(
+                schemas = setOf(schema),
+                packageName = basePackageName,
+                language = Language.KOTLIN,
+                includeImports = mapOf(Pair("validator", "com.test.validator")),
+                includeClassImports = mapOf("ValidPerson" to mapOf(Pair("BasicValidation", "com.test.validator.groups"))),
+                generateCustomAnnotations = true
+            )
+        )
+        val dataTypes = codeGen.generate().kotlinDataTypes
+
+        assertThat(dataTypes).hasSize(1)
+        assertThat(dataTypes[0].name).isEqualTo("Person")
+
+        val annotationSpec = (((dataTypes as ArrayList<*>)[0] as FileSpec).members[0] as TypeSpec).annotationSpecs[0]
+        assertThat((annotationSpec.typeName as ClassName).canonicalName).isEqualTo("com.test.validator.ValidPerson")
+        assertThat(annotationSpec.members[0]).extracting("args").asList().hasSize(1)
+        assertThat(annotationSpec.members[0]).extracting("args").asString().contains("com.test.validator.groups.BasicValidation")
+
+        val parameterSpec = (((dataTypes[0].members)[0] as TypeSpec).primaryConstructor as FunSpec).parameters[0]
+        assertThat(parameterSpec.name).isEqualTo("name")
+        assertThat(parameterSpec.annotations).hasSize(2)
+        assertThat((parameterSpec.annotations[0].typeName as ClassName).canonicalName).isEqualTo("com.fasterxml.jackson.annotation.JsonProperty")
+        assertThat((parameterSpec.annotations[1].typeName as ClassName).canonicalName).isEqualTo("com.test.anotherValidator.ValidName")
+    }
+
+    @Test
+    fun annotateOnTypesWithClassObjectsNoMapping() {
+        val schema = """
+            type Person @annotate(name: "ValidPerson", type: "validator", inputs: {groups: "BasicValidation.class"}) {
+                name: String @annotate(name: "com.test.anotherValidator.ValidName")
+            }
+        """.trimIndent()
+
+        val codeGen = CodeGen(
+            CodeGenConfig(
+                schemas = setOf(schema),
+                packageName = basePackageName,
+                language = Language.KOTLIN,
+                includeImports = mapOf(Pair("validator", "com.test.validator")),
+                generateCustomAnnotations = true
+            )
+        )
+        val dataTypes = codeGen.generate().kotlinDataTypes
+
+        assertThat(dataTypes).hasSize(1)
+        assertThat(dataTypes[0].name).isEqualTo("Person")
+
+        val annotationSpec = (((dataTypes as ArrayList<*>)[0] as FileSpec).members[0] as TypeSpec).annotationSpecs[0]
+        assertThat((annotationSpec.typeName as ClassName).canonicalName).isEqualTo("com.test.validator.ValidPerson")
+        assertThat(annotationSpec.members[0]).extracting("args").asList().hasSize(1)
+        assertThat(annotationSpec.members[0]).extracting("args").asString().contains("BasicValidation.class") // treat as string when no mapping is provided
+
+        val parameterSpec = (((dataTypes[0].members)[0] as TypeSpec).primaryConstructor as FunSpec).parameters[0]
+        assertThat(parameterSpec.name).isEqualTo("name")
+        assertThat(parameterSpec.annotations).hasSize(2)
+        assertThat((parameterSpec.annotations[0].typeName as ClassName).canonicalName).isEqualTo("com.fasterxml.jackson.annotation.JsonProperty")
+        assertThat((parameterSpec.annotations[1].typeName as ClassName).canonicalName).isEqualTo("com.test.anotherValidator.ValidName")
+    }
+
+    @Test
+    fun annotateOnTypesWithListOfClassObjects() {
+        val schema = """
+            type Person @annotate(name: "ValidPerson", type: "validator", inputs: {groups: ["BasicValidation.class","AdvanceValidation.class"]}) {
+                name: String @annotate(name: "com.test.anotherValidator.ValidName")
+            }
+        """.trimIndent()
+
+        val codeGen = CodeGen(
+            CodeGenConfig(
+                schemas = setOf(schema),
+                packageName = basePackageName,
+                language = Language.KOTLIN,
+                includeImports = mapOf(Pair("validator", "com.test.validator")),
+                includeClassImports = mapOf(
+                    "ValidPerson" to mapOf(
+                        Pair("BasicValidation", "com.test.validator.groups"),
+                        Pair("AdvanceValidation", "com.test.validator.groups")
+                    )
+                ),
+                generateCustomAnnotations = true
+            )
+        )
+        val dataTypes = codeGen.generate().kotlinDataTypes
+
+        assertThat(dataTypes).hasSize(1)
+        assertThat(dataTypes[0].name).isEqualTo("Person")
+
+        val annotationSpec = (((dataTypes as ArrayList<*>)[0] as FileSpec).members[0] as TypeSpec).annotationSpecs[0]
+        assertThat((annotationSpec.typeName as ClassName).canonicalName).isEqualTo("com.test.validator.ValidPerson")
+        assertThat(annotationSpec.members[0]).extracting("args").asList().hasSize(1)
+        assertThat(annotationSpec.members[0]).extracting("args").asString().contains("com.test.validator.groups.BasicValidation", "com.test.validator.groups.AdvanceValidation")
+
+        val parameterSpec = (((dataTypes[0].members)[0] as TypeSpec).primaryConstructor as FunSpec).parameters[0]
+        assertThat(parameterSpec.name).isEqualTo("name")
+        assertThat(parameterSpec.annotations).hasSize(2)
+        assertThat((parameterSpec.annotations[0].typeName as ClassName).canonicalName).isEqualTo("com.fasterxml.jackson.annotation.JsonProperty")
+        assertThat((parameterSpec.annotations[1].typeName as ClassName).canonicalName).isEqualTo("com.test.anotherValidator.ValidName")
+    }
+
+    @Test
+    fun annotateOnTypesWithMultipleListsOfClassObjects() {
+        val schema = """
+            type Person @annotate(name: "ValidPerson", type: "validator", inputs: {groups: ["BasicValidation.class","AdvanceValidation.class"]}) {
+                name: String @annotate(name: "com.test.anotherValidator.ValidName")
+                type: String @annotate(name: "ValidDateOfBirth", type: "dateOfBirth", inputs: {levels: ["PreliminaryValidation.class","SecondaryValidation.class"]}) 
+            }
+        """.trimIndent()
+
+        val codeGen = CodeGen(
+            CodeGenConfig(
+                schemas = setOf(schema),
+                packageName = basePackageName,
+                language = Language.KOTLIN,
+                includeImports = mapOf(Pair("validator", "com.test.validator"), Pair("dateOfBirth", "com.test.validator.dob")),
+                includeClassImports = mapOf(
+                    "ValidPerson" to mapOf(
+                        Pair("BasicValidation", "com.test.validator.groups"),
+                        Pair("AdvanceValidation", "com.test.validator.groups")
+                    ),
+                    "ValidDateOfBirth" to mapOf(
+                        Pair("PreliminaryValidation", "com.test.validator.dob.levels"),
+                        Pair("SecondaryValidation", "com.test.validator.dob.levels")
+                    )
+                ),
+                generateCustomAnnotations = true
+            )
+        )
+        val dataTypes = codeGen.generate().kotlinDataTypes
+
+        assertThat(dataTypes).hasSize(1)
+        assertThat(dataTypes[0].name).isEqualTo("Person")
+
+        val annotationSpec = (((dataTypes as ArrayList<*>)[0] as FileSpec).members[0] as TypeSpec).annotationSpecs[0]
+        assertThat((annotationSpec.typeName as ClassName).canonicalName).isEqualTo("com.test.validator.ValidPerson")
+        assertThat(annotationSpec.members[0]).extracting("args").asList().hasSize(1)
+        assertThat(annotationSpec.members[0]).extracting("args").asString().contains("com.test.validator.groups.BasicValidation", "com.test.validator.groups.AdvanceValidation")
+
+        val parameterSpec = (((dataTypes[0].members)[0] as TypeSpec).primaryConstructor as FunSpec).parameters[0]
+        assertThat(parameterSpec.name).isEqualTo("name")
+        assertThat(parameterSpec.annotations).hasSize(2)
+        assertThat((parameterSpec.annotations[0].typeName as ClassName).canonicalName).isEqualTo("com.fasterxml.jackson.annotation.JsonProperty")
+        assertThat((parameterSpec.annotations[1].typeName as ClassName).canonicalName).isEqualTo("com.test.anotherValidator.ValidName")
+
+        val parameterSpec2 = (((dataTypes[0].members)[0] as TypeSpec).primaryConstructor as FunSpec).parameters[1]
+        val annotationSpec2 = (((dataTypes[0].members)[0] as TypeSpec).primaryConstructor as FunSpec).parameters[1].annotations[1]
+        assertThat((parameterSpec2.annotations[0].typeName as ClassName).canonicalName).isEqualTo("com.fasterxml.jackson.annotation.JsonProperty")
+        assertThat((parameterSpec2.annotations[1].typeName as ClassName).canonicalName).isEqualTo("com.test.validator.dob.ValidDateOfBirth")
+        assertThat(annotationSpec2.members[0]).extracting("args").asString().contains("com.test.validator.dob.levels.PreliminaryValidation", "com.test.validator.dob.levels.SecondaryValidation")
+    }
+
+    @Test
     fun annotateOnTypesWithEnums() {
         val schema = """
             type Person @annotate(name: "ValidPerson", type: "validator", inputs: {sexType: MALE}) {

--- a/graphql-dgs-codegen-gradle/src/main/kotlin/com/netflix/graphql/dgs/codegen/gradle/GenerateJavaTask.kt
+++ b/graphql-dgs-codegen-gradle/src/main/kotlin/com/netflix/graphql/dgs/codegen/gradle/GenerateJavaTask.kt
@@ -138,6 +138,9 @@ open class GenerateJavaTask : DefaultTask() {
     @Input
     var includeEnumImports = mutableMapOf<String, MutableMap<String, String>>()
 
+    @Input
+    var includeClassImports = mutableMapOf<String, MutableMap<String, String>>()
+
     @TaskAction
     fun generate() {
         val schemaJarFilesFromDependencies = emptyList<File>().toMutableList()
@@ -194,6 +197,7 @@ open class GenerateJavaTask : DefaultTask() {
             addDeprecatedAnnotation = addDeprecatedAnnotation,
             includeImports = includeImports,
             includeEnumImports = includeEnumImports,
+            includeClassImports = includeClassImports,
             generateCustomAnnotations = generateCustomAnnotations
         )
 


### PR DESCRIPTION
**Add support for class objects as inputs for custom annotation.**

@srinivasankavitha As per https://github.com/Netflix/dgs-codegen/issues/476, updated custom annotation logic to interpret strings containing ".class" as class objects.

Sample schema

```
type Person @annotate(name: "ValidPerson", type: "validator", inputs: {groups: "BasicValidation.class"}) {
  name: String @annotate(name: "com.test.anotherValidator.ValidName")
}
```
Sample generated class

```
package com.netflix.graphql.dgs.codegen.tests.generated.types

import com.fasterxml.jackson.`annotation`.JsonProperty
import com.test.anotherValidator.ValidName
import com.test.validator.ValidPerson
import com.test.validator.groups.BasicValidation
import kotlin.String

@ValidPerson(groups = BasicValidation::class)
public data class Person(
  @JsonProperty("name")
  @ValidName
  public val name: String? = null,
) {
  public companion object
}
```
Sample schema

```
type Person @annotate(name: "ValidPerson", type: "validator", inputs: {groups: ["BasicValidation.class","AdvanceValidation.class"]}) {
  name: String @annotate(name: "com.test.anotherValidator.ValidName")
}
```
Sample generated class

```
package com.netflix.graphql.dgs.codegen.tests.generated.types

import com.fasterxml.jackson.`annotation`.JsonProperty
import com.test.anotherValidator.ValidName
import com.test.validator.ValidPerson
import kotlin.String

@ValidPerson(groups = [com.test.validator.groups.BasicValidation::class, com.test.validator.groups.AdvanceValidation::class])
public data class Person(
  @JsonProperty("name")
  @ValidName
  public val name: String? = null,
) {
  public companion object
}
```