### PR TITLE
Add toggle for sealed interface generation

### DIFF
--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
@@ -497,7 +497,8 @@ class CodeGenConfig(
     var javaGenerateAllConstructor: Boolean = true,
     var implementSerializable: Boolean = false,
     var addGeneratedAnnotation: Boolean = false,
-    var addDeprecatedAnnotation: Boolean = false
+    var addDeprecatedAnnotation: Boolean = false,
+    var kotlinv2GenerateSealedInterfaces: Boolean = true
 ) {
     val packageNameClient: String = "$packageName.$subPackageNameClient"
 

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin2/GenerateKotlin2Interfaces.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin2/GenerateKotlin2Interfaces.kt
@@ -84,7 +84,11 @@ fun generateKotlin2Interfaces(
             // create the interface
             val interfaceSpec = TypeSpec.interfaceBuilder(interfaceDefinition.name)
                 .addOptionalGeneratedAnnotation(config)
-                .addModifiers(KModifier.SEALED)
+                .apply {
+                    if (config.kotlinv2GenerateSealedInterfaces) {
+                        addModifiers(KModifier.SEALED)
+                    }
+                }
                 // add docs if available
                 .apply {
                     if (interfaceDefinition.description != null) {

--- a/graphql-dgs-codegen-gradle/src/main/kotlin/com/netflix/graphql/dgs/codegen/gradle/GenerateJavaTask.kt
+++ b/graphql-dgs-codegen-gradle/src/main/kotlin/com/netflix/graphql/dgs/codegen/gradle/GenerateJavaTask.kt
@@ -145,6 +145,9 @@ open class GenerateJavaTask : DefaultTask() {
     @Input
     var includeClassImports = mutableMapOf<String, MutableMap<String, String>>()
 
+    @Input
+    var kotlinv2GenerateSealedInterfaces = true
+
     @TaskAction
     fun generate() {
         val schemaJarFilesFromDependencies = emptyList<File>().toMutableList()
@@ -204,7 +207,8 @@ open class GenerateJavaTask : DefaultTask() {
             includeImports = includeImports,
             includeEnumImports = includeEnumImports,
             includeClassImports = includeClassImports,
-            generateCustomAnnotations = generateCustomAnnotations
+            generateCustomAnnotations = generateCustomAnnotations,
+            kotlinv2GenerateSealedInterfaces = kotlinv2GenerateSealedInterfaces
         )
 
         logger.info("Codegen config: {}", config)


### PR DESCRIPTION
Hi,

another small PR to add an option to change whether interfaces should be generated as sealed interfaces or not.

Background:
We have a package containing some common GraphQL types available for use in our other packages. Recently we've added a common interface that should be implemented in the other packages, but since the interface was generated as a `sealed interface` we weren't able to add implementations for it in other packages.

This is backwards compatible, if not set it will behave like before (i.e. generating as sealed).

Thanks!