### PR TITLE
fix: generate input types when client api is generated

### DIFF
--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
@@ -323,9 +323,7 @@ class CodeGen(private val config: CodeGenConfig) {
 
         val requiredTypeCollector = RequiredTypeCollector(
             document = document,
-            queries = config.includeQueries,
-            mutations = config.includeMutations,
-            subscriptions = config.includeSubscriptions
+            config = config
         )
         val requiredTypes = requiredTypeCollector.requiredTypes
 

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
@@ -63,9 +63,7 @@ class CodeGen(private val config: CodeGenConfig) {
     private val document = buildDocument()
     private val requiredTypeCollector = RequiredTypeCollector(
         document = document,
-        queries = config.includeQueries,
-        mutations = config.includeMutations,
-        subscriptions = config.includeSubscriptions
+        config = config
     )
 
     @Suppress("DuplicatedCode")

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/RequiredTypeCollector.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/RequiredTypeCollector.kt
@@ -53,7 +53,6 @@ class RequiredTypeCollector(
             }
         }
 
-
         val required = requiredTypes as MutableSet<String>
 
         NodeTraverser().postOrder(

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/RequiredTypeCollector.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/RequiredTypeCollector.kt
@@ -34,9 +34,7 @@ import graphql.util.TraverserContext
 
 class RequiredTypeCollector(
     private val document: Document,
-    queries: Set<String> = emptySet(),
-    mutations: Set<String> = emptySet(),
-    subscriptions: Set<String> = emptySet()
+    config: CodeGenConfig
 ) {
     val requiredTypes: Set<String> = LinkedHashSet()
 
@@ -44,11 +42,17 @@ class RequiredTypeCollector(
         val fieldDefinitions = mutableListOf<FieldDefinition>()
         for (definition in document.definitions.asSequence().filterIsInstance<ObjectTypeDefinition>()) {
             when (definition.name) {
-                "Query" -> definition.fieldDefinitions.filterTo(fieldDefinitions) { it.name in queries }
-                "Mutation" -> definition.fieldDefinitions.filterTo(fieldDefinitions) { it.name in mutations }
-                "Subscription" -> definition.fieldDefinitions.filterTo(fieldDefinitions) { it.name in subscriptions }
+                "Query" -> definition.fieldDefinitions.filterTo(fieldDefinitions) { it.name in config.includeQueries }
+                "Mutation" -> definition.fieldDefinitions.filterTo(fieldDefinitions) { it.name in config.includeMutations }
+                "Subscription" -> definition.fieldDefinitions.filterTo(fieldDefinitions) { it.name in config.includeSubscriptions }
+                else -> {
+                    if (config?.generateClientApiv2 == true || config?.generateClientApi == true) {
+                        fieldDefinitions.addAll(definition.fieldDefinitions)
+                    }
+                }
             }
         }
+
 
         val required = requiredTypes as MutableSet<String>
 

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/RequiredTypeCollectorTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/RequiredTypeCollectorTest.kt
@@ -56,35 +56,35 @@ class RequiredTypeCollectorTest {
 
     @Test
     fun `Related input types and enums should be included`() {
-        val types = RequiredTypeCollector(document, setOf("search")).requiredTypes
+        val types = RequiredTypeCollector(document, CodeGenConfig(includeQueries = setOf("search"))).requiredTypes
 
         assertThat(types).contains("Filter", "ShowType")
     }
 
     @Test
     fun `Related nested input types and enums should be included`() {
-        val types = RequiredTypeCollector(document, setOf("searchByExample")).requiredTypes
+        val types = RequiredTypeCollector(document, CodeGenConfig(includeQueries = setOf("searchByExample"))).requiredTypes
 
         assertThat(types).contains("ExampleShow", "ExampleActor", "ShowType")
     }
 
     @Test
     fun `Unrelated input types should be omitted`() {
-        val types = RequiredTypeCollector(document, setOf("searchByExample")).requiredTypes
+        val types = RequiredTypeCollector(document, CodeGenConfig(includeQueries = setOf("searchByExample"))).requiredTypes
 
         assertThat(types).doesNotContain("Filter")
     }
 
     @Test
     fun `All related input types should be included for multiple queries`() {
-        val types = RequiredTypeCollector(document, setOf("searchByExample", "search")).requiredTypes
+        val types = RequiredTypeCollector(document, CodeGenConfig(includeQueries = setOf("searchByExample", "search"))).requiredTypes
 
         assertThat(types).contains("ExampleShow", "Filter", "ShowType", "ExampleActor")
     }
 
     @Test
     fun `Lists of required input types should be included`() {
-        val types = RequiredTypeCollector(document, setOf("searchByExamples")).requiredTypes
+        val types = RequiredTypeCollector(document, CodeGenConfig(includeQueries = setOf("searchByExamples"))).requiredTypes
         assertThat(types).contains("ExampleShow", "ExampleActor", "ShowType")
     }
 }


### PR DESCRIPTION
This change fixes an issue where input types are missing when generateDataTypes=false and the client API is generated.