### PR TITLE
fix(DataTypeGenerator): support typeMapping for union parent type

### DIFF
--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/DataTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/DataTypeGenerator.kt
@@ -394,7 +394,10 @@ abstract class BaseDataTypeGenerator(
     }
 
     private fun addInterface(type: String, javaType: TypeSpec.Builder) {
-        javaType.addSuperinterface(ClassName.get(packageName, type))
+        val interfaceTypeMappedName: String? = config.typeMapping[type]
+        val interfaceName: ClassName = if (interfaceTypeMappedName == null) ClassName.get(packageName, type) else ClassName.bestGuess(interfaceTypeMappedName)
+
+        javaType.addSuperinterface(interfaceName)
     }
 
     private fun addField(fieldDefinition: Field, javaType: TypeSpec.Builder) {

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
@@ -4151,4 +4151,34 @@ It takes a title and such.
         // Check that the third field of the Person type is an Integer
         assertThat(dataTypes[0].typeSpec.fieldSpecs[2].type.toString()).isEqualTo("java.lang.Integer")
     }
+
+    @Test
+    fun `Supports typeMapping for union types`() {
+        val schema = """
+            type A {
+                name: String
+            }
+        
+            type B {
+                count: Int
+            }
+        
+            union C = A | B
+        """.trimIndent()
+
+        val (dataTypes) = CodeGen(
+            CodeGenConfig(
+                schemas = setOf(schema),
+                packageName = basePackageName,
+                typeMapping = mapOf(
+                    "C" to "java.lang.String"
+                )
+            )
+        ).generate()
+
+        assertThat(dataTypes.size).isEqualTo(2)
+
+        assertThat(dataTypes[0].typeSpec.superinterfaces[0].toString()).isEqualTo("java.lang.String")
+        assertThat(dataTypes[1].typeSpec.superinterfaces[0].toString()).isEqualTo("java.lang.String")
+    }
 }


### PR DESCRIPTION
Resolves #545 

This change fixes an issue where data types that are generated from a union definition will have a missing import when using `typeMapping` and declaring the union type. To fix the issue, this change checks if a given Interface is defined in the `typeMapping` configuration, and if so, it uses that for the ClassName`.

Verified with a new unit test.