### PR TITLE
Do not apply maxProjectionDepth for client V2 API, not required to limit the generation.

### DIFF
--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ClientApiGeneratorv2.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ClientApiGeneratorv2.kt
@@ -502,7 +502,7 @@ class ClientApiGeneratorv2(private val config: CodeGenConfig, private val docume
                 .filter { it.name == type.name }
                 .flatMap { it.fieldDefinitions }
 
-        val codeGenResult = if (queryDepth < config.maxProjectionDepth || config.maxProjectionDepth == -1) {
+        val codeGenResult =
             fieldDefinitions
                 .filterSkipped()
                 .mapNotNull {
@@ -536,7 +536,6 @@ class ClientApiGeneratorv2(private val config: CodeGenConfig, private val docume
                     createSubProjection(typeDef, javaType.build(), root, "${typeDef.name.capitalized()}", updatedProcessedEdges, queryDepth + 1)
                 }
                 .fold(CodeGenResult()) { total, current -> total.merge(current) }
-        } else CodeGenResult()
 
         fieldDefinitions
             .filterSkipped()

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/clientapi/ClientApiGenQueryTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/clientapi/ClientApiGenQueryTest.kt
@@ -225,6 +225,7 @@ class ClientApiGenQueryTest {
             type Query {
                 movies(filter: MovieQuery): [String]
             }
+           
             
             input MovieQuery {
                 booleanQuery: BooleanQuery!

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/clientapiv2/ClientApiGenProjectionTestv2.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/clientapiv2/ClientApiGenProjectionTestv2.kt
@@ -491,17 +491,17 @@ class ClientApiGenProjectionTestv2 {
             CodeGenConfig(
                 schemas = setOf(schema),
                 packageName = basePackageName,
-                generateClientApiv2 = true,
-                maxProjectionDepth = 2
+                generateClientApiv2 = true
             )
         ).generate()
 
-        assertThat(codeGenResult.clientProjections.size).isEqualTo(5)
+        assertThat(codeGenResult.clientProjections.size).isEqualTo(6)
         assertThat(codeGenResult.clientProjections[0].typeSpec.name).isEqualTo("MoviesProjectionRoot")
         assertThat(codeGenResult.clientProjections[1].typeSpec.name).isEqualTo("RatingProjection")
         assertThat(codeGenResult.clientProjections[2].typeSpec.name).isEqualTo("ReviewProjection")
         assertThat(codeGenResult.clientProjections[3].typeSpec.name).isEqualTo("ActorProjection")
         assertThat(codeGenResult.clientProjections[4].typeSpec.name).isEqualTo("AgentProjection")
+        assertThat(codeGenResult.clientProjections[5].typeSpec.name).isEqualTo("AddressProjection")
 
         assertCompilesJava(codeGenResult.clientProjections + codeGenResult.javaQueryTypes)
     }
@@ -711,8 +711,7 @@ class ClientApiGenProjectionTestv2 {
             CodeGenConfig(
                 schemas = setOf(schema),
                 packageName = basePackageName,
-                generateClientApiv2 = true,
-                maxProjectionDepth = 2
+                generateClientApiv2 = true
             )
         ).generate()
 


### PR DESCRIPTION
Since the V2 implementation of client API generation only generates one projection per type in the schema, we no longer need to limit the depth of the projections generation. Doing so only prevents fields from being generated. 