### PR TITLE
Handle the empty schema case

### DIFF
--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
@@ -133,6 +133,7 @@ class CodeGen(private val config: CodeGenConfig) {
             } catch (exception: InvalidSyntaxException) {
                 // check if the schema is empty
                 if (exception.sourcePreview.trim() == "") {
+                    logger.info("Schema is empty")
                     // return an empty document
                     return Document.newDocument().build()
                 } else {

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
@@ -133,7 +133,7 @@ class CodeGen(private val config: CodeGenConfig) {
             } catch (exception: InvalidSyntaxException) {
                 // check if the schema is empty
                 if (exception.sourcePreview.trim() == "") {
-                    logger.info("Schema is empty")
+                    logger.warn("Schema is empty")
                     // return an empty document
                     return Document.newDocument().build()
                 } else {

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
@@ -131,7 +131,13 @@ class CodeGen(private val config: CodeGenConfig) {
             try {
                 parser.parseDocument(reader, options)
             } catch (exception: InvalidSyntaxException) {
-                throw CodeGenSchemaParsingException(debugReaderBuilder.build(), exception)
+                // check if the schema is empty
+                if (exception.sourcePreview.trim() == "") {
+                    // return an empty document
+                    return Document.newDocument().build()
+                } else {
+                    throw CodeGenSchemaParsingException(debugReaderBuilder.build(), exception)
+                }
             }
         }
         return document

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
@@ -89,7 +89,7 @@ class CodeGenTest {
     }
 
     @Test
-    fun `When the schema is just an opening bracket, an invalid syntax (EOF) error is thrown`() {
+    fun `When the schema is just an opening bracket, a parsing error is thrown`() {
         val schema = """{""".trimIndent()
 
         Assertions.assertThatThrownBy {

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
@@ -75,6 +75,43 @@ class CodeGenTest {
     }
 
     @Test
+    fun `When the schema is empty, there is no parsing error`() {
+        val schema = """"""
+
+        CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName)).generate()
+    }
+
+    @Test
+    fun `When the schema contains just whitespace, there is no parsing error`() {
+        val schema = """
+            
+            
+            
+            
+            
+            
+            
+                    
+                    
+                    
+        """
+
+        CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName)).generate()
+    }
+
+    @Test
+    fun `When the schema is just an opening bracket, an invalid syntax (EOF) error is thrown`() {
+        val schema = """{""".trimIndent()
+
+        Assertions.assertThatThrownBy {
+            CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName)).generate()
+        }.isInstanceOf(CodeGenSchemaParsingException::class.java)
+            .hasMessageContainingAll(
+                "Invalid Syntax : offending token '<EOF>' at line 1 column 2",
+            )
+    }
+
+    @Test
     fun generateDataClassWithStringProperties() {
         val schema = """
             type Query {
@@ -4078,4 +4115,7 @@ It takes a title and such.
         assertThat(dataTypes[0].typeSpec.fieldSpecs[1].type.toString()).contains(basePackageName)
         assertThat(dataTypes[0].typeSpec.fieldSpecs[2].type.toString()).isEqualTo("java.time.LocalDate")
     }
+
+
 }
+

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
@@ -83,18 +83,7 @@ class CodeGenTest {
 
     @Test
     fun `When the schema contains just whitespace, there is no parsing error`() {
-        val schema = """
-            
-            
-            
-            
-            
-            
-            
-                    
-                    
-                    
-        """
+        val schema = """     """
 
         CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName)).generate()
     }
@@ -106,9 +95,6 @@ class CodeGenTest {
         Assertions.assertThatThrownBy {
             CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName)).generate()
         }.isInstanceOf(CodeGenSchemaParsingException::class.java)
-            .hasMessageContainingAll(
-                "Invalid Syntax : offending token '<EOF>' at line 1 column 2"
-            )
     }
 
     @Test

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
@@ -107,7 +107,7 @@ class CodeGenTest {
             CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName)).generate()
         }.isInstanceOf(CodeGenSchemaParsingException::class.java)
             .hasMessageContainingAll(
-                "Invalid Syntax : offending token '<EOF>' at line 1 column 2",
+                "Invalid Syntax : offending token '<EOF>' at line 1 column 2"
             )
     }
 
@@ -4115,7 +4115,4 @@ It takes a title and such.
         assertThat(dataTypes[0].typeSpec.fieldSpecs[1].type.toString()).contains(basePackageName)
         assertThat(dataTypes[0].typeSpec.fieldSpecs[2].type.toString()).isEqualTo("java.time.LocalDate")
     }
-
-
 }
-

--- a/graphql-dgs-codegen-gradle/src/test/kotlin/com/netflix/graphql/dgs/CodegenGradlePluginTest.kt
+++ b/graphql-dgs-codegen-gradle/src/test/kotlin/com/netflix/graphql/dgs/CodegenGradlePluginTest.kt
@@ -140,8 +140,34 @@ class CodegenGradlePluginTest {
         assertThat(File(EXPECTED_DEFAULT_PATH + "Filter.java").exists()).isTrue
     }
 
+    @Test
+    fun nothingIsGeneratedForNoSchema() {
+        // build a project
+        val result = GradleRunner.create()
+            .withProjectDir(File("src/test/resources/test-project-no-schema-files/"))
+            .withPluginClasspath()
+            .withArguments(
+                "--stacktrace",
+                "-c",
+                "smoke_test_settings_with_default_dir.gradle",
+                "-b",
+                "build_with_default_dir.gradle",
+                "clean",
+                "build"
+            ).forwardOutput()
+            .withDebug(true)
+            .build()
+
+        // Verify the result
+        assertThat(result.task(":build")).extracting { it?.outcome }.isEqualTo(SUCCESS)
+
+        // Check that the generated directory is empty
+        assertThat(File(EXPECTED_PATH_EMPTY_SCHEMA).walk().count()).isEqualTo(0)
+    }
+
     companion object {
         const val EXPECTED_PATH = "src/test/resources/test-project/build/graphql/generated/sources/dgs-codegen/com/netflix/testproject/graphql/types/"
         const val EXPECTED_DEFAULT_PATH = "src/test/resources/test-project/build/generated/sources/dgs-codegen/com/netflix/testproject/graphql/types/"
+        const val EXPECTED_PATH_EMPTY_SCHEMA = "src/test/resources/test-project-no-schema-files/build/graphql/generated/sources/dgs-codegen/com/netflix/testproject/graphql/types/"
     }
 }

--- a/graphql-dgs-codegen-gradle/src/test/resources/test-project-no-schema-files/build.gradle
+++ b/graphql-dgs-codegen-gradle/src/test/resources/test-project-no-schema-files/build.gradle
@@ -1,0 +1,42 @@
+/*
+ *
+ *  Copyright 2020 Netflix, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+plugins {
+    id 'java'
+    id 'com.netflix.dgs.codegen'
+}
+
+configurations {
+    // injected by Gradle Runner through test configuration, see CodegenGradlePluginTest
+    CodeGenConfiguration.exclude group: "com.netflix.graphql.dgs.codegen", module: "graphql-dgs-codegen-core"
+}
+
+generateJava {
+    schemaPaths = ["${projectDir}/src/main/resources/schema"]
+    packageName = 'com.netflix.testproject.graphql'
+    generatedSourcesDir = "${projectDir}/build/graphql"
+    typeMapping = [Date:"java.time.LocalDateTime"]
+}
+
+codegen.clientCoreConventionsEnabled = false
+
+tasks.register("copyMainSources", Copy) {
+    //This should be enough to depend on the 'generateJava' task
+    from sourceSets.main.java
+    into "build/tmp/main"
+}

--- a/graphql-dgs-codegen-gradle/src/test/resources/test-project-no-schema-files/build_omit_null_input_fields.gradle
+++ b/graphql-dgs-codegen-gradle/src/test/resources/test-project-no-schema-files/build_omit_null_input_fields.gradle
@@ -1,0 +1,38 @@
+/*
+ *
+ *  Copyright 2020 Netflix, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+plugins {
+    id 'java'
+    id 'com.netflix.dgs.codegen'
+}
+
+configurations {
+    // injected by Gradle Runner through test configuration, see CodegenGradlePluginTest
+    CodeGenConfiguration.exclude group: "com.netflix.graphql.dgs.codegen", module: "graphql-dgs-codegen-core"
+}
+
+generateJava {
+    schemaPaths = ["${projectDir}/src/main/resources/schema"]
+    packageName = 'com.netflix.testproject.graphql'
+    typeMapping = [Date:"java.time.LocalDateTime"]
+    omitNullInputFields = true
+    generateClient = true
+    generateDataTypes = true
+}
+
+codegen.clientCoreConventionsEnabled = false

--- a/graphql-dgs-codegen-gradle/src/test/resources/test-project-no-schema-files/build_with_default_dir.gradle
+++ b/graphql-dgs-codegen-gradle/src/test/resources/test-project-no-schema-files/build_with_default_dir.gradle
@@ -1,0 +1,36 @@
+/*
+ *
+ *  Copyright 2020 Netflix, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+plugins {
+    id 'java'
+    id 'com.netflix.dgs.codegen'
+}
+
+configurations {
+    // injected by Gradle Runner through test configuration, see CodegenGradlePluginTest
+    CodeGenConfiguration.exclude group: "com.netflix.graphql.dgs.codegen", module: "graphql-dgs-codegen-core"
+}
+
+generateJava {
+    schemaPaths = ["${projectDir}/src/main/resources/schema"]
+    packageName = 'com.netflix.testproject.graphql'
+    typeMapping = [Date:"java.time.LocalDateTime"]
+    // no generated sources dir specified
+}
+
+codegen.clientCoreConventionsEnabled = false

--- a/graphql-dgs-codegen-gradle/src/test/resources/test-project-no-schema-files/smoke_test_settings.gradle
+++ b/graphql-dgs-codegen-gradle/src/test/resources/test-project-no-schema-files/smoke_test_settings.gradle
@@ -1,0 +1,19 @@
+/*
+ *
+ *  Copyright 2020 Netflix, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+rootProject.name = 'test-project'

--- a/graphql-dgs-codegen-gradle/src/test/resources/test-project-no-schema-files/smoke_test_settings_omit_null_input_fields.gradle
+++ b/graphql-dgs-codegen-gradle/src/test/resources/test-project-no-schema-files/smoke_test_settings_omit_null_input_fields.gradle
@@ -1,0 +1,19 @@
+/*
+ *
+ *  Copyright 2020 Netflix, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+rootProject.buildFileName = 'build_omit_null_input_fields.gradle'

--- a/graphql-dgs-codegen-gradle/src/test/resources/test-project-no-schema-files/smoke_test_settings_with_default_dir.gradle
+++ b/graphql-dgs-codegen-gradle/src/test/resources/test-project-no-schema-files/smoke_test_settings_with_default_dir.gradle
@@ -1,0 +1,20 @@
+/*
+ *
+ *  Copyright 2020 Netflix, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+include 'smoke_test_settings.gradle'
+rootProject.buildFileName = 'build_with_default_dir.gradle'

--- a/graphql-dgs-codegen-gradle/src/test/resources/test-project-no-schema-files/src.main/java/com/netflix/testproject/Foo.java
+++ b/graphql-dgs-codegen-gradle/src/test/resources/test-project-no-schema-files/src.main/java/com/netflix/testproject/Foo.java
@@ -1,0 +1,7 @@
+package com.netflix.testproject;
+
+public class Foo {
+    public static void main(String[] args) {
+        System.out.println("Hello, world!");
+    }
+}


### PR DESCRIPTION
If the schema is empty, the generateJava task returns successfully instead of throwing a parsing exception. This allows the project to continue building instead of failing the build.