### PR TITLE
add generateIsGetterForPrimitiveBooleanFields to generateJava task inputs

### DIFF
--- a/graphql-dgs-codegen-gradle/src/main/kotlin/com/netflix/graphql/dgs/codegen/gradle/GenerateJavaTask.kt
+++ b/graphql-dgs-codegen-gradle/src/main/kotlin/com/netflix/graphql/dgs/codegen/gradle/GenerateJavaTask.kt
@@ -69,6 +69,9 @@ open class GenerateJavaTask @Inject constructor(
     var generateBoxedTypes = false
 
     @Input
+    var generateIsGetterForPrimitiveBooleanFields = false
+
+    @Input
     var generateClient = false
 
     @Input
@@ -183,6 +186,7 @@ open class GenerateJavaTask @Inject constructor(
             subPackageNameTypes = subPackageNameTypes,
             language = Language.valueOf(language.uppercase(Locale.getDefault())),
             generateBoxedTypes = generateBoxedTypes,
+            generateIsGetterForPrimitiveBooleanFields = generateIsGetterForPrimitiveBooleanFields,
             generateClientApi = generateClient,
             generateClientApiv2 = generateClientv2,
             generateKotlinNullableClasses = generateKotlinNullableClasses,


### PR DESCRIPTION
Follow up to https://github.com/Netflix/dgs-codegen/pull/599, issue: #598 

I forgot to add it to `generateJava` task inputs so it cannot be set right now.
Please let me know in case I forgot anything else, this is my first time working on a gradle plugin. 