### PR TITLE
Make Kotlin2CodeGen respect implementSerializable config

### DIFF
--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin2/GenerateKotlin2DataTypes.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin2/GenerateKotlin2DataTypes.kt
@@ -43,12 +43,14 @@ import com.squareup.kotlinpoet.LambdaTypeName
 import com.squareup.kotlinpoet.ParameterSpec
 import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.TypeSpec
+import com.squareup.kotlinpoet.asClassName
 import com.squareup.kotlinpoet.buildCodeBlock
 import graphql.language.Document
 import graphql.language.FieldDefinition
 import graphql.language.ObjectTypeDefinition
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import java.io.Serializable
 
 internal val logger: Logger = LoggerFactory.getLogger("com.netflix.graphql.dgs.codegen.generators.kotlin2")
 
@@ -176,6 +178,12 @@ fun generateKotlin2DataTypes(
                 .addSuperinterfaces(
                     superInterfaces.map { typeLookup.findKtInterfaceName(it, config.packageNameTypes) }
                 )
+                // add Serializable interface if requested
+                .apply {
+                    if (config.implementSerializable) {
+                        addSuperinterface(Serializable::class.asClassName())
+                    }
+                }
                 // add a constructor with a supplier for every field
                 .primaryConstructor(
                     FunSpec.constructorBuilder()

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/Kotline2CodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/Kotline2CodeGenTest.kt
@@ -1,0 +1,58 @@
+/*
+ *
+ *  Copyright 2020 Netflix, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package com.netflix.graphql.dgs.codegen
+
+import com.squareup.kotlinpoet.TypeSpec
+import com.squareup.kotlinpoet.asClassName
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.io.Serializable
+
+class Kotline2CodeGenTest {
+    @Test
+    fun generateSerializableDataClass() {
+        val schema = """
+            type Person {
+                firstname: String
+                lastname: String
+            }
+        """.trimIndent()
+
+        val codeGenResult = CodeGen(
+            CodeGenConfig(
+                schemas = setOf(schema),
+                packageName = basePackageName,
+                language = Language.KOTLIN,
+                generateKotlinNullableClasses = true,
+                generateKotlinClosureProjections = true,
+                implementSerializable = true
+            )
+        ).generate()
+
+        val dataTypes = codeGenResult.kotlinDataTypes
+
+        assertThat(dataTypes).hasSize(1)
+        assertThat(dataTypes.first().packageName).isEqualTo(typesPackageName)
+        assertThat(dataTypes.first().members).singleElement()
+            .satisfies({ member ->
+                val typeSpec = member as TypeSpec
+                assertThat(typeSpec.superinterfaces).containsKey(Serializable::class.asClassName())
+            })
+    }
+}


### PR DESCRIPTION
We noticed that the new `Kotlin2CodeGen` doesn't respect the `implementSerializable` config parameter yet. This PR adds support for the flag by correctly generating the types implementing the Serializable interface.

Also, thanks for the awesome library!