### PR TITLE
fix(GraphQLQueryRequestOptions): allow allowNullablePropertyInputValues to be mutable

### DIFF
--- a/graphql-dgs-codegen-shared-core/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/GraphQLQueryRequest.kt
+++ b/graphql-dgs-codegen-shared-core/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/GraphQLQueryRequest.kt
@@ -37,7 +37,7 @@ class GraphQLQueryRequest @JvmOverloads constructor(
     class GraphQLQueryRequestOptions(val scalars: Map<Class<*>, Coercing<*, *>> = emptyMap()) {
         // When enabled, input values that are derived from properties
         // whose values are null will be serialized in the query request
-        val allowNullablePropertyInputValues = false
+        var allowNullablePropertyInputValues = false
     }
 
     val inputValueSerializer =

--- a/graphql-dgs-codegen-shared-core/src/test/kotlin/com/netflix/graphql/dgs/client/codegen/GraphQLQueryRequestTest.kt
+++ b/graphql-dgs-codegen-shared-core/src/test/kotlin/com/netflix/graphql/dgs/client/codegen/GraphQLQueryRequestTest.kt
@@ -18,6 +18,7 @@
 
 package com.netflix.graphql.dgs.client.codegen
 
+import com.netflix.graphql.dgs.client.codegen.GraphQLQueryRequest.GraphQLQueryRequestOptions
 import com.netflix.graphql.dgs.client.codegen.exampleprojection.EntitiesProjectionRoot
 import graphql.language.OperationDefinition
 import graphql.language.StringValue
@@ -375,6 +376,28 @@ class GraphQLQueryRequestTest {
               |    }
               |  }
               |}
+            """.trimMargin()
+        )
+    }
+
+    @Test
+    fun serializeWithNullableInputValueSerializer() {
+        val query = TestGraphQLQuery().apply {
+            input["movie"] = Movie(1234, "name", null)
+        }
+        val options = GraphQLQueryRequestOptions().apply {
+            allowNullablePropertyInputValues = true
+        }
+        val request = GraphQLQueryRequest(query, MovieProjection().name().movieId(), options)
+        val result = request.serialize()
+        assertValidQuery(result)
+        assertThat(result).isEqualTo(
+            """{
+            |  test(movie: {movieId : 1234, name : "name", window : null}) {
+            |    name
+            |    movieId
+            |  }
+            |}
             """.trimMargin()
         )
     }


### PR DESCRIPTION
In addition to https://github.com/Netflix/dgs-codegen/pull/557

Allow the GraphQlQueryRequestOptions to be mutable and make use of the NullableInputValueSerializer.
