### PR TITLE
Configuration cache fix for <GenerateJavaTask`: invocation of 'Task.project' at execution time is unsupported.>

### DIFF
--- a/graphql-dgs-codegen-gradle/src/main/kotlin/com/netflix/graphql/dgs/codegen/gradle/GenerateJavaTask.kt
+++ b/graphql-dgs-codegen-gradle/src/main/kotlin/com/netflix/graphql/dgs/codegen/gradle/GenerateJavaTask.kt
@@ -157,6 +157,7 @@ open class GenerateJavaTask @Inject constructor(
     val dgsCodegenClasspath: ConfigurableFileCollection = objectFactory.fileCollection().from(
         project.configurations.named("dgsCodegen")
     )
+
     @TaskAction
     fun generate() {
         val schemaJarFilesFromDependencies = dgsCodegenClasspath.toList()

--- a/graphql-dgs-codegen-gradle/src/test/kotlin/com/netflix/graphql/dgs/CodegenGradlePluginCompatibilityTest.kt
+++ b/graphql-dgs-codegen-gradle/src/test/kotlin/com/netflix/graphql/dgs/CodegenGradlePluginCompatibilityTest.kt
@@ -108,6 +108,7 @@ class CodegenGradlePluginCompatibilityTest {
             .withArguments(
                 "--stacktrace",
                 "--info",
+                "--configuration-cache",
                 "generateJava",
                 "build"
             ).build()


### PR DESCRIPTION

Using dgs-codegen plugin (version: 5.12.4) with configuration cache enabled - results in error: 
``` Task :spot-server:generateJava of type com.netflix.graphql.dgs.codegen.gradle.GenerateJavaTask: invocation of Task.project at execution time is unsupported.```

Generally this is visible when running `./gradlew --configuration-cache --rerun-tasks assemble`.
One can reproduce it by running the CodegenGradlePluginCompatibilityTest tests with parameter `--configuration-cache`.
With version 5.12.4 tests fail with the message mentioned above. 
One can also reproduce it by invoking 
```
git clone git@github.com:Netflix/dgs-examples-kotlin.git
cd dgs-examples-kotlin-2.7
./gradlew --configuration-cache --rerun-tasks assemble
```

This pull request moves the classpath calculation outside of the task execution scope making it readable to the configuration cache.