### PR TITLE
Ignore non-GraphQL files in the schema path

### DIFF
--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
@@ -153,6 +153,7 @@ class CodeGen(private val config: CodeGenConfig) {
             val schemaFiles = config.schemaFiles.sorted()
                 .flatMap { it.walkTopDown() }
                 .filter { it.isFile }
+                .filter { it.name.endsWith(".graphql") || it.name.endsWith(".graphqls") }
             for (schemaFile in schemaFiles) {
                 rb.string("\n", "codegen")
                 rb.reader(schemaFile.reader(), schemaFile.name)

--- a/graphql-dgs-codegen-gradle/src/test/resources/test-project/src/main/resources/schema/notSchema.notgraphql
+++ b/graphql-dgs-codegen-gradle/src/test/resources/test-project/src/main/resources/schema/notSchema.notgraphql
@@ -1,0 +1,3 @@
+type NotSchema {
+    ignored: Boolean
+}

--- a/graphql-dgs-codegen-gradle/src/test/resources/test-project/src/main/resources/schema/schema.graphqlconfig
+++ b/graphql-dgs-codegen-gradle/src/test/resources/test-project/src/main/resources/schema/schema.graphqlconfig
@@ -1,0 +1,3 @@
+{
+  "schemaPath": "schema.graphql"
+}


### PR DESCRIPTION
For files in the schema path, only those ending in .graphql or .graphqls are added to the schema. This means that the build will not automatically fail if any non-GraphQL files are included in the path.