### PR TITLE
fix(InputerValueSerializer): allow scalars to be assignable from class

### DIFF
--- a/graphql-dgs-codegen-shared-core/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/InputValueSerializer.kt
+++ b/graphql-dgs-codegen-shared-core/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/InputValueSerializer.kt
@@ -81,8 +81,10 @@ class InputValueSerializer(private val scalars: Map<Class<*>, Coercing<*, *>> = 
             return input
         }
 
-        if (input::class.java in scalars) {
-            return scalars.getValue(input::class.java).valueToLiteral(input)
+        for (scalar in scalars.keys) {
+            if (input::class.java == scalar || scalar.isAssignableFrom(input::class.java)) {
+                return scalars[scalar]!!.valueToLiteral(input)
+            }
         }
 
         if (input::class in toStringClasses) {

--- a/graphql-dgs-codegen-shared-core/src/test/kotlin/com/netflix/graphql/dgs/client/codegen/GraphQLQueryRequestTest.kt
+++ b/graphql-dgs-codegen-shared-core/src/test/kotlin/com/netflix/graphql/dgs/client/codegen/GraphQLQueryRequestTest.kt
@@ -18,7 +18,6 @@
 
 package com.netflix.graphql.dgs.client.codegen
 
-import com.netflix.graphql.dgs.DgsScalar
 import com.netflix.graphql.dgs.client.codegen.exampleprojection.EntitiesProjectionRoot
 import graphql.language.OperationDefinition
 import graphql.language.StringValue
@@ -26,15 +25,10 @@ import graphql.language.Value
 import graphql.parser.InvalidSyntaxException
 import graphql.parser.Parser
 import graphql.schema.Coercing
-import graphql.schema.CoercingParseLiteralException
-import graphql.schema.CoercingParseValueException
-import graphql.schema.CoercingSerializeException
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
 import java.time.ZoneId
-import java.time.format.DateTimeParseException
-import java.time.zone.ZoneRulesException
 import java.util.*
 
 class GraphQLQueryRequestTest {

--- a/graphql-dgs-codegen-shared-core/src/test/kotlin/com/netflix/graphql/dgs/client/codegen/ZoneIdScalar.kt
+++ b/graphql-dgs-codegen-shared-core/src/test/kotlin/com/netflix/graphql/dgs/client/codegen/ZoneIdScalar.kt
@@ -29,7 +29,6 @@ import java.time.ZoneId
 import java.time.format.DateTimeParseException
 import java.time.zone.ZoneRulesException
 
-
 @DgsScalar(name = "ZoneId")
 class ZoneIdScalar : Coercing<ZoneId, String> {
     @Throws(CoercingSerializeException::class)
@@ -55,14 +54,16 @@ class ZoneIdScalar : Coercing<ZoneId, String> {
                 String.format(
                     "A valid ZoneId must be provided. I.e. 'Europe/Berlin' or 'UTC'. Was: '%s'.",
                     input
-                ), e
+                ),
+                e
             )
         } catch (e: ZoneRulesException) {
             throw CoercingParseValueException(
                 String.format(
                     "A valid ZoneId must be provided. I.e. 'Europe/Berlin' or 'UTC'. Was: '%s'.",
                     input
-                ), e
+                ),
+                e
             )
         }
     }
@@ -93,8 +94,9 @@ class ZoneIdScalar : Coercing<ZoneId, String> {
             throw CoercingParseLiteralException("Expected a StringValue.")
         }
     }
+
     @Throws(CoercingParseLiteralException::class)
     override fun valueToLiteral(input: Any): Value<out Value<*>> {
-        return StringValue.of(input.toString());
+        return StringValue.of(input.toString())
     }
 }

--- a/graphql-dgs-codegen-shared-core/src/test/kotlin/com/netflix/graphql/dgs/client/codegen/ZoneIdScalar.kt
+++ b/graphql-dgs-codegen-shared-core/src/test/kotlin/com/netflix/graphql/dgs/client/codegen/ZoneIdScalar.kt
@@ -1,0 +1,100 @@
+/*
+ *
+ *  Copyright 2020 Netflix, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package com.netflix.graphql.dgs.client.codegen
+
+import com.netflix.graphql.dgs.DgsScalar
+import graphql.language.StringValue
+import graphql.language.Value
+import graphql.schema.Coercing
+import graphql.schema.CoercingParseLiteralException
+import graphql.schema.CoercingParseValueException
+import graphql.schema.CoercingSerializeException
+import java.time.ZoneId
+import java.time.format.DateTimeParseException
+import java.time.zone.ZoneRulesException
+
+
+@DgsScalar(name = "ZoneId")
+class ZoneIdScalar : Coercing<ZoneId, String> {
+    @Throws(CoercingSerializeException::class)
+    override fun serialize(dataFetcherResult: Any): String {
+        return dataFetcherResult as? String
+            ?: if (dataFetcherResult is ZoneId) {
+                dataFetcherResult.id
+            } else {
+                throw CoercingSerializeException("Expected type 'ZoneId', but was " + dataFetcherResult.javaClass.name)
+            }
+    }
+
+    @Throws(CoercingParseValueException::class)
+    override fun parseValue(input: Any): ZoneId {
+        return try {
+            if (input is String) {
+                ZoneId.of(input)
+            } else {
+                throw CoercingParseValueException("Expected a String")
+            }
+        } catch (e: DateTimeParseException) {
+            throw CoercingParseValueException(
+                String.format(
+                    "A valid ZoneId must be provided. I.e. 'Europe/Berlin' or 'UTC'. Was: '%s'.",
+                    input
+                ), e
+            )
+        } catch (e: ZoneRulesException) {
+            throw CoercingParseValueException(
+                String.format(
+                    "A valid ZoneId must be provided. I.e. 'Europe/Berlin' or 'UTC'. Was: '%s'.",
+                    input
+                ), e
+            )
+        }
+    }
+
+    @Throws(CoercingParseLiteralException::class)
+    override fun parseLiteral(input: Any): ZoneId {
+        return if (input is StringValue) {
+            try {
+                ZoneId.of(input.getValue())
+            } catch (e: DateTimeParseException) {
+                throw CoercingParseValueException(
+                    String.format(
+                        "A valid ZoneId must be provided. I.e. 'Europe/Berlin' or 'UTC'. Was: '%s'.",
+                        input
+                    ),
+                    e
+                )
+            } catch (e: ZoneRulesException) {
+                throw CoercingParseValueException(
+                    String.format(
+                        "A valid ZoneId must be provided. I.e. 'Europe/Berlin' or 'UTC'. Was: '%s'.",
+                        input
+                    ),
+                    e
+                )
+            }
+        } else {
+            throw CoercingParseLiteralException("Expected a StringValue.")
+        }
+    }
+    @Throws(CoercingParseLiteralException::class)
+    override fun valueToLiteral(input: Any): Value<out Value<*>> {
+        return StringValue.of(input.toString());
+    }
+}


### PR DESCRIPTION
Resolves #1522

This change addresses an edge case in `InputValueSerializer`, where an input object's class may be assignable from a scalar's class. For example, if I register my `ZoneId` scalar, and my input object is actually a `ZoneRegion extends ZoneId`, our strict matching will not be able to parse this input object. With this change, the matching of scalars is opened up to allow input objects to match to scalars where the class is assignable. 

@srinivasankavitha any concerns about backwards compatibility here? I can only imagine if folks were using typeMapping in ways that aren't intended.