### PR TITLE
fix(ClientApiGenFragmentTestv2.kt): fragment name projection

### DIFF
--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ClientApiGeneratorv2.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ClientApiGeneratorv2.kt
@@ -402,15 +402,16 @@ class ClientApiGeneratorv2(private val config: CodeGenConfig, private val docume
         val rootRef = if (javaType.build().name == rootType.name) "this" else "getRoot()"
         val rootTypeName = if (javaType.build().name == rootType.name) "${rootType.name}<PARENT, ROOT>" else "ROOT"
         val parentRef = javaType.build().name
-        val projectionName = "${it.name.capitalized()}Projection"
-        val typeVariable = TypeVariableName.get("$projectionName<$parentRef<PARENT, ROOT>, $rootTypeName>")
+        val projectionName = "${it.name.capitalized()}Fragment"
+        val fullProjectionName = "${projectionName}Projection"
+        val typeVariable = TypeVariableName.get("$fullProjectionName<$parentRef<PARENT, ROOT>, $rootTypeName>")
         javaType.addMethod(
             MethodSpec.methodBuilder("on${it.name}")
                 .addModifiers(Modifier.PUBLIC)
                 .returns(typeVariable)
                 .addCode(
                     """
-                    |$projectionName<$parentRef<PARENT, ROOT>, $rootTypeName> fragment = new $projectionName<>(this, $rootRef);
+                    |$fullProjectionName<$parentRef<PARENT, ROOT>, $rootTypeName> fragment = new $fullProjectionName<>(this, $rootRef);
                     |getFragments().add(fragment);
                     |return fragment;
                     """.trimMargin()
@@ -418,7 +419,7 @@ class ClientApiGeneratorv2(private val config: CodeGenConfig, private val docume
                 .build()
         )
 
-        return createFragment(it as ObjectTypeDefinition, javaType.build(), rootType, "${it.name.capitalized()}", processedEdges, queryDepth)
+        return createFragment(it as ObjectTypeDefinition, javaType.build(), rootType, projectionName, processedEdges, queryDepth)
     }
 
     private fun createFragment(type: ObjectTypeDefinition, parent: TypeSpec, root: TypeSpec, prefix: String, processedEdges: Set<Pair<String, String>>, queryDepth: Int): CodeGenResult {

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/EntitiesClientApiGenTestv2.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/EntitiesClientApiGenTestv2.kt
@@ -130,10 +130,11 @@ class EntitiesClientApiGenTestv2 {
         val projections = codeGenResult.clientProjections
         assertThat(projections[0].typeSpec.name).isEqualTo("SearchProjectionRoot")
         assertThat(projections[1].typeSpec.name).isEqualTo("IActorProjection")
-        assertThat(projections[2].typeSpec.name).isEqualTo("ActorProjection")
-        assertThat(projections[3].typeSpec.name).isEqualTo("EntitiesProjectionRoot")
-        assertThat(projections[3].typeSpec.methodSpecs).extracting("name").contains("onMovie")
-        assertThat(projections[4].typeSpec.name).isEqualTo("EntitiesMovieKeyProjection")
+        assertThat(projections[2].typeSpec.name).isEqualTo("ActorFragmentProjection")
+        assertThat(projections[3].typeSpec.name).isEqualTo("ActorProjection")
+        assertThat(projections[4].typeSpec.name).isEqualTo("EntitiesProjectionRoot")
+        assertThat(projections[4].typeSpec.methodSpecs).extracting("name").contains("onMovie")
+        assertThat(projections[5].typeSpec.name).isEqualTo("EntitiesMovieKeyProjection")
 
         val representations = codeGenResult.javaDataTypes.filter { "Representation" in it.typeSpec.name }
         assertThat(representations).hasSize(2)

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/clientapiv2/ClientApiGenFragmentTestv2.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/clientapiv2/ClientApiGenFragmentTestv2.kt
@@ -61,12 +61,12 @@ class ClientApiGenFragmentTestv2 {
         assertThat(codeGenResult.clientProjections.size).isEqualTo(3)
         assertThat(codeGenResult.clientProjections[0].typeSpec.name).isEqualTo("SearchProjectionRoot")
         assertThat(codeGenResult.clientProjections[0].typeSpec.methodSpecs).extracting("name").contains("title")
-        assertThat(codeGenResult.clientProjections[1].typeSpec.name).isEqualTo("MovieProjection")
+        assertThat(codeGenResult.clientProjections[1].typeSpec.name).isEqualTo("MovieFragmentProjection")
         assertThat(codeGenResult.clientProjections[1].typeSpec.methodSpecs).extracting("name").contains("duration")
         assertThat(codeGenResult.clientProjections[1].typeSpec.methodSpecs).extracting("name").contains("title")
         assertThat(codeGenResult.clientProjections[1].typeSpec.methodSpecs).extracting("name")
             .doesNotContain("episodes")
-        assertThat(codeGenResult.clientProjections[2].typeSpec.name).isEqualTo("SeriesProjection")
+        assertThat(codeGenResult.clientProjections[2].typeSpec.name).isEqualTo("SeriesFragmentProjection")
         assertThat(codeGenResult.clientProjections[2].typeSpec.methodSpecs).extracting("name").contains("episodes")
         assertThat(codeGenResult.clientProjections[2].typeSpec.methodSpecs).extracting("name").contains("title")
         assertThat(codeGenResult.clientProjections[2].typeSpec.methodSpecs).extracting("name")
@@ -116,12 +116,12 @@ class ClientApiGenFragmentTestv2 {
         assertThat(codeGenResult.clientProjections[0].typeSpec.name).isEqualTo("SearchProjectionRoot")
         assertThat(codeGenResult.clientProjections[1].typeSpec.name).isEqualTo("ShowProjection")
         assertThat(codeGenResult.clientProjections[1].typeSpec.methodSpecs).extracting("name").contains("title")
-        assertThat(codeGenResult.clientProjections[2].typeSpec.name).isEqualTo("MovieProjection")
+        assertThat(codeGenResult.clientProjections[2].typeSpec.name).isEqualTo("MovieFragmentProjection")
         assertThat(codeGenResult.clientProjections[2].typeSpec.methodSpecs).extracting("name").contains("duration")
         assertThat(codeGenResult.clientProjections[2].typeSpec.methodSpecs).extracting("name").contains("title")
         assertThat(codeGenResult.clientProjections[2].typeSpec.methodSpecs).extracting("name")
             .doesNotContain("episodes")
-        assertThat(codeGenResult.clientProjections[3].typeSpec.name).isEqualTo("SeriesProjection")
+        assertThat(codeGenResult.clientProjections[3].typeSpec.name).isEqualTo("SeriesFragmentProjection")
         assertThat(codeGenResult.clientProjections[3].typeSpec.methodSpecs).extracting("name").contains("episodes")
         assertThat(codeGenResult.clientProjections[3].typeSpec.methodSpecs).extracting("name").contains("title")
         assertThat(codeGenResult.clientProjections[3].typeSpec.methodSpecs).extracting("name")
@@ -162,12 +162,58 @@ class ClientApiGenFragmentTestv2 {
         assertThat(codeGenResult.clientProjections[0].typeSpec.name).isEqualTo("SearchProjectionRoot")
         assertThat(codeGenResult.clientProjections[0].typeSpec.methodSpecs).extracting("name").contains("onMovie")
         assertThat(codeGenResult.clientProjections[0].typeSpec.methodSpecs).extracting("name").contains("onActor")
-        assertThat(codeGenResult.clientProjections[1].typeSpec.name).isEqualTo("MovieProjection")
+        assertThat(codeGenResult.clientProjections[1].typeSpec.name).isEqualTo("MovieFragmentProjection")
         assertThat(codeGenResult.clientProjections[1].typeSpec.methodSpecs).extracting("name").contains("title")
         assertThat(codeGenResult.clientProjections[1].typeSpec.methodSpecs).extracting("name").doesNotContain("name")
-        assertThat(codeGenResult.clientProjections[2].typeSpec.name).isEqualTo("ActorProjection")
+        assertThat(codeGenResult.clientProjections[2].typeSpec.name).isEqualTo("ActorFragmentProjection")
         assertThat(codeGenResult.clientProjections[2].typeSpec.methodSpecs).extracting("name").contains("name")
         assertThat(codeGenResult.clientProjections[2].typeSpec.methodSpecs).extracting("name").doesNotContain("title")
+
+        assertCompilesJava(
+            codeGenResult.clientProjections + codeGenResult.javaQueryTypes + codeGenResult.javaEnumTypes + codeGenResult.javaDataTypes + codeGenResult.javaInterfaces
+        )
+    }
+
+    @Test
+    fun unionFragmentSharingSubProjection() {
+        val schema = """
+            type Query {
+                search: [Result]
+                actor: Actor
+            }
+            
+            union Result = Movie | Actor
+
+            type Movie {
+                title: String
+            }
+
+            type Actor {
+                name: String
+            }
+        """.trimIndent()
+
+        val codeGenResult = CodeGen(
+            CodeGenConfig(
+                schemas = setOf(schema),
+                packageName = basePackageName,
+                generateClientApiv2 = true
+            )
+        ).generate()
+
+        assertThat(codeGenResult.clientProjections.size).isEqualTo(4)
+        assertThat(codeGenResult.clientProjections[0].typeSpec.name).isEqualTo("SearchProjectionRoot")
+        assertThat(codeGenResult.clientProjections[0].typeSpec.methodSpecs).extracting("name").contains("onMovie")
+        assertThat(codeGenResult.clientProjections[0].typeSpec.methodSpecs).extracting("name").contains("onActor")
+        assertThat(codeGenResult.clientProjections[1].typeSpec.name).isEqualTo("MovieFragmentProjection")
+        assertThat(codeGenResult.clientProjections[1].typeSpec.methodSpecs).extracting("name").contains("title")
+        assertThat(codeGenResult.clientProjections[1].typeSpec.methodSpecs).extracting("name").doesNotContain("name")
+        assertThat(codeGenResult.clientProjections[2].typeSpec.name).isEqualTo("ActorFragmentProjection")
+        assertThat(codeGenResult.clientProjections[2].typeSpec.methodSpecs).extracting("name").contains("name")
+        assertThat(codeGenResult.clientProjections[2].typeSpec.methodSpecs).extracting("name").doesNotContain("title")
+        assertThat(codeGenResult.clientProjections[3].typeSpec.name).isEqualTo("ActorProjectionRoot")
+        assertThat(codeGenResult.clientProjections[3].typeSpec.methodSpecs).extracting("name").contains("name")
+        assertThat(codeGenResult.clientProjections[3].typeSpec.methodSpecs).extracting("name").doesNotContain("title")
 
         assertCompilesJava(
             codeGenResult.clientProjections + codeGenResult.javaQueryTypes + codeGenResult.javaEnumTypes + codeGenResult.javaDataTypes + codeGenResult.javaInterfaces
@@ -212,10 +258,10 @@ class ClientApiGenFragmentTestv2 {
         assertThat(codeGenResult.clientProjections[1].typeSpec.methodSpecs).extracting("name").doesNotContain("name")
         assertThat(codeGenResult.clientProjections[1].typeSpec.methodSpecs).extracting("name").contains("onMovie")
         assertThat(codeGenResult.clientProjections[1].typeSpec.methodSpecs).extracting("name").contains("onActor")
-        assertThat(codeGenResult.clientProjections[2].typeSpec.name).isEqualTo("MovieProjection")
+        assertThat(codeGenResult.clientProjections[2].typeSpec.name).isEqualTo("MovieFragmentProjection")
         assertThat(codeGenResult.clientProjections[2].typeSpec.methodSpecs).extracting("name").contains("title")
         assertThat(codeGenResult.clientProjections[2].typeSpec.methodSpecs).extracting("name").doesNotContain("name")
-        assertThat(codeGenResult.clientProjections[3].typeSpec.name).isEqualTo("ActorProjection")
+        assertThat(codeGenResult.clientProjections[3].typeSpec.name).isEqualTo("ActorFragmentProjection")
         assertThat(codeGenResult.clientProjections[3].typeSpec.methodSpecs).extracting("name").contains("name")
         assertThat(codeGenResult.clientProjections[3].typeSpec.methodSpecs).extracting("name").doesNotContain("title")
 

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/clientapiv2/ClientApiGenProjectionTestv2.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/clientapiv2/ClientApiGenProjectionTestv2.kt
@@ -118,7 +118,7 @@ class ClientApiGenProjectionTestv2 {
 
         assertThat(codeGenResult.clientProjections.size).isEqualTo(4)
         assertThat(codeGenResult.clientProjections[0].typeSpec.name).isEqualTo("SearchProjectionRoot")
-        assertThat(codeGenResult.clientProjections[1].typeSpec.name).isEqualTo("MovieProjection")
+        assertThat(codeGenResult.clientProjections[1].typeSpec.name).isEqualTo("MovieFragmentProjection")
         assertThat(codeGenResult.clientProjections[2].typeSpec.name).isEqualTo("DetailsProjection")
         assertThat(codeGenResult.clientProjections[3].typeSpec.name).isEqualTo("ShowProjection")
 
@@ -162,8 +162,8 @@ class ClientApiGenProjectionTestv2 {
 
         assertThat(codeGenResult.clientProjections.size).isEqualTo(5)
         assertThat(codeGenResult.clientProjections[0].typeSpec.name).isEqualTo("SearchProjectionRoot")
-        assertThat(codeGenResult.clientProjections[1].typeSpec.name).isEqualTo("ShowProjection")
-        assertThat(codeGenResult.clientProjections[2].typeSpec.name).isEqualTo("MovieProjection")
+        assertThat(codeGenResult.clientProjections[1].typeSpec.name).isEqualTo("ShowFragmentProjection")
+        assertThat(codeGenResult.clientProjections[2].typeSpec.name).isEqualTo("MovieFragmentProjection")
         assertThat(codeGenResult.clientProjections[3].typeSpec.name).isEqualTo("RelatedProjection")
         assertThat(codeGenResult.clientProjections[4].typeSpec.name).isEqualTo("VideoProjection")
 

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/clientapiv2/ClientApiGenQueryTestv2.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/clientapiv2/ClientApiGenQueryTestv2.kt
@@ -210,8 +210,8 @@ class ClientApiGenQueryTestv2 {
         assertThat(codeGenResult.clientProjections)
             .extracting("typeSpec").extracting("name").containsExactly(
                 "ShowsProjectionRoot",
-                "ShowProjection",
-                "MovieProjection",
+                "ShowFragmentProjection",
+                "MovieFragmentProjection",
                 "RelatedProjection",
                 "VideoProjection"
             )
@@ -442,9 +442,9 @@ class ClientApiGenQueryTestv2 {
         assertThat(codeGenResult.clientProjections.size).isEqualTo(3)
         assertThat(codeGenResult.clientProjections[0].typeSpec.name).isEqualTo("SearchProjectionRoot")
         assertThat(codeGenResult.clientProjections[0].typeSpec.methodSpecs[1].name).isEqualTo("title")
-        assertThat(codeGenResult.clientProjections[1].typeSpec.name).isEqualTo("MovieProjection")
+        assertThat(codeGenResult.clientProjections[1].typeSpec.name).isEqualTo("MovieFragmentProjection")
         assertThat(codeGenResult.clientProjections[1].typeSpec.methodSpecs[2].name).isEqualTo("duration")
-        assertThat(codeGenResult.clientProjections[2].typeSpec.name).isEqualTo("SeriesProjection")
+        assertThat(codeGenResult.clientProjections[2].typeSpec.name).isEqualTo("SeriesFragmentProjection")
         assertThat(codeGenResult.clientProjections[2].typeSpec.methodSpecs[2].name).isEqualTo("episodes")
 
         assertCompilesJava(


### PR DESCRIPTION
This change fixes an issue where the codegen results in two Projection generated objects that share the name when used for union types as well as field projections.

Example schema:
```graphql
type Query {
   videos: Video
   bestMovie: Movie
}

type Movie {
   title
}

type Show {
   title
}

union Video = Movie | Show
```

Because `Movie` is used both as a field and as a union type, when codegen generates projection objects for each, they will result in the same `MovieProjection` and only one file will be written to disk. What this change does is it renames the projection objects used in fragments, so that they can be written to disk separately.
