### PR TITLE
fix(ClientUtilsConventions): apply dependency locking at time of plugin initialization

### DIFF
--- a/graphql-dgs-codegen-gradle/src/main/kotlin/com/netflix/graphql/dgs/codegen/gradle/ClientUtilsConventions.kt
+++ b/graphql-dgs-codegen-gradle/src/main/kotlin/com/netflix/graphql/dgs/codegen/gradle/ClientUtilsConventions.kt
@@ -54,7 +54,7 @@ object ClientUtilsConventions {
             val configurationDependencies = project.configurations.getByName(dependencyConfiguration).dependencies
             configurationDependencies.add(project.dependencies.create(dependencyString))
             logger.info("DGS CodeGen added [{}] to the {} dependencies.", dependencyString, dependencyConfiguration)
-            
+
             project.plugins.withId(CLIENT_UTILS_NEBULA_LOCK_ID) {
                 val extension = project.extensions.getByType(DependencyLockExtension::class.java)
                 if (extension != null) {

--- a/graphql-dgs-codegen-gradle/src/main/kotlin/com/netflix/graphql/dgs/codegen/gradle/ClientUtilsConventions.kt
+++ b/graphql-dgs-codegen-gradle/src/main/kotlin/com/netflix/graphql/dgs/codegen/gradle/ClientUtilsConventions.kt
@@ -53,13 +53,13 @@ object ClientUtilsConventions {
             val dependencyConfiguration = optionalCodeClientDependencyScope.orElse(GRADLE_CLASSPATH_CONFIGURATION)
             val configurationDependencies = project.configurations.getByName(dependencyConfiguration).dependencies
             configurationDependencies.add(project.dependencies.create(dependencyString))
-            logger.info("DGS CodeGen added [{}] to the {} dependencies.", dependencyString, dependencyConfiguration)
+            logger.info("DGS CodeGen added dependency [{}] to {}.", dependencyString, dependencyConfiguration)
 
             project.plugins.withId(CLIENT_UTILS_NEBULA_LOCK_ID) {
                 val extension = project.extensions.getByType(DependencyLockExtension::class.java)
                 if (extension != null) {
                     extension.skippedDependencies.add(dependencyLockString)
-                    logger.info("DGS CodeGen added [{}] to the skippedDependencies.", dependencyLockString)
+                    logger.info("DGS CodeGen added skipped dependency [{}].", dependencyLockString)
                 }
             }
         }

--- a/graphql-dgs-codegen-gradle/src/main/kotlin/com/netflix/graphql/dgs/codegen/gradle/CodegenPlugin.kt
+++ b/graphql-dgs-codegen-gradle/src/main/kotlin/com/netflix/graphql/dgs/codegen/gradle/CodegenPlugin.kt
@@ -74,7 +74,7 @@ class CodegenPlugin : Plugin<Project> {
             if (codegenExtension.clientCoreConventionsEnabled.getOrElse(true)) {
                 project.dependencyLocking.ignoredDependencies.add(dependencyLockString)
                 logger.info(
-                    "DGS CodeGen added [{}] to ignoredDependencies.",
+                    "DGS CodeGen added ignored dependency [{}].",
                     dependencyLockString
                 )
             }

--- a/graphql-dgs-codegen-gradle/src/test/kotlin/com/netflix/graphql/dgs/CodegenGradlePluginClientUtilsConventionsTest.kt
+++ b/graphql-dgs-codegen-gradle/src/test/kotlin/com/netflix/graphql/dgs/CodegenGradlePluginClientUtilsConventionsTest.kt
@@ -33,7 +33,7 @@ class CodegenGradlePluginClientUtilsConventionsTest {
     private val inferredVersion = ClientUtilsConventions.pluginMetaInfVersion
 
     @Test
-    fun `If disabled, will not add the graphql-dgs-codegen-shared-core`() {
+    fun `If disabled, will not add the graphql-dgs-codegen-shared-core to dependencies`() {
         prepareBuildGradleFile(
             """
 plugins {
@@ -59,9 +59,7 @@ codegen.clientCoreConventionsEnabled = false
         val result = runner.build()
 
         assertThat(result.output)
-            .doesNotContain("DGS CodeGen added [com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-shared-core")
-        assertThat(result.output)
-            .doesNotContain("com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-shared-core")
+            .doesNotContain("DGS CodeGen added dependency")
     }
 
     @Test
@@ -91,7 +89,7 @@ dependencies { }
         val result = runner.build()
         // then we assert that the dependency was resolved to the proper version
         assertThat(result.output)
-            .contains("DGS CodeGen added [com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-shared-core:${inferredVersion.get()}")
+            .contains("DGS CodeGen added dependency [com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-shared-core:${inferredVersion.get()}")
         assertThat(result.output)
             .contains("- com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-shared-core:${inferredVersion.get()}")
     }
@@ -128,7 +126,7 @@ dependencies { }
         val result = runner.build()
         // then we assert that the dependency was resolved to the higher version.
         assertThat(result.output)
-            .contains("DGS CodeGen added [com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-shared-core:${inferredVersion.get()}] to the $configuration dependencies.")
+            .contains("DGS CodeGen added dependency [com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-shared-core:${inferredVersion.get()}] to $configuration.")
     }
 
     @Test
@@ -163,7 +161,7 @@ codegen {
         val result = runner.build()
         // then we assert that the dependency was resolved to the higher version.
         assertThat(result.output)
-            .contains("DGS CodeGen added [com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-shared-core:$higherVersion")
+            .contains("DGS CodeGen added dependency [com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-shared-core:$higherVersion")
         assertThat(result.output)
             .contains("- com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-shared-core:$higherVersion FAILED")
     }
@@ -198,7 +196,7 @@ dependencies {
         val result = runner.build()
         // then we assert that the dependency was resolved to the higher version.
         assertThat(result.output)
-            .contains("DGS CodeGen added [com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-shared-core")
+            .contains("DGS CodeGen added dependency [com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-shared-core")
         assertThat(result.output)
             .contains("- com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-shared-core:${inferredVersion.get()} -> $higherVersion FAILED")
     }


### PR DESCRIPTION
We ran into an issue where one application was observing the following error as it tried to apply ignored dependencies:
> The value for property 'ignoredDependencies' is final and cannot be changed any further.

This was very confusing because during my localhost testing, modifying ignoredDependencies went off without a hitch. This gave me a feeling this somehow a lifecycle was involved here.

I first started by catching any exception thrown when adding to ignoredDependencies. However, it wasn't until I removed `project.afterEvaluate` that the error disappeared entirely for the application in question.

Reading up on `afterEvaluate`, it does tend to cause these headaches. I worked through it every angle and first tried to remove `afterEvaluate`, but that broke CI. 

Eventually I moved dependency locking to plugin initialization and left the rest of the conventions for `afterEvaluate`