### PR TITLE
(chore) Gradle 8.2 compatibility work

### DIFF
--- a/graphql-dgs-codegen-gradle/generated-docs/Query.find.md
+++ b/graphql-dgs-codegen-gradle/generated-docs/Query.find.md
@@ -8,7 +8,7 @@
 ## Example
 ```graphql
 {
-  find(filter: {mandatoryString : "randomString", optionalString : "randomString", mandatoryNumber : 197539653235116614, optionalNumber : 5816126044854263270}) {
+  find(filter: {mandatoryString : "randomString", optionalString : "randomString", mandatoryNumber : 269109734867147797, optionalNumber : 6032492703890891451}) {
     isSuccessful
     result
   }

--- a/graphql-dgs-codegen-gradle/src/main/kotlin/com/netflix/graphql/dgs/codegen/gradle/CodegenPlugin.kt
+++ b/graphql-dgs-codegen-gradle/src/main/kotlin/com/netflix/graphql/dgs/codegen/gradle/CodegenPlugin.kt
@@ -23,7 +23,9 @@ import org.gradle.api.Project
 import org.gradle.api.logging.Logging
 import org.gradle.api.plugins.JavaPlugin
 import org.gradle.api.plugins.JavaPluginConvention
+import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.api.tasks.SourceSet
+import org.gradle.util.GradleVersion
 import java.util.Optional
 
 class CodegenPlugin : Plugin<Project> {
@@ -42,7 +44,9 @@ class CodegenPlugin : Plugin<Project> {
         generateJavaTaskProvider.configure { it.group = GRADLE_GROUP }
 
         val javaConvention = project.convention.getPlugin(JavaPluginConvention::class.java)
-        val sourceSets = javaConvention.sourceSets
+        val javaExtension = project.extensions.getByType(JavaPluginExtension::class.java)
+
+        val sourceSets = if (GradleVersion.current() >= GradleVersion.version("7.1")) javaExtension.sourceSets else javaConvention.sourceSets
         val mainSourceSet = sourceSets.getByName(SourceSet.MAIN_SOURCE_SET_NAME)
         val outputDir = generateJavaTaskProvider.map(GenerateJavaTask::getOutputDir)
         mainSourceSet.java.srcDirs(project.files(outputDir).builtBy(generateJavaTaskProvider))

--- a/graphql-dgs-codegen-gradle/src/test/kotlin/com/netflix/graphql/dgs/CodegenGradlePluginCompatibilityTest.kt
+++ b/graphql-dgs-codegen-gradle/src/test/kotlin/com/netflix/graphql/dgs/CodegenGradlePluginCompatibilityTest.kt
@@ -40,7 +40,7 @@ class CodegenGradlePluginCompatibilityTest {
     lateinit var projectDir: File
 
     @ParameterizedTest
-    @ValueSource(strings = ["7.0.2", "7.1.1", "7.2"])
+    @ValueSource(strings = ["7.0.2", "7.1.1", "7.2", "7.6", "8.0", "8.1"])
     fun `Test generateJava against multiple Gradle Versions`(gradleVersion: String) {
         prepareBuildGraphQLSchema(
             """


### PR DESCRIPTION
Hi folks,

This is to address the following:

1. Use `JavaPluginExtension` rather than convention in Gradle 7.1+. This is the preferred approach as convention has been deprecated and will be removed in Gradle 9.0
2. Modify [CodegenGradlePluginCompatibilityTest.kt](https://github.com/Netflix/dgs-codegen/compare/gradle-compatibility-enhancements?expand=1#diff-a7d44192ef602181efaee453ab08100715659a8403eeb30fbafcdae6b3a5117b) to test against modern versions of Gradle also 