### PR TITLE
Add serializeCompact to GraphQLQueryRequest

### DIFF
--- a/graphql-dgs-codegen-shared-core/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/GraphQLQueryRequest.kt
+++ b/graphql-dgs-codegen-shared-core/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/GraphQLQueryRequest.kt
@@ -35,6 +35,14 @@ class GraphQLQueryRequest(
     val projectionSerializer = ProjectionSerializer(inputValueSerializer)
 
     fun serialize(): String {
+        return serialize(false)
+    }
+
+    fun serializeCompact(): String {
+        return serialize( true)
+    }
+
+    private fun serialize(compact: Boolean): String {
         val operationDef = OperationDefinition.newOperationDefinition()
 
         query.name?.let { operationDef.name(it) }
@@ -66,6 +74,10 @@ class GraphQLQueryRequest(
 
         operationDef.selectionSet(SelectionSet.newSelectionSet().selection(selection.build()).build())
 
-        return AstPrinter.printAst(operationDef.build())
+        return if(compact) {
+            AstPrinter.printAstCompact(operationDef.build());
+        } else {
+            AstPrinter.printAst(operationDef.build())
+        }
     }
 }

--- a/graphql-dgs-codegen-shared-core/src/test/kotlin/com/netflix/graphql/dgs/client/codegen/GraphQLQueryRequestTest.kt
+++ b/graphql-dgs-codegen-shared-core/src/test/kotlin/com/netflix/graphql/dgs/client/codegen/GraphQLQueryRequestTest.kt
@@ -32,6 +32,19 @@ import java.util.Optional
 import java.util.UUID
 
 class GraphQLQueryRequestTest {
+
+    @Test
+    fun testSerializeCompactListOfStringsAsInput() {
+        val query = TestGraphQLQuery().apply {
+            input["actors"] = "actorA"
+            input["movies"] = listOf("movie1", "movie2")
+        }
+        val request = GraphQLQueryRequest(query)
+        val result = request.serializeCompact()
+        assertValidQuery(result)
+        assertThat(result).isEqualTo("""{test(actors:"actorA",movies:["movie1","movie2"])}""")
+    }
+
     @Test
     fun testSerializeListOfStringsAsInput() {
         val query = TestGraphQLQuery().apply {


### PR DESCRIPTION
### Goal
While upgrading from `graphql-dgs-codegen-client-core` to `graphql-dgs-codegen-shared-core`, we encountered some issue because the way `GraphQLQueryRequest` is serialized is slightly different. This PR allows `GraphQLQueryRequest` to be serialized as compact which is a little bit closer to what we had before. It's IMO a little better when we want to log the query, it stays on one line.

### Implementation

To keep backward compatibility with Java, I created a new method. If backward compatibility with java is not an issue, I could just do one method with a default param, something like:
```
fun serialize(compact: Boolean = true): String {
    ...
}
```

### Testing
I feel like the unit test I added is enough, but let me know if you disagree with that, I can add more tests.