### PR TITLE
Check whether projection root is not null in GraphQLMultiQueryRequest

### DIFF
--- a/graphql-dgs-codegen-shared-core/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/GraphQLMultiQueryRequest.kt
+++ b/graphql-dgs-codegen-shared-core/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/GraphQLMultiQueryRequest.kt
@@ -57,7 +57,7 @@ class GraphQLMultiQueryRequest(
             }
 
             if (request.projection != null) {
-                val selectionSet = if (request.projection is BaseSubProjectionNode<*, *>) {
+                val selectionSet = if (request.projection is BaseSubProjectionNode<*, *> && request.projection.root() != null) {
                     request.projectionSerializer.toSelectionSet(request.projection.root() as BaseProjectionNode)
                 } else {
                     request.projectionSerializer.toSelectionSet(request.projection)


### PR DESCRIPTION
This PR prevents a `NullPointerException` when `request.projection.root()` might end up as `null` in `GraphQLMultiQueryRequest`. The check is similar to the one in [GraphQLQueryRequest](https://github.com/Netflix/dgs-codegen/blob/master/graphql-dgs-codegen-shared-core/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/GraphQLQueryRequest.kt#L72). 

Please have a look, thank you!