### PR TITLE
feat(ClientUtilsConventions): ignore dependency locking for shared core

### DIFF
--- a/graphql-dgs-codegen-gradle/build.gradle
+++ b/graphql-dgs-codegen-gradle/build.gradle
@@ -24,6 +24,7 @@ apply plugin: 'java-gradle-plugin'
 
 dependencies {
     api project(":graphql-dgs-codegen-core")
+    compileOnly "com.netflix.nebula:gradle-dependency-lock-plugin:latest.release"
     compileOnly "org.jetbrains.kotlin:kotlin-gradle-plugin:${Versions.KOTLIN_VERSION}"
 
     testApi gradleTestKit()

--- a/graphql-dgs-codegen-gradle/src/main/kotlin/com/netflix/graphql/dgs/codegen/gradle/ClientUtilsConventions.kt
+++ b/graphql-dgs-codegen-gradle/src/main/kotlin/com/netflix/graphql/dgs/codegen/gradle/ClientUtilsConventions.kt
@@ -50,9 +50,11 @@ object ClientUtilsConventions {
             project.plugins.withId(CLIENT_UTILS_NEBULA_LOCK_ID) {
                 val extension = project.extensions.getByType(DependencyLockExtension::class.java)
                 if (extension != null) {
+                    logger.info("DGS CodeGen added [{}] to the skippedDependencies.", dependencyLockString, dependencyConfiguration)
                     extension.skippedDependencies.add(dependencyLockString)
                 }
 
+                logger.info("DGS CodeGen added [{}] to the ignoredDependencies.", dependencyLockString, dependencyConfiguration)
                 project.dependencyLocking.ignoredDependencies.add(dependencyLockString)
             }
         }

--- a/graphql-dgs-codegen-gradle/src/main/kotlin/com/netflix/graphql/dgs/codegen/gradle/ClientUtilsConventions.kt
+++ b/graphql-dgs-codegen-gradle/src/main/kotlin/com/netflix/graphql/dgs/codegen/gradle/ClientUtilsConventions.kt
@@ -47,15 +47,15 @@ object ClientUtilsConventions {
             configurationDependencies.add(project.dependencies.create(dependencyString))
             logger.info("DGS CodeGen added [{}] to the {} dependencies.", dependencyString, dependencyConfiguration)
 
+            project.dependencyLocking.ignoredDependencies.add(dependencyLockString)
+            logger.info("DGS CodeGen added [{}] to the ignoredDependencies.", dependencyLockString, dependencyConfiguration)
+
             project.plugins.withId(CLIENT_UTILS_NEBULA_LOCK_ID) {
                 val extension = project.extensions.getByType(DependencyLockExtension::class.java)
                 if (extension != null) {
-                    logger.info("DGS CodeGen added [{}] to the skippedDependencies.", dependencyLockString, dependencyConfiguration)
                     extension.skippedDependencies.add(dependencyLockString)
+                    logger.info("DGS CodeGen added [{}] to the skippedDependencies.", dependencyLockString, dependencyConfiguration)
                 }
-
-                logger.info("DGS CodeGen added [{}] to the ignoredDependencies.", dependencyLockString, dependencyConfiguration)
-                project.dependencyLocking.ignoredDependencies.add(dependencyLockString)
             }
         }
     }


### PR DESCRIPTION
This change adds an integration with Nebula's Gradle Locking Plugin, if when present, will add Codegen to ignored dependencies for a given project. This will help align the generated client and types with the functionality provided by the 
shared core, so that they don't become out of sync or require a dependency update.

- [X] Open PR
- [x] Local validation and testing