### PR TITLE
Fix for #499: Add missing import statements for interface with mapped sub-types

### DIFF
--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/InterfaceGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/InterfaceGenerator.kt
@@ -90,8 +90,9 @@ class InterfaceGenerator(private val config: CodeGenConfig, private val document
             .filter { node -> node.implements.any { it.isEqualTo(TypeName(definition.name)) } }
             .map { node ->
                 val nodeName = if (config.generateInterfaces) "I${node.name}" else node.name
-                ClassName.get(packageName, nodeName)
+                typeUtils.findJavaInterfaceName(nodeName, packageName)
             }
+            .filterIsInstance<ClassName>()
             .toList()
 
         if (implementations.isNotEmpty()) {

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinInterfaceTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinInterfaceTypeGenerator.kt
@@ -87,7 +87,8 @@ class KotlinInterfaceTypeGenerator(private val config: CodeGenConfig, private va
 
         val implementations = document.getDefinitionsOfType(ObjectTypeDefinition::class.java).asSequence()
             .filter { node -> node.implements.any { it.isEqualTo(TypeName(definition.name)) } }
-            .map { node -> ClassName(packageName, node.name) }
+            .map { node -> typeUtils.findKtInterfaceName(node.name, packageName) }
+            .filterIsInstance<ClassName>()
             .toList()
 
         if (implementations.isNotEmpty()) {

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
@@ -950,6 +950,61 @@ class KotlinCodeGenTest {
         assertThat((dataTypes[0].members[0] as TypeSpec).propertySpecs[0].type.toString()).isEqualTo("mypackage.Person?")
     }
 
+    @Test
+    fun `Use mapped type name when the type implements not-mapped interface`() {
+        val schema = """
+            interface Pet {
+              name: ID!
+            }
+            type Cat implements Pet {
+              name: ID!
+            }
+            type Dog implements Pet {
+              name: ID!
+            }
+        """.trimIndent()
+
+        val codeGenResult = CodeGen(
+            CodeGenConfig(
+                schemas = setOf(schema),
+                packageName = basePackageName,
+                language = Language.KOTLIN,
+                typeMapping = mapOf(
+                    "Cat" to "mypackage.Cat"
+                )
+            )
+        ).generate()
+        val interfaces = codeGenResult.kotlinInterfaces
+
+        assertThat(interfaces.size).isEqualTo(1)
+        assertThat(interfaces[0].toString()).isEqualTo(
+            """
+                |package com.netflix.graphql.dgs.codegen.tests.generated.types
+                |
+                |import com.fasterxml.jackson.`annotation`.JsonSubTypes
+                |import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+                |import kotlin.String
+                |import mypackage.Cat
+                |
+                |@JsonTypeInfo(
+                |  use = JsonTypeInfo.Id.NAME,
+                |  include = JsonTypeInfo.As.PROPERTY,
+                |  property = "__typename",
+                |)
+                |@JsonSubTypes(value = [
+                |  JsonSubTypes.Type(value = Cat::class, name = "Cat"),
+                |  JsonSubTypes.Type(value = Dog::class, name = "Dog")
+                |])
+                |public interface Pet {
+                |  public val name: String
+                |
+                |  public companion object
+                |}
+                |
+            """.trimMargin()
+        )
+    }
+
     class MappedTypesTestCases : ArgumentsProvider {
         override fun provideArguments(context: ExtensionContext): Stream<out Arguments> = of(
             arguments("java.time.LocalDateTime", "java.time.LocalDateTime"),


### PR DESCRIPTION
Fix for issue #499.

What's the problem?
--------------------

Generated interface file doesn't contain all `import` statements when a subtype is mapped via the "typeMapping" configuration. - The `@JsonSubTypes` annotation then references a non-existing class.

Fix
---

* Kotlin and Java generators:
Fixed to correctly map types in `@JsonSubTypes` using the existing `findKtInterfaceName`/`findJavaInterfaceName` utils.
* Kotlin2 generator:
This generator does not support this case well - generated interfaces are sealed so a sub-type cannot be in a different package anyway. No fix done/needed imho.

--------

Please let me know if there's anything missing / to change. .) Thank you. .)
