### PR TITLE
Initialize `GraphQLQuery#name` from generated subclasses

### DIFF
--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ClientApiGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ClientApiGenerator.kt
@@ -110,12 +110,12 @@ class ClientApiGenerator(private val config: CodeGenConfig, private val document
                     .addCode(
                         if (it.inputValueDefinitions.isNotEmpty()) {
                             """
-                            |return new $methodName(${it.inputValueDefinitions.joinToString(", ") { ReservedKeywordSanitizer.sanitize(it.name) }}, fieldsSet);
+                            |return new $methodName(${it.inputValueDefinitions.joinToString(", ") { ReservedKeywordSanitizer.sanitize(it.name) }}, queryName, fieldsSet);
                             |         
                             """.trimMargin()
                         } else {
                             """
-                            |return new $methodName();                                     
+                            |return new $methodName(queryName);                                     
                             """.trimMargin()
                         }
                     )
@@ -126,7 +126,7 @@ class ClientApiGenerator(private val config: CodeGenConfig, private val document
             .addModifiers(Modifier.PUBLIC)
         constructorBuilder.addCode(
             """
-            |super("${operation.lowercase()}");
+            |super("${operation.lowercase()}", queryName);
             |
             """.trimMargin()
         )
@@ -169,6 +169,22 @@ class ClientApiGenerator(private val config: CodeGenConfig, private val document
                 )
             }
         }
+
+        val nameMethodBuilder = MethodSpec.methodBuilder("queryName")
+            .addParameter(String::class.java, "queryName")
+            .returns(ClassName.get("", "Builder"))
+            .addModifiers(Modifier.PUBLIC)
+            .addCode(
+                """
+                |this.queryName = queryName;
+                |return this;
+                """.trimMargin()
+            )
+
+        builderClass.addField(FieldSpec.builder(String::class.java, "queryName", Modifier.PRIVATE).build())
+            .addMethod(nameMethodBuilder.build())
+
+        constructorBuilder.addParameter(String::class.java, "queryName")
 
         if (it.inputValueDefinitions.size > 0) {
             constructorBuilder.addParameter(setOfStringType, "fieldsSet")

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/clientapi/ClientApiGenMutationTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/clientapi/ClientApiGenMutationTest.kt
@@ -160,7 +160,7 @@ class ClientApiGenMutationTest {
             .find { it.name == "<init>" }?.code.toString()
 
         val expected = """
-            |super("mutation");
+            |super("mutation", queryName);
             |if (movie != null || fieldsSet.contains("movie")) {
             |    getInput().put("movie", movie);
             |}if (reviews != null || fieldsSet.contains("reviews")) {
@@ -200,7 +200,7 @@ class ClientApiGenMutationTest {
         assert(
             codeGenResult.javaQueryTypes[0].typeSpec.methodSpecs
                 .find { it.name == "<init>" }?.code.toString()
-                .contains("super(\"mutation\");\ngetInput().put(\"movieId\", movieId);")
+                .contains("super(\"mutation\", queryName);\ngetInput().put(\"movieId\", movieId);")
         )
 
         assertCompilesJava(


### PR DESCRIPTION
Fixes #354.

This PR adds a `queryName` field to the builders and constructors of the generated query classes. The `queryName` is passed to the `GraphQLQuery#name` property via the super constructor.

The purpose is to set a name for the query which can be used for reporting on the server side. Currently, there is no way to specify an operation name after the operation:

```graphql
query ($id: String!) {
    getOrderById (id: $id) {
        id
    }
}
```

With this change, the operation name can be set via the builder for the generated query class:
```java
GetOrderByIdGraphQLQuery.newRequest()
    .queryName("gibOrder")
    .id(id)
    .build();
```

or the constructor, if preferred:
```java
new GetOrderByIdGraphQLQuery(id, "gibOrder");
```

which results in the desired payload:
```graphql
query gibOrder ($id: String!) {
    getOrderById (id: $id) {
        id
    }
}
```