### PR TITLE
Fix keyword sanitization in Java query class constructor generation

### DIFF
--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ClientApiGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ClientApiGenerator.kt
@@ -162,7 +162,7 @@ class ClientApiGenerator(private val config: CodeGenConfig, private val document
             } else {
                 constructorBuilder.addCode(
                     """
-                    |if (${inputValue.name} != null || fieldsSet.contains("${inputValue.name}")) {
+                    |if (${ReservedKeywordSanitizer.sanitize(inputValue.name)} != null || fieldsSet.contains("${inputValue.name}")) {
                     |    getInput().put("${inputValue.name}", ${ReservedKeywordSanitizer.sanitize(inputValue.name)});
                     |}
                     """.trimMargin()


### PR DESCRIPTION
This PR fixes a bug in the keyword sanitization for query arguments. Currently, if a query has an argument called something like `public`, the following code will get generated for the query class constructor.

```java
if (public != null || fieldsSet.contains("public")) {
        getInput().put("public", _public);
}
```

This code doesn't compile. This PR fixes the generator so that it sanitizes the argument name to match the argument list of the method:

```java
if (_public != null || fieldsSet.contains("public")) {
        getInput().put("public", _public);
}
```
