### PR TITLE
fix(ClientApiGenerator): serialize inputs as maps ref orig name

### DIFF
--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ClientApiGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ClientApiGenerator.kt
@@ -163,7 +163,7 @@ class ClientApiGenerator(private val config: CodeGenConfig, private val document
                 constructorBuilder.addCode(
                     """
                     |if (${ReservedKeywordSanitizer.sanitize(inputValue.name)} != null || fieldsSet.contains("${inputValue.name}")) {
-                    |    getInput().put("${inputValue.name}", ${ReservedKeywordSanitizer.sanitize(inputValue.name)});
+                    |    getInput().put("${inputValue.name}", ${ReservedKeywordSanitizer.sanitize(inputValue.name)}.getAllFields());
                     |}
                     """.trimMargin()
                 )

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ClientApiGeneratorv2.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ClientApiGeneratorv2.kt
@@ -145,7 +145,7 @@ class ClientApiGeneratorv2(private val config: CodeGenConfig, private val docume
                 constructorBuilder.addCode(
                     """
                     |if (${ReservedKeywordSanitizer.sanitize(inputValue.name)} != null || fieldsSet.contains("${inputValue.name}")) {
-                    |    getInput().put("${inputValue.name}", ${ReservedKeywordSanitizer.sanitize(inputValue.name)});
+                    |    getInput().put("${inputValue.name}", ${ReservedKeywordSanitizer.sanitize(inputValue.name)}.getAllFields());
                     |}
                     """.trimMargin()
                 )

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ClientApiGeneratorv2.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ClientApiGeneratorv2.kt
@@ -34,7 +34,6 @@ class ClientApiGeneratorv2(private val config: CodeGenConfig, private val docume
     private val typeUtils = TypeUtils(getDatatypesPackageName(), config, document)
     private val typeLookup = Kotlin2TypeLookup(config, document)
 
-
     fun generate(definition: ObjectTypeDefinition, methodNames: MutableSet<String>): CodeGenResult {
         return definition.fieldDefinitions.filterIncludedInConfig(definition.name, config).filterSkipped().map {
             val javaFile = createQueryClass(it, definition.name, methodNames)

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/DataTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/DataTypeGenerator.kt
@@ -255,9 +255,18 @@ abstract class BaseDataTypeGenerator(
             javaType.addAnnotation(disableJsonTypeInfoAnnotation())
         }
 
+        val setterMethodBuilder = MethodSpec.methodBuilder("getAllFields")
+            .addModifiers(Modifier.PUBLIC)
+            .addStatement("java.util.Map<String, Object> fields = new java.util.HashMap()")
+            .returns(ClassName.get("java.util", "Map"));
+
         fields.forEach {
             addField(it, javaType)
+            setterMethodBuilder.addStatement("fields.put(\"\$N\", this.\$N)", it.name, ReservedKeywordSanitizer.sanitize(it.name))
         }
+
+        setterMethodBuilder.addStatement("return fields")
+        javaType.addMethod(setterMethodBuilder.build())
 
         addDefaultConstructor(javaType)
 

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/DataTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/DataTypeGenerator.kt
@@ -257,8 +257,8 @@ abstract class BaseDataTypeGenerator(
 
         val setterMethodBuilder = MethodSpec.methodBuilder("getAllFields")
             .addModifiers(Modifier.PUBLIC)
-            .addStatement("java.util.Map<String, Object> fields = new java.util.HashMap()")
-            .returns(ClassName.get("java.util", "Map"));
+            .addStatement("Map<String, Object> fields = new java.util.HashMap()")
+            .returns(ClassName.get("java.util", "Map"))
 
         fields.forEach {
             addField(it, javaType)

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
@@ -2178,136 +2178,146 @@ class CodeGenTest {
 
         assertThat(JavaFile.builder("$basePackageName.types", talent).build().toString()).isEqualTo(
             """
-                |package com.netflix.graphql.dgs.codegen.tests.generated.types;
-                |
-                |import com.fasterxml.jackson.annotation.JsonTypeInfo;
-                |import java.lang.Object;
-                |import java.lang.Override;
-                |import java.lang.String;
-                |
-                |@JsonTypeInfo(
-                |    use = JsonTypeInfo.Id.NONE
-                |)
-                |public class Talent implements com.netflix.graphql.dgs.codegen.tests.generated.types.Employee {
-                |  private String firstname;
-                |
-                |  private String lastname;
-                |
-                |  private String company;
-                |
-                |  private String imdbProfile;
-                |
-                |  public Talent() {
-                |  }
-                |
-                |  public Talent(String firstname, String lastname, String company, String imdbProfile) {
-                |    this.firstname = firstname;
-                |    this.lastname = lastname;
-                |    this.company = company;
-                |    this.imdbProfile = imdbProfile;
-                |  }
-                |
-                |  public String getFirstname() {
-                |    return firstname;
-                |  }
-                |
-                |  public void setFirstname(String firstname) {
-                |    this.firstname = firstname;
-                |  }
-                |
-                |  public String getLastname() {
-                |    return lastname;
-                |  }
-                |
-                |  public void setLastname(String lastname) {
-                |    this.lastname = lastname;
-                |  }
-                |
-                |  public String getCompany() {
-                |    return company;
-                |  }
-                |
-                |  public void setCompany(String company) {
-                |    this.company = company;
-                |  }
-                |
-                |  public String getImdbProfile() {
-                |    return imdbProfile;
-                |  }
-                |
-                |  public void setImdbProfile(String imdbProfile) {
-                |    this.imdbProfile = imdbProfile;
-                |  }
-                |
-                |  @Override
-                |  public String toString() {
-                |    return "Talent{" + "firstname='" + firstname + "'," +"lastname='" + lastname + "'," +"company='" + company + "'," +"imdbProfile='" + imdbProfile + "'" +"}";
-                |  }
-                |
-                |  @Override
-                |  public boolean equals(Object o) {
-                |    if (this == o) return true;
-                |        if (o == null || getClass() != o.getClass()) return false;
-                |        Talent that = (Talent) o;
-                |        return java.util.Objects.equals(firstname, that.firstname) &&
-                |                            java.util.Objects.equals(lastname, that.lastname) &&
-                |                            java.util.Objects.equals(company, that.company) &&
-                |                            java.util.Objects.equals(imdbProfile, that.imdbProfile);
-                |  }
-                |
-                |  @Override
-                |  public int hashCode() {
-                |    return java.util.Objects.hash(firstname, lastname, company, imdbProfile);
-                |  }
-                |
-                |  public static com.netflix.graphql.dgs.codegen.tests.generated.types.Talent.Builder newBuilder() {
-                |    return new Builder();
-                |  }
-                |
-                |  public static class Builder {
-                |    private String firstname;
-                |
-                |    private String lastname;
-                |
-                |    private String company;
-                |
-                |    private String imdbProfile;
-                |
-                |    public Talent build() {
-                |                  com.netflix.graphql.dgs.codegen.tests.generated.types.Talent result = new com.netflix.graphql.dgs.codegen.tests.generated.types.Talent();
-                |                      result.firstname = this.firstname;
-                |          result.lastname = this.lastname;
-                |          result.company = this.company;
-                |          result.imdbProfile = this.imdbProfile;
-                |                      return result;
-                |    }
-                |
-                |    public com.netflix.graphql.dgs.codegen.tests.generated.types.Talent.Builder firstname(
-                |        String firstname) {
-                |      this.firstname = firstname;
-                |      return this;
-                |    }
-                |
-                |    public com.netflix.graphql.dgs.codegen.tests.generated.types.Talent.Builder lastname(
-                |        String lastname) {
-                |      this.lastname = lastname;
-                |      return this;
-                |    }
-                |
-                |    public com.netflix.graphql.dgs.codegen.tests.generated.types.Talent.Builder company(
-                |        String company) {
-                |      this.company = company;
-                |      return this;
-                |    }
-                |
-                |    public com.netflix.graphql.dgs.codegen.tests.generated.types.Talent.Builder imdbProfile(
-                |        String imdbProfile) {
-                |      this.imdbProfile = imdbProfile;
-                |      return this;
-                |    }
-                |  }
-                |}
-                |
+              |package com.netflix.graphql.dgs.codegen.tests.generated.types;
+              |
+              |import com.fasterxml.jackson.annotation.JsonTypeInfo;
+              |import java.lang.Object;
+              |import java.lang.Override;
+              |import java.lang.String;
+              |import java.util.Map;
+              |
+              |@JsonTypeInfo(
+              |    use = JsonTypeInfo.Id.NONE
+              |)
+              |public class Talent implements com.netflix.graphql.dgs.codegen.tests.generated.types.Employee {
+              |  private String firstname;
+              |
+              |  private String lastname;
+              |
+              |  private String company;
+              |
+              |  private String imdbProfile;
+              |
+              |  public Talent() {
+              |  }
+              |
+              |  public Talent(String firstname, String lastname, String company, String imdbProfile) {
+              |    this.firstname = firstname;
+              |    this.lastname = lastname;
+              |    this.company = company;
+              |    this.imdbProfile = imdbProfile;
+              |  }
+              |
+              |  public String getFirstname() {
+              |    return firstname;
+              |  }
+              |
+              |  public void setFirstname(String firstname) {
+              |    this.firstname = firstname;
+              |  }
+              |
+              |  public String getLastname() {
+              |    return lastname;
+              |  }
+              |
+              |  public void setLastname(String lastname) {
+              |    this.lastname = lastname;
+              |  }
+              |
+              |  public String getCompany() {
+              |    return company;
+              |  }
+              |
+              |  public void setCompany(String company) {
+              |    this.company = company;
+              |  }
+              |
+              |  public String getImdbProfile() {
+              |    return imdbProfile;
+              |  }
+              |
+              |  public void setImdbProfile(String imdbProfile) {
+              |    this.imdbProfile = imdbProfile;
+              |  }
+              |
+              |  public Map getAllFields() {
+              |    Map<String, Object> fields = new java.util.HashMap();
+              |    fields.put("firstname", this.firstname);
+              |    fields.put("lastname", this.lastname);
+              |    fields.put("company", this.company);
+              |    fields.put("imdbProfile", this.imdbProfile);
+              |    return fields;
+              |  }
+              |
+              |  @Override
+              |  public String toString() {
+              |    return "Talent{" + "firstname='" + firstname + "'," +"lastname='" + lastname + "'," +"company='" + company + "'," +"imdbProfile='" + imdbProfile + "'" +"}";
+              |  }
+              |
+              |  @Override
+              |  public boolean equals(Object o) {
+              |    if (this == o) return true;
+              |        if (o == null || getClass() != o.getClass()) return false;
+              |        Talent that = (Talent) o;
+              |        return java.util.Objects.equals(firstname, that.firstname) &&
+              |                            java.util.Objects.equals(lastname, that.lastname) &&
+              |                            java.util.Objects.equals(company, that.company) &&
+              |                            java.util.Objects.equals(imdbProfile, that.imdbProfile);
+              |  }
+              |
+              |  @Override
+              |  public int hashCode() {
+              |    return java.util.Objects.hash(firstname, lastname, company, imdbProfile);
+              |  }
+              |
+              |  public static com.netflix.graphql.dgs.codegen.tests.generated.types.Talent.Builder newBuilder() {
+              |    return new Builder();
+              |  }
+              |
+              |  public static class Builder {
+              |    private String firstname;
+              |
+              |    private String lastname;
+              |
+              |    private String company;
+              |
+              |    private String imdbProfile;
+              |
+              |    public Talent build() {
+              |                  com.netflix.graphql.dgs.codegen.tests.generated.types.Talent result = new com.netflix.graphql.dgs.codegen.tests.generated.types.Talent();
+              |                      result.firstname = this.firstname;
+              |          result.lastname = this.lastname;
+              |          result.company = this.company;
+              |          result.imdbProfile = this.imdbProfile;
+              |                      return result;
+              |    }
+              |
+              |    public com.netflix.graphql.dgs.codegen.tests.generated.types.Talent.Builder firstname(
+              |        String firstname) {
+              |      this.firstname = firstname;
+              |      return this;
+              |    }
+              |
+              |    public com.netflix.graphql.dgs.codegen.tests.generated.types.Talent.Builder lastname(
+              |        String lastname) {
+              |      this.lastname = lastname;
+              |      return this;
+              |    }
+              |
+              |    public com.netflix.graphql.dgs.codegen.tests.generated.types.Talent.Builder company(
+              |        String company) {
+              |      this.company = company;
+              |      return this;
+              |    }
+              |
+              |    public com.netflix.graphql.dgs.codegen.tests.generated.types.Talent.Builder imdbProfile(
+              |        String imdbProfile) {
+              |      this.imdbProfile = imdbProfile;
+              |      return this;
+              |    }
+              |  }
+              |}
+              |
             """.trimMargin()
         )
 
@@ -4047,9 +4057,9 @@ It takes a title and such.
         assertThat(methods[0].annotations).hasSize(0)
         assertThat((methods[1] as MethodSpec).name).isEqualTo("setName")
         assertThat(methods[1].annotations).hasSize(0)
-        assertThat((methods[3] as MethodSpec).name).isEqualTo("<init>")
-        assertThat(methods[3].annotations).hasSize(0)
-        val parameters = (methods[3] as MethodSpec).parameters
+        assertThat((methods[4] as MethodSpec).name).isEqualTo("<init>")
+        assertThat(methods[4].annotations).hasSize(0)
+        val parameters = (methods[4] as MethodSpec).parameters
         assertThat(parameters).hasSize(1)
         assertThat(((parameters[0].annotations[0] as AnnotationSpec).type as ClassName).simpleName()).isEqualTo("ValidName")
     }
@@ -4152,7 +4162,6 @@ It takes a title and such.
         assertThat(dataTypes[0].typeSpec.fieldSpecs[2].type.toString()).isEqualTo("java.lang.Integer")
     }
 
-
     @Test
     fun testReservedKeywords() {
         val schema = """
@@ -4181,8 +4190,8 @@ It takes a title and such.
 
         val test = interfaceParams.toString()
 
-        assertThat(test).contains("public java.util.Map getAllFields()");
-        assertThat(test).contains("fields.put(\"class\", this._class)");
+        assertThat(test).contains("public java.util.Map getAllFields()")
+        assertThat(test).contains("fields.put(\"class\", this._class)")
 
         assertCompilesJava(dataTypes + interfaces)
     }

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/clientapi/ClientApiGenMutationTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/clientapi/ClientApiGenMutationTest.kt
@@ -162,7 +162,7 @@ class ClientApiGenMutationTest {
         val expected = """
             |super("mutation", queryName);
             |if (movie != null || fieldsSet.contains("movie")) {
-            |    getInput().put("movie", movie);
+            |    getInput().put("movie", movie.getAllFields());
             |}if (reviews != null || fieldsSet.contains("reviews")) {
             |    getInput().put("reviews", reviews);
             |}if (uuid != null || fieldsSet.contains("uuid")) {

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/clientapiv2/ClientApiGenMutationTestv2.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/clientapiv2/ClientApiGenMutationTestv2.kt
@@ -162,7 +162,7 @@ class ClientApiGenMutationTestv2 {
         val expected = """
             |super("mutation", queryName);
             |if (movie != null || fieldsSet.contains("movie")) {
-            |    getInput().put("movie", movie);
+            |    getInput().put("movie", movie.getAllFields());
             |}if (reviews != null || fieldsSet.contains("reviews")) {
             |    getInput().put("reviews", reviews);
             |}if (uuid != null || fieldsSet.contains("uuid")) {

--- a/graphql-dgs-codegen-gradle/src/test/kotlin/com/netflix/graphql/dgs/CodegenGradlePluginSpringBootSmokeTest.kt
+++ b/graphql-dgs-codegen-gradle/src/test/kotlin/com/netflix/graphql/dgs/CodegenGradlePluginSpringBootSmokeTest.kt
@@ -31,6 +31,7 @@ class CodegenGradlePluginSpringBootSmokeTest {
             type Query {
                 result: Result!
                 find(filter: Filter!): Result!
+                interface(params: InterfaceParams): String
             }
             
             type Result {
@@ -66,6 +67,10 @@ class CodegenGradlePluginSpringBootSmokeTest {
                 data: [String]
                 lastUpdated: DateTime
                 lastUpdatedBy: String
+            }
+
+            input InterfaceParams {
+                class: String
             }
             
             scalar Date 

--- a/graphql-dgs-codegen-gradle/src/test/resources/test-project/build.gradle
+++ b/graphql-dgs-codegen-gradle/src/test/resources/test-project/build.gradle
@@ -31,6 +31,7 @@ generateJava {
     packageName = 'com.netflix.testproject.graphql'
     generatedSourcesDir = "${projectDir}/build/graphql"
     typeMapping = [Date:"java.time.LocalDateTime"]
+    generateClient = true
 }
 
 codegen.clientCoreConventionsEnabled = false

--- a/graphql-dgs-codegen-gradle/src/test/resources/test-project/src/main/resources/schema/schema.graphqls
+++ b/graphql-dgs-codegen-gradle/src/test/resources/test-project/src/main/resources/schema/schema.graphqls
@@ -1,6 +1,7 @@
 type Query {
     result: Result!
     find(filter: Filter!): Result!
+    interface(params: InterfaceParams): String
 }
 
 type Result {
@@ -13,4 +14,9 @@ input Filter {
     optionalString: String
     mandatoryNumber: Int!
     optionalNumber: Int
+}
+
+
+input InterfaceParams {
+    class: String
 }


### PR DESCRIPTION
# Problem

There is an issue today with codegen, where _reserved keywords_ in the Java language can be used as the names for schema fields. Because of this, our code generation sanitizes those keywords before using them. 

For example:

```graphql
type Query {
    interface(params: InterfaceParams): String
}

input InterfaceParams {
    class: String
}
```

When codegen processes the schema above, `interface` is referenced as the operation name:

```java
  @Override
  public String getOperationName() {
     return "interface";
  }

```

The issue with the schema above, is that `class` will be sanitized as the generated type's field name:

```java
public class InterfaceParams {
  private String _class;
```

And there's no reference back to it's original schema name: **class**; which you'll see here via the generated query code:

```java
  public InterfaceGraphQLQuery(InterfaceParams params, String queryName, Set<String> fieldsSet) {
    super("query", queryName);
    if (params != null || fieldsSet.contains("params")) {
        getInput().put("params", params);
    }
  }
```

Since **params: InterfaceParams,** does not match the original shape of the schema, the query will fail to validate. We need the generated query code to provide "params" as the same shape as the schema.

# Solution

The solution requires that we first provide the values from `InterfaceParams` but in the shape of the schema, before any sanitization. So in this change I am proposing that we add `getAllFields()` to generated plain objects:

```java
  public Map getAllFields() {
    java.util.Map<String, Object> fields = new java.util.HashMap();
    fields.put("class", this._class);
    return fields;
  }
  ```
  
This method is generated from the list of fields, providing the schema name as the string key. From there, the generated query code will call `getAllFields()` instead:

```java
  public InterfaceGraphQLQuery(InterfaceParams params, String queryName, Set<String> fieldsSet) {
    super("query", queryName);
    if (params != null || fieldsSet.contains("params")) {
        getInput().put("params", params.getAllFields());
    }
  }
```

Since `input` (of `getInput()`) accepts maps, objects, anything really, this should allow anyone to use reserved keywords as the name of a field in an input type.
