### PR TITLE
fix: remove currency as commonScalar

### DIFF
--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/TypeUtils.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/TypeUtils.kt
@@ -30,7 +30,6 @@ import graphql.relay.PageInfo
 import graphql.util.TraversalControl
 import graphql.util.TraverserContext
 import java.time.*
-import java.util.*
 import com.squareup.javapoet.TypeName as JavaTypeName
 
 class TypeUtils(private val packageName: String, private val config: CodeGenConfig, private val document: Document) {
@@ -41,7 +40,6 @@ class TypeUtils(private val packageName: String, private val config: CodeGenConf
         "TimeZone" to ClassName.get(String::class.java),
         "Date" to ClassName.get(LocalDate::class.java),
         "DateTime" to ClassName.get(OffsetDateTime::class.java),
-        "Currency" to ClassName.get(Currency::class.java),
         "Instant" to ClassName.get(Instant::class.java),
         "RelayPageInfo" to ClassName.get(PageInfo::class.java),
         "PageInfo" to ClassName.get(PageInfo::class.java),

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/TypeUtils.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/TypeUtils.kt
@@ -30,6 +30,7 @@ import graphql.relay.PageInfo
 import graphql.util.TraversalControl
 import graphql.util.TraverserContext
 import java.time.*
+import java.util.*
 import com.squareup.javapoet.TypeName as JavaTypeName
 
 class TypeUtils(private val packageName: String, private val config: CodeGenConfig, private val document: Document) {
@@ -40,6 +41,7 @@ class TypeUtils(private val packageName: String, private val config: CodeGenConf
         "TimeZone" to ClassName.get(String::class.java),
         "Date" to ClassName.get(LocalDate::class.java),
         "DateTime" to ClassName.get(OffsetDateTime::class.java),
+        "Currency" to ClassName.get(Currency::class.java),
         "Instant" to ClassName.get(Instant::class.java),
         "RelayPageInfo" to ClassName.get(PageInfo::class.java),
         "PageInfo" to ClassName.get(PageInfo::class.java),
@@ -72,7 +74,7 @@ class TypeUtils(private val packageName: String, private val config: CodeGenConf
                 if (useWildcardType) {
                     if (typeName is ClassName) {
                         if (document.definitions.filterIsInstance<ObjectTypeDefinition>()
-                            .any { e -> "I${e.name}" == typeName.simpleName() }
+                                .any { e -> "I${e.name}" == typeName.simpleName() }
                         ) {
                             canUseWildcardType = true
                         }
@@ -172,7 +174,7 @@ class TypeUtils(private val packageName: String, private val config: CodeGenConf
             return schemaType.toTypeName()
         }
 
-        if (name in commonScalars) {
+        if (name in commonScalars && !isFieldTypeDefinedInDocument(name)) {
             return commonScalars.getValue(name)
         }
 
@@ -244,6 +246,11 @@ class TypeUtils(private val packageName: String, private val config: CodeGenConf
             originName
         }
     }
+
+    private fun isFieldTypeDefinedInDocument(name: String): Boolean =
+        document.definitions.filterIsInstance<ObjectTypeDefinition>().any { e -> e.name == name } ||
+                document.definitions.filterIsInstance<EnumTypeDefinition>().any { e -> e.name == name } ||
+                document.definitions.filterIsInstance<ScalarTypeDefinition>().any { e -> e.name == name }
 
     companion object {
         const val getClass = "getClass"

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinTypeUtils.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinTypeUtils.kt
@@ -29,6 +29,7 @@ import graphql.relay.PageInfo
 import graphql.util.TraversalControl
 import graphql.util.TraverserContext
 import java.time.*
+import java.util.*
 import com.squareup.kotlinpoet.TypeName as KtTypeName
 
 class KotlinTypeUtils(private val packageName: String, private val config: CodeGenConfig, private val document: Document) {
@@ -38,6 +39,7 @@ class KotlinTypeUtils(private val packageName: String, private val config: CodeG
         "LocalDate" to LocalDate::class.asTypeName(),
         "LocalDateTime" to LocalDateTime::class.asTypeName(),
         "TimeZone" to STRING,
+        "Currency" to Currency::class.asTypeName(),
         "Instant" to Instant::class.asTypeName(),
         "Date" to LocalDate::class.asTypeName(),
         "DateTime" to OffsetDateTime::class.asTypeName(),
@@ -132,7 +134,7 @@ class KotlinTypeUtils(private val packageName: String, private val config: CodeG
             return schemaType.toKtTypeName()
         }
 
-        if (name in commonScalars) {
+        if (name in commonScalars && !isFieldTypeDefinedInDocument(name)) {
             return commonScalars.getValue(name)
         }
 
@@ -150,4 +152,9 @@ class KotlinTypeUtils(private val packageName: String, private val config: CodeG
             else -> "$packageName.$name".toKtTypeName()
         }
     }
+
+    private fun isFieldTypeDefinedInDocument(name: String): Boolean =
+        document.definitions.filterIsInstance<ObjectTypeDefinition>().any { e -> e.name == name } ||
+                document.definitions.filterIsInstance<EnumTypeDefinition>().any { e -> e.name == name } ||
+                document.definitions.filterIsInstance<ScalarTypeDefinition>().any { e -> e.name == name }
 }

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinTypeUtils.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinTypeUtils.kt
@@ -29,7 +29,6 @@ import graphql.relay.PageInfo
 import graphql.util.TraversalControl
 import graphql.util.TraverserContext
 import java.time.*
-import java.util.*
 import com.squareup.kotlinpoet.TypeName as KtTypeName
 
 class KotlinTypeUtils(private val packageName: String, private val config: CodeGenConfig, private val document: Document) {
@@ -39,7 +38,6 @@ class KotlinTypeUtils(private val packageName: String, private val config: CodeG
         "LocalDate" to LocalDate::class.asTypeName(),
         "LocalDateTime" to LocalDateTime::class.asTypeName(),
         "TimeZone" to STRING,
-        "Currency" to Currency::class.asTypeName(),
         "Instant" to Instant::class.asTypeName(),
         "Date" to LocalDate::class.asTypeName(),
         "DateTime" to OffsetDateTime::class.asTypeName(),

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
@@ -3936,4 +3936,30 @@ It takes a title and such.
             ).generate()
         }
     }
+
+    @Test
+    fun `Use schema type when type name clashes with commonScalars`() {
+        val schema = """
+            type Price {
+                amount: Double
+                currency: Currency
+                date: Date
+            }
+            enum Currency {
+                EUR
+                GBP
+            }
+        """.trimIndent()
+
+        val (dataTypes) = CodeGen(
+            CodeGenConfig(
+                schemas = setOf(schema),
+                packageName = basePackageName
+            )
+        ).generate()
+
+        assertThat(dataTypes.size).isEqualTo(1)
+        assertThat(dataTypes[0].typeSpec.fieldSpecs[1].type.toString()).contains(basePackageName)
+        assertThat(dataTypes[0].typeSpec.fieldSpecs[2].type.toString()).isEqualTo("java.time.LocalDate")
+    }
 }

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
@@ -3548,4 +3548,30 @@ It takes a title and such.
         assertThat(fields).hasSize(1)
         assertThat(fields[0].annotations).hasSize(0)
     }
+
+    @Test
+    fun `Use schema type when type name clashes with commonScalars`() {
+        val schema = """
+            type Price {
+                amount: Double
+                currency: Currency
+                date: Date
+            }
+            enum Currency {
+                EUR
+                GBP
+            }
+        """.trimIndent()
+
+        val (dataTypes) = CodeGen(
+            CodeGenConfig(
+                schemas = setOf(schema),
+                packageName = basePackageName
+            )
+        ).generate()
+
+        assertThat(dataTypes.size).isEqualTo(1)
+        assertThat(dataTypes[0].typeSpec.fieldSpecs[1].type.toString()).contains(basePackageName)
+        assertThat(dataTypes[0].typeSpec.fieldSpecs[2].type.toString()).isEqualTo("java.time.LocalDate")
+    }
 }


### PR DESCRIPTION
Currency was being translated into java.util.Currency which caused problems as many users have their own Currency types. It has been removed from both KotlinTypeUtils and TypeUtils