### PR TITLE
fix: check Type/Enum does not exist in document before casting to scalar

### DIFF
--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/TypeUtils.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/TypeUtils.kt
@@ -174,7 +174,7 @@ class TypeUtils(private val packageName: String, private val config: CodeGenConf
             return schemaType.toTypeName()
         }
 
-        if (name in commonScalars) {
+        if (name in commonScalars && !isFieldTypeDefinedInDocument(name)) {
             return commonScalars.getValue(name)
         }
 
@@ -246,6 +246,10 @@ class TypeUtils(private val packageName: String, private val config: CodeGenConf
             originName
         }
     }
+
+    private fun isFieldTypeDefinedInDocument(name: String): Boolean =
+        document.definitions.filterIsInstance<ObjectTypeDefinition>().any { e -> e.name == name } ||
+            document.definitions.filterIsInstance<EnumTypeDefinition>().any { e -> e.name == name }
 
     companion object {
         const val getClass = "getClass"

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinTypeUtils.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinTypeUtils.kt
@@ -134,7 +134,7 @@ class KotlinTypeUtils(private val packageName: String, private val config: CodeG
             return schemaType.toKtTypeName()
         }
 
-        if (name in commonScalars) {
+        if (name in commonScalars && !isFieldTypeDefinedInDocument(name)) {
             return commonScalars.getValue(name)
         }
 
@@ -152,4 +152,8 @@ class KotlinTypeUtils(private val packageName: String, private val config: CodeG
             else -> "$packageName.$name".toKtTypeName()
         }
     }
+
+    private fun isFieldTypeDefinedInDocument(name: String): Boolean =
+        document.definitions.filterIsInstance<ObjectTypeDefinition>().any { e -> e.name == name } ||
+            document.definitions.filterIsInstance<EnumTypeDefinition>().any { e -> e.name == name }
 }

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
@@ -3936,4 +3936,30 @@ It takes a title and such.
             ).generate()
         }
     }
+
+    @Test
+    fun `Use schema type when type name clashes with commonScalars`() {
+        val schema = """
+            type Price {
+                amount: Double
+                currency: Currency
+                date: Date
+            }
+            enum Currency {
+                EUR
+                GBP
+            }
+        """.trimIndent()
+
+        val (dataTypes) = CodeGen(
+            CodeGenConfig(
+                schemas = setOf(schema),
+                packageName = basePackageName
+            )
+        ).generate()
+
+        assertThat(dataTypes.size).isEqualTo(1)
+        assertThat(dataTypes[0].typeSpec.fieldSpecs[1].type.toString()).contains(basePackageName)
+        assertThat(dataTypes[0].typeSpec.fieldSpecs[2].type.toString()).isEqualTo("java.time.LocalDate")
+    }
 }

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
@@ -3548,4 +3548,30 @@ It takes a title and such.
         assertThat(fields).hasSize(1)
         assertThat(fields[0].annotations).hasSize(0)
     }
+
+    @Test
+    fun `Use schema type when type name clashes with commonScalars`() {
+        val schema = """
+            type Price {
+                amount: Double
+                currency: Currency
+                date: Date
+            }
+            enum Currency {
+                EUR
+                GBP
+            }
+        """.trimIndent()
+
+        val (dataTypes) = CodeGen(
+            CodeGenConfig(
+                schemas = setOf(schema),
+                packageName = basePackageName
+            )
+        ).generate()
+
+        assertThat(dataTypes.size).isEqualTo(1)
+        assertThat(dataTypes[0].typeSpec.fieldSpecs[1].type.toString()).contains(basePackageName)
+        assertThat(dataTypes[0].typeSpec.fieldSpecs[2].type.toString()).isEqualTo("java.time.LocalDate")
+    }
 }


### PR DESCRIPTION
Currency was being translated into java.util.Currency which caused problems as many user have their own Currency types. A check has been added to avoid casting types if they are already in the document. Unit test also added.een removed from both KotlinTypeUtils and TypeUtils