### PR TITLE
Fixing wrong caps on generated DgsConstants

### DIFF
--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ConstantsGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ConstantsGenerator.kt
@@ -104,7 +104,7 @@ class ConstantsGenerator(private val config: CodeGenConfig, private val document
         if (document.definitions.any { it is ObjectTypeDefinition && it.name == "Query" }) {
             javaType.addField(FieldSpec.builder(TypeName.get(String::class.java), "QUERY_TYPE").addModifiers(Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL).initializer(""""Query"""").build())
         }
-        if (document.definitions.any { it is ObjectTypeDefinition && it.name == "MUTATION" }) {
+        if (document.definitions.any { it is ObjectTypeDefinition && it.name == "Mutation" }) {
             javaType.addField(FieldSpec.builder(TypeName.get(String::class.java), "MUTATION_TYPE").addModifiers(Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL).initializer(""""Mutation"""").build())
         }
         if (document.definitions.any { it is ObjectTypeDefinition && it.name == "Subscription" }) {

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinConstantsGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinConstantsGenerator.kt
@@ -102,11 +102,11 @@ class KotlinConstantsGenerator(private val config: CodeGenConfig, private val do
         }
 
         if (document.definitions.any { it is ObjectTypeDefinition && it.name == "Mutation" }) {
-            baseConstantsType.addProperty(PropertySpec.builder("Mutation_TYPE", String::class).addModifiers(KModifier.CONST).initializer(""""Mutation"""").build())
+            baseConstantsType.addProperty(PropertySpec.builder("MUTATION_TYPE", String::class).addModifiers(KModifier.CONST).initializer(""""Mutation"""").build())
         }
 
         if (document.definitions.any { it is ObjectTypeDefinition && it.name == "Subscription" }) {
-            baseConstantsType.addProperty(PropertySpec.builder("Subscription_TYPE", String::class).addModifiers(KModifier.CONST).initializer(""""Subscription"""").build())
+            baseConstantsType.addProperty(PropertySpec.builder("SUBSCRIPTION_TYPE", String::class).addModifiers(KModifier.CONST).initializer(""""Subscription"""").build())
         }
 
         val fileSpec = FileSpec.builder(config.packageName, "DgsConstants").addType(baseConstantsType.build()).build()


### PR DESCRIPTION
While trying to use [Codegen Constants](https://netflix.github.io/dgs/datafetching/#codegen-constants) I'm facing problems because `DgsConstants.MUTATION_TYPE` is not declared.

This seems too obvious... Am I trying to use MUTATION_TYPE in the wrong way? 🤔