### PR TITLE
feat(GraphQLQueryRequest): support alias in projections

### DIFF
--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ClientApiGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ClientApiGenerator.kt
@@ -466,7 +466,7 @@ class ClientApiGenerator(private val config: CodeGenConfig, private val document
         val javaType = TypeSpec.classBuilder(clazzName)
             .addOptionalGeneratedAnnotation(config)
             .addModifiers(Modifier.PUBLIC)
-            .superclass(ParameterizedTypeName.get(className, ClassName.get(getPackageName(), parent.name), ClassName.get(getPackageName(), root.name)))
+            .superclass(ParameterizedTypeName.get(className, ClassName.get(getPackageName(), clazzName), ClassName.get(getPackageName(), parent.name), ClassName.get(getPackageName(), root.name)))
             .addMethod(
                 MethodSpec.constructorBuilder()
                     .addModifiers(Modifier.PUBLIC)

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ClientApiGeneratorv2.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ClientApiGeneratorv2.kt
@@ -211,14 +211,14 @@ class ClientApiGeneratorv2(private val config: CodeGenConfig, private val docume
     private fun createRootProjection(type: TypeDefinition<*>, prefix: String): CodeGenResult {
         val clazzName = "${prefix}ProjectionRoot"
         val className = ClassName.get(BaseSubProjectionNode::class.java)
-        val parentJavaType = TypeVariableName.get("PARENT").withBounds(ParameterizedTypeName.get(className, TypeVariableName.get("?"), TypeVariableName.get("?")))
-        val rootJavaType = TypeVariableName.get("ROOT").withBounds(ParameterizedTypeName.get(className, TypeVariableName.get("?"), TypeVariableName.get("?")))
+        val parentJavaType = TypeVariableName.get("PARENT").withBounds(ParameterizedTypeName.get(className, TypeVariableName.get("?"), TypeVariableName.get("?"), TypeVariableName.get("?")))
+        val rootJavaType = TypeVariableName.get("ROOT").withBounds(ParameterizedTypeName.get(className, TypeVariableName.get("?"), TypeVariableName.get("?"), TypeVariableName.get("?")))
         val javaType = TypeSpec.classBuilder(clazzName)
             .addOptionalGeneratedAnnotation(config)
             .addTypeVariable(parentJavaType)
             .addTypeVariable(rootJavaType)
             .addModifiers(Modifier.PUBLIC)
-            .superclass(ParameterizedTypeName.get(className, TypeVariableName.get("PARENT"), TypeVariableName.get("ROOT")))
+            .superclass(ParameterizedTypeName.get(className, ClassName.get(getPackageName(), clazzName), TypeVariableName.get("PARENT"), TypeVariableName.get("ROOT")))
             .addMethod(
                 MethodSpec.constructorBuilder()
                     .addModifiers(Modifier.PUBLIC)
@@ -333,14 +333,14 @@ class ClientApiGeneratorv2(private val config: CodeGenConfig, private val docume
     private fun createEntitiesRootProjection(federatedTypes: List<ObjectTypeDefinition>): CodeGenResult {
         val clazzName = "EntitiesProjectionRoot"
         val className = ClassName.get(BaseSubProjectionNode::class.java)
-        val parentType = TypeVariableName.get("PARENT").withBounds(ParameterizedTypeName.get(className, TypeVariableName.get("?"), TypeVariableName.get("?")))
-        val rootType = TypeVariableName.get("ROOT").withBounds(ParameterizedTypeName.get(className, TypeVariableName.get("?"), TypeVariableName.get("?")))
+        val parentType = TypeVariableName.get("PARENT").withBounds(ParameterizedTypeName.get(className, TypeVariableName.get("?"), TypeVariableName.get("?"), TypeVariableName.get("?")))
+        val rootType = TypeVariableName.get("ROOT").withBounds(ParameterizedTypeName.get(className, TypeVariableName.get("?"), TypeVariableName.get("?"), TypeVariableName.get("?")))
         val javaType = TypeSpec.classBuilder(clazzName)
             .addOptionalGeneratedAnnotation(config)
             .addTypeVariable(parentType)
             .addTypeVariable(rootType)
             .addModifiers(Modifier.PUBLIC)
-            .superclass(ParameterizedTypeName.get(className, TypeVariableName.get("PARENT"), TypeVariableName.get("ROOT")))
+            .superclass(ParameterizedTypeName.get(className, ClassName.get(getPackageName(), clazzName), TypeVariableName.get("PARENT"), TypeVariableName.get("ROOT")))
             .addMethod(
                 MethodSpec.constructorBuilder()
                     .addModifiers(Modifier.PUBLIC)
@@ -480,14 +480,14 @@ class ClientApiGeneratorv2(private val config: CodeGenConfig, private val docume
         val clazzName = "${prefix}Projection"
         if (generatedClasses.contains(clazzName)) return null else generatedClasses.add(clazzName)
 
-        val parentJavaType = TypeVariableName.get("PARENT").withBounds(ParameterizedTypeName.get(className, TypeVariableName.get("?"), TypeVariableName.get("?")))
-        val rootJavaType = TypeVariableName.get("ROOT").withBounds(ParameterizedTypeName.get(className, TypeVariableName.get("?"), TypeVariableName.get("?")))
+        val parentJavaType = TypeVariableName.get("PARENT").withBounds(ParameterizedTypeName.get(className, TypeVariableName.get("?"), TypeVariableName.get("?"), TypeVariableName.get("?")))
+        val rootJavaType = TypeVariableName.get("ROOT").withBounds(ParameterizedTypeName.get(className, TypeVariableName.get("?"), TypeVariableName.get("?"), TypeVariableName.get("?")))
         val javaType = TypeSpec.classBuilder(clazzName)
             .addOptionalGeneratedAnnotation(config)
             .addTypeVariable(parentJavaType)
             .addTypeVariable(rootJavaType)
             .addModifiers(Modifier.PUBLIC)
-            .superclass(ParameterizedTypeName.get(className, TypeVariableName.get("PARENT"), TypeVariableName.get("ROOT")))
+            .superclass(ParameterizedTypeName.get(className, ClassName.get(getPackageName(), clazzName), TypeVariableName.get("PARENT"), TypeVariableName.get("ROOT")))
             .addMethod(
                 MethodSpec.constructorBuilder()
                     .addModifiers(Modifier.PUBLIC)

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/clientapi/ClientApiGenFragmentTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/clientapi/ClientApiGenFragmentTest.kt
@@ -127,7 +127,8 @@ class ClientApiGenFragmentTest {
             .doesNotContain("duration")
 
         val superclass = codeGenResult.clientProjections[3].typeSpec.superclass as ParameterizedTypeName
-        assertThat(superclass.typeArguments[1]).extracting("simpleName").isEqualTo("SearchProjectionRoot")
+        assertThat(superclass.typeArguments[1]).extracting("simpleName").isEqualTo("Search_ShowProjection")
+        assertThat(superclass.typeArguments[2]).extracting("simpleName").isEqualTo("SearchProjectionRoot")
 
         assertCompilesJava(
             codeGenResult.clientProjections + codeGenResult.javaQueryTypes + codeGenResult.javaEnumTypes + codeGenResult.javaDataTypes + codeGenResult.javaInterfaces
@@ -225,7 +226,8 @@ class ClientApiGenFragmentTest {
         assertThat(codeGenResult.clientProjections[3].typeSpec.initializerBlock.isEmpty).isFalse
 
         val superclass = codeGenResult.clientProjections[3].typeSpec.superclass as ParameterizedTypeName
-        assertThat(superclass.typeArguments[1]).extracting("simpleName").isEqualTo("SearchProjectionRoot")
+        assertThat(superclass.typeArguments[1]).extracting("simpleName").isEqualTo("Search_ResultProjection")
+        assertThat(superclass.typeArguments[2]).extracting("simpleName").isEqualTo("SearchProjectionRoot")
 
         val searchResult = codeGenResult.javaInterfaces[0].typeSpec
 

--- a/graphql-dgs-codegen-shared-core/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/BaseProjectionNode.kt
+++ b/graphql-dgs-codegen-shared-core/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/BaseProjectionNode.kt
@@ -33,8 +33,10 @@ abstract class BaseProjectionNode(
 ) {
 
     val fields: MutableMap<String, Any?> = LinkedHashMap()
+    val aliases: MutableMap<String, FieldAlias> = LinkedHashMap()
     val fragments: MutableList<BaseProjectionNode> = LinkedList()
     val inputArguments: MutableMap<String, List<InputArgument>> = LinkedHashMap()
 
     data class InputArgument(val name: String, val value: Any?)
+    data class FieldAlias(val fieldName: String, val value: Any?)
 }

--- a/graphql-dgs-codegen-shared-core/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/BaseSubProjectionNode.kt
+++ b/graphql-dgs-codegen-shared-core/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/BaseSubProjectionNode.kt
@@ -18,19 +18,60 @@ package com.netflix.graphql.dgs.client.codegen
 
 import java.util.*
 
-abstract class BaseSubProjectionNode<T, R>(
+abstract class BaseSubProjectionNode<S, T, R>(
     val parent: T,
     val root: R,
     schemaType: Optional<String> = Optional.empty()
 ) : BaseProjectionNode(schemaType) {
 
     constructor(parent: T, root: R) : this(parent, root, schemaType = Optional.empty())
-
     fun parent(): T {
         return parent
     }
 
     fun root(): R {
         return root
+    }
+
+    fun alias(alias: String, assigner: (node: S) -> Any): S {
+        // Avoid alias against existing field name
+        if (this.javaClass.kotlin.members.any { it.name.equals(alias, ignoreCase = true) }) {
+            throw AssertionError("Tried to specify alias $alias which already exists as field.")
+        }
+
+        // Stash our current set of fields
+        val currentFields = fields.toMap()
+        val currentInputArguments = inputArguments.toMap()
+        fields.clear()
+        inputArguments.clear()
+
+        // Track the aliased field
+        @Suppress("UNCHECKED_CAST")
+        assigner(this as S)
+
+        // Constraints on how aliases are assigned
+        if (fields.isEmpty()) {
+            throw AssertionError("Tried to initialize alias but did not call any fields.")
+        }
+
+        if (fields.size > 1) {
+            throw AssertionError("Tried to call multiple fields while initializing alias.")
+        }
+
+        val fieldName = fields.keys.first()
+        val fieldValue = fields.values.first()
+        val fieldArguments = mapOf(alias to inputArguments[fieldName]?.let { it }.orEmpty())
+
+        // Restore our fields stash
+        fields.clear()
+        fields.putAll(currentFields)
+        inputArguments.clear()
+        inputArguments.putAll(currentInputArguments)
+
+        // Layer in our new state
+        aliases[alias] = FieldAlias(fieldName = fieldName, value = fieldValue)
+        inputArguments.putAll(fieldArguments)
+
+        return this
     }
 }

--- a/graphql-dgs-codegen-shared-core/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/GraphQLMultiQueryRequest.kt
+++ b/graphql-dgs-codegen-shared-core/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/GraphQLMultiQueryRequest.kt
@@ -57,7 +57,7 @@ class GraphQLMultiQueryRequest(
             }
 
             if (request.projection != null) {
-                val selectionSet = if (request.projection is BaseSubProjectionNode<*, *>) {
+                val selectionSet = if (request.projection is BaseSubProjectionNode<*, *, *>) {
                     request.projectionSerializer.toSelectionSet(request.projection.root() as BaseProjectionNode)
                 } else {
                     request.projectionSerializer.toSelectionSet(request.projection)

--- a/graphql-dgs-codegen-shared-core/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/GraphQLQueryRequest.kt
+++ b/graphql-dgs-codegen-shared-core/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/GraphQLQueryRequest.kt
@@ -58,7 +58,7 @@ class GraphQLQueryRequest @JvmOverloads constructor(
         }
 
         if (projection != null) {
-            val selectionSetFromProjection = if (projection is BaseSubProjectionNode<*, *> && projection.root() != null) {
+            val selectionSetFromProjection = if (projection is BaseSubProjectionNode<*, *, *> && projection.root() != null) {
                 projectionSerializer.toSelectionSet(projection.root() as BaseProjectionNode)
             } else {
                 projectionSerializer.toSelectionSet(projection)

--- a/graphql-dgs-codegen-shared-core/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/ProjectionSerializer.kt
+++ b/graphql-dgs-codegen-shared-core/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/ProjectionSerializer.kt
@@ -51,6 +51,30 @@ class ProjectionSerializer(private val inputValueSerializer: InputValueSerialize
             selectionSet.selection(fieldSelection.build())
         }
 
+        for ((fieldName, fieldAlias) in projection.aliases) {
+            val fieldSelection = Field.newField()
+                .name(fieldAlias.fieldName)
+                .alias(fieldName)
+                .arguments(
+                    projection.inputArguments[fieldName].orEmpty().map { (argName, values) ->
+                        Argument(argName, inputValueSerializer.toValue(values))
+                    }
+                )
+            if (fieldAlias.value is BaseProjectionNode) {
+                val fieldSelectionSet = toSelectionSet(fieldAlias.value)
+                if (fieldSelectionSet.selections.isNotEmpty()) {
+                    fieldSelection.selectionSet(fieldSelectionSet)
+                }
+            } else if (fieldAlias.value != null) {
+                fieldSelection.selectionSet(
+                    SelectionSet.newSelectionSet()
+                        .selection(Field.newField(fieldAlias.value.toString()).build())
+                        .build()
+                )
+            }
+            selectionSet.selection(fieldSelection.build())
+        }
+
         for (fragment in projection.fragments) {
             val typeCondition = fragment.schemaType.map { TypeName(it) }
                 .orElseGet {

--- a/graphql-dgs-codegen-shared-core/src/test/java/com/netflix/graphql/dgs/client/codegen/exampleprojection/ShowsProjectionRoot.java
+++ b/graphql-dgs-codegen-shared-core/src/test/java/com/netflix/graphql/dgs/client/codegen/exampleprojection/ShowsProjectionRoot.java
@@ -57,7 +57,7 @@ public class ShowsProjectionRoot extends BaseProjectionNode {
         return this;
     }
 
-    public static class Shows_ReviewsProjection extends BaseSubProjectionNode<ShowsProjectionRoot, ShowsProjectionRoot> {
+    public static class Shows_ReviewsProjection extends BaseSubProjectionNode<Shows_ReviewsProjection, ShowsProjectionRoot, ShowsProjectionRoot> {
       public Shows_ReviewsProjection(ShowsProjectionRoot parent, ShowsProjectionRoot root) {
         super(parent, root);
       }

--- a/graphql-dgs-codegen-shared-core/src/test/kotlin/com/netflix/graphql/dgs/client/codegen/ProjectionSerializerTest.kt
+++ b/graphql-dgs-codegen-shared-core/src/test/kotlin/com/netflix/graphql/dgs/client/codegen/ProjectionSerializerTest.kt
@@ -102,4 +102,37 @@ internal class ProjectionSerializerTest {
             """.trimMargin()
         )
     }
+
+    @Test
+    fun `Projection supports aliases`() {
+        // given
+        val root = EntitiesProjectionRoot()
+            .onMovie(Optional.empty())
+            .moveId().title().releaseYear()
+            .alias("colesReviews") { it.reviews("Cole", 10).username().score() }
+            .reviews(username = "Foo", score = 10).username().score()
+            .root()
+        // when
+        val serialized = ProjectionSerializer(InputValueSerializer()).serialize(root)
+        // then
+        assertThat(serialized).isEqualTo(
+            """{
+            |  ... on EntitiesMovieKey {
+            |    __typename
+            |    moveId
+            |    title
+            |    releaseYear
+            |    reviews(username: "Foo", score: 10) {
+            |      username
+            |      score
+            |    }
+            |    colesReviews: reviews(username: "Cole", score: 10) {
+            |      username
+            |      score
+            |    }
+            |  }
+            |}
+            """.trimMargin()
+        )
+    }
 }

--- a/graphql-dgs-codegen-shared-core/src/test/kotlin/com/netflix/graphql/dgs/client/codegen/exampleprojection/EntitiesMovieKeyProjection.kt
+++ b/graphql-dgs-codegen-shared-core/src/test/kotlin/com/netflix/graphql/dgs/client/codegen/exampleprojection/EntitiesMovieKeyProjection.kt
@@ -23,7 +23,7 @@ class EntitiesMovieKeyProjection(
     parent: EntitiesProjectionRoot,
     root: EntitiesProjectionRoot,
     schemaType: Optional<String>
-) : BaseSubProjectionNode<EntitiesProjectionRoot, EntitiesProjectionRoot>(
+) : BaseSubProjectionNode<EntitiesMovieKeyProjection, EntitiesProjectionRoot, EntitiesProjectionRoot>(
     parent,
     root,
     schemaType = schemaType

--- a/graphql-dgs-codegen-shared-core/src/test/kotlin/com/netflix/graphql/dgs/client/codegen/exampleprojection/Movies_ReviewsProjection.kt
+++ b/graphql-dgs-codegen-shared-core/src/test/kotlin/com/netflix/graphql/dgs/client/codegen/exampleprojection/Movies_ReviewsProjection.kt
@@ -21,7 +21,7 @@ package com.netflix.graphql.dgs.client.codegen.exampleprojection
 import com.netflix.graphql.dgs.client.codegen.BaseSubProjectionNode
 
 class Movies_ReviewsProjection(parent: EntitiesMovieKeyProjection, root: EntitiesProjectionRoot) :
-    BaseSubProjectionNode<EntitiesMovieKeyProjection, EntitiesProjectionRoot>(parent, root) {
+    BaseSubProjectionNode<Movies_ReviewsProjection, EntitiesMovieKeyProjection, EntitiesProjectionRoot>(parent, root) {
     fun username(): Movies_ReviewsProjection {
         fields["username"] = null
         return this


### PR DESCRIPTION
Resolves #539 and #64

This change implements a new API for aliasing field usage. It does so by tracking the `fields` state, maintaining a copy of it while in the `alias` context, and then merging the two states upon completion.

Example:
```java
       val root = EntitiesProjectionRoot()
            .onMovie(Optional.empty())
            .moveId().title().releaseYear()
            .alias("colesReviews") { it.reviews("Cole", 10).username().score() }
            .reviews(username = "Foo", score = 10).username().score()
            .root()
```

Will be serialized as:

```graphql
{
  ... on EntitiesMovieKey {
    __typename
    moveId
    title
    releaseYear
    reviews(username: "Foo", score: 10) {
     username
      score
    }
    colesReviews: reviews(username: "Cole", score: 10) {
      username
      score
    }
  }
}
```