### PR TITLE
feat: add NullableInputVariableSerializer

### DIFF
--- a/graphql-dgs-codegen-shared-core/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/GraphQLQueryRequest.kt
+++ b/graphql-dgs-codegen-shared-core/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/GraphQLQueryRequest.kt
@@ -30,8 +30,8 @@ class GraphQLQueryRequest @JvmOverloads constructor(
 ) {
 
     private var selectionSet: SelectionSet? = null
-
-    @JvmOverloads constructor(query: GraphQLQuery, selectionSet: SelectionSet, scalars: Map<Class<*>, Coercing<*, *>>? = null) : this(query = query, projection = null, options = GraphQLQueryRequestOptions(scalars = scalars ?: emptyMap())) {
+    constructor(query: GraphQLQuery, projection: BaseProjectionNode, scalars: Map<Class<*>, Coercing<*, *>>) : this(query = query, projection = projection, options = GraphQLQueryRequestOptions(scalars = scalars))
+    constructor(query: GraphQLQuery, selectionSet: SelectionSet, scalars: Map<Class<*>, Coercing<*, *>>? = null) : this(query = query, projection = null, options = GraphQLQueryRequestOptions(scalars = scalars ?: emptyMap())) {
         this.selectionSet = selectionSet
     }
     class GraphQLQueryRequestOptions(val scalars: Map<Class<*>, Coercing<*, *>> = emptyMap()) {

--- a/graphql-dgs-codegen-shared-core/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/GraphQLQueryRequest.kt
+++ b/graphql-dgs-codegen-shared-core/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/GraphQLQueryRequest.kt
@@ -26,7 +26,7 @@ import graphql.schema.Coercing
 class GraphQLQueryRequest @JvmOverloads constructor(
     val query: GraphQLQuery,
     val projection: BaseProjectionNode?,
-    val inputValueSerializer: InputValueSerializer?
+    val inputValueSerializer: InputValueSerializerInterface
 ) {
 
     private var selectionSet: SelectionSet? = null

--- a/graphql-dgs-codegen-shared-core/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/GraphQLQueryRequest.kt
+++ b/graphql-dgs-codegen-shared-core/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/GraphQLQueryRequest.kt
@@ -47,7 +47,7 @@ class GraphQLQueryRequest @JvmOverloads constructor(
             InputValueSerializer(options?.scalars ?: emptyMap())
         }
 
-    val projectionSerializer = ProjectionSerializer(inputValueSerializer ?: InputValueSerializer(emptyMap()))
+    val projectionSerializer = ProjectionSerializer(inputValueSerializer)
 
     fun serialize(): String {
         val operationDef = OperationDefinition.newOperationDefinition()

--- a/graphql-dgs-codegen-shared-core/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/GraphQLQueryRequest.kt
+++ b/graphql-dgs-codegen-shared-core/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/GraphQLQueryRequest.kt
@@ -25,18 +25,17 @@ import graphql.schema.Coercing
 
 class GraphQLQueryRequest @JvmOverloads constructor(
     val query: GraphQLQuery,
-    val projection: BaseProjectionNode? = null,
-    scalars: Map<Class<*>, Coercing<*, *>>? = null
+    val projection: BaseProjectionNode?,
+    val inputValueSerializer: InputValueSerializer?
 ) {
 
     private var selectionSet: SelectionSet? = null
 
-    @JvmOverloads constructor(query: GraphQLQuery, selectionSet: SelectionSet, scalars: Map<Class<*>, Coercing<*, *>>? = null) : this(query = query, scalars = scalars) {
+    @JvmOverloads constructor(query: GraphQLQuery, selectionSet: SelectionSet, scalars: Map<Class<*>, Coercing<*, *>>? = null) : this(query = query, projection = null, inputValueSerializer = InputValueSerializer(scalars ?: emptyMap())) {
         this.selectionSet = selectionSet
     }
 
-    val inputValueSerializer = InputValueSerializer(scalars ?: emptyMap())
-    val projectionSerializer = ProjectionSerializer(inputValueSerializer)
+    val projectionSerializer = ProjectionSerializer(inputValueSerializer ?: InputValueSerializer(emptyMap()))
 
     fun serialize(): String {
         val operationDef = OperationDefinition.newOperationDefinition()

--- a/graphql-dgs-codegen-shared-core/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/GraphQLQueryRequest.kt
+++ b/graphql-dgs-codegen-shared-core/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/GraphQLQueryRequest.kt
@@ -25,8 +25,8 @@ import graphql.schema.Coercing
 
 class GraphQLQueryRequest @JvmOverloads constructor(
     val query: GraphQLQuery,
-    val projection: BaseProjectionNode?,
-    options: GraphQLQueryRequestOptions?
+    val projection: BaseProjectionNode? = null,
+    options: GraphQLQueryRequestOptions? = null
 ) {
 
     private var selectionSet: SelectionSet? = null

--- a/graphql-dgs-codegen-shared-core/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/InputValueSerializerInterface.kt
+++ b/graphql-dgs-codegen-shared-core/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/InputValueSerializerInterface.kt
@@ -1,0 +1,36 @@
+/*
+ *
+ *  Copyright 2020 Netflix, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package com.netflix.graphql.dgs.client.codegen
+
+import graphql.language.Value
+
+/**
+ * Marks this property invisible for input value serialization.
+ */
+@Target(AnnotationTarget.PROPERTY)
+internal annotation class Transient
+
+interface InputValueSerializerInterface {
+    fun serialize(input: Any?): String
+    fun toValue(input: Any?): Value<*>
+}
+
+interface InputValue {
+    fun inputValues(): List<Pair<String, Any?>>
+}

--- a/graphql-dgs-codegen-shared-core/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/NullableInputValueSerializer.kt
+++ b/graphql-dgs-codegen-shared-core/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/NullableInputValueSerializer.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.client.codegen
+
+import graphql.language.NullValue
+import graphql.language.ObjectField
+import graphql.language.ObjectValue
+import graphql.language.Value
+import graphql.schema.Coercing
+import kotlin.reflect.full.allSuperclasses
+
+class NullableInputValueSerializer(scalars: Map<Class<*>, Coercing<*, *>> = emptyMap()) :
+    InputValueSerializer(scalars) {
+
+    override fun toValue(input: Any?): Value<*> {
+        if (input == null) {
+            return NullValue.newNullValue().build()
+        }
+
+        val optionalValue = getOptionalValue(input)
+
+        if (optionalValue.isPresent) {
+            return optionalValue.get()
+        }
+
+        val classes = (sequenceOf(input::class) + input::class.allSuperclasses.asSequence()) - Any::class
+        val propertyValues = getPropertyValues(classes, input)
+
+        val objectFields = propertyValues.asSequence()
+            .map { (name, value) -> ObjectField(name, toValue(value)) }
+            .toList()
+        return ObjectValue.newObjectValue()
+            .objectFields(objectFields)
+            .build()
+    }
+}

--- a/graphql-dgs-codegen-shared-core/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/ProjectionSerializer.kt
+++ b/graphql-dgs-codegen-shared-core/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/ProjectionSerializer.kt
@@ -23,7 +23,7 @@ import graphql.language.InlineFragment
 import graphql.language.SelectionSet
 import graphql.language.TypeName
 
-class ProjectionSerializer(private val inputValueSerializer: InputValueSerializer) {
+class ProjectionSerializer(private val inputValueSerializer: InputValueSerializerInterface) {
 
     fun toSelectionSet(projection: BaseProjectionNode): SelectionSet {
         val selectionSet = SelectionSet.newSelectionSet()

--- a/graphql-dgs-codegen-shared-core/src/test/kotlin/com/netflix/graphql/dgs/client/codegen/InputValueSerializerTest.kt
+++ b/graphql-dgs-codegen-shared-core/src/test/kotlin/com/netflix/graphql/dgs/client/codegen/InputValueSerializerTest.kt
@@ -60,11 +60,27 @@ class InputValueSerializerTest {
     }
 
     @Test
-    fun `Null values should be skipped`() {
-        val movieInput = MovieInput(1)
+    fun `Null values should be serialized except when properties of a POJO`() {
+        class ExamplePojo {
+            private val movieId: String? = null
+            private val movieTitle: String = "Bojack Horseman"
+        }
 
-        val serialize = InputValueSerializer(mapOf(DateRange::class.java to DateRangeScalar())).serialize(movieInput)
-        assertThat(serialize).isEqualTo("{movieId : 1}")
+        assertThat(InputValueSerializer(mapOf()).serialize(null)).isEqualTo("null")
+        assertThat(InputValueSerializer(mapOf()).serialize(mapOf("hello" to null))).isEqualTo("{hello : null}")
+        assertThat(InputValueSerializer(mapOf()).serialize(ExamplePojo())).isEqualTo("{movieTitle : \"Bojack Horseman\"}")
+    }
+
+    @Test
+    fun `NullableInputValueSerializer allows null values from POJO`() {
+        class ExamplePojo {
+            private val movieId: String? = null
+            private val movieTitle: String = "Bojack Horseman"
+        }
+
+        assertThat(NullableInputValueSerializer(mapOf()).serialize(null)).isEqualTo("null")
+        assertThat(NullableInputValueSerializer(mapOf()).serialize(mapOf("hello" to null))).isEqualTo("{hello : null}")
+        assertThat(NullableInputValueSerializer(mapOf()).serialize(ExamplePojo())).isEqualTo("{movieId : null, movieTitle : \"Bojack Horseman\"}")
     }
 
     @Test


### PR DESCRIPTION
Fixes #544 

This change refactors how GraphQLQueryRequest accepts input variables for serialization by adding a new feature where the `InputVariableSerializer` can be passed into `GraphQLQueryRequest`

By doing this, I was able to create a new interface that supplies both a `InputVariableSerializer` and `NullableInputVariableSerializer`, which share common functionality for getting property values and input values. The only difference is how nullable property values are handled when coming from a POJO. I've updated our tests to reflect what is actually happening as well as this new use case.

In the future, to make this the default behavior, we can swap out which serializer is used by default. This should be backwards compatible.