### PR TITLE
Client code: Generate deprecations

### DIFF
--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/JavaPoetUtils.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/JavaPoetUtils.kt
@@ -127,7 +127,15 @@ fun jsonSubTypeAnnotation(subTypes: Collection<ClassName>): AnnotationSpec {
  * https://github.com/square/javapoet/issues/670
  */
 fun Description.sanitizeJavaDoc(): String {
-    return this.content.lines().joinToString("\n").replace("$", "$$")
+    return this.content.lines().joinToString("\n").sanitizeJavaDoc()
+}
+
+/**
+ * Javapoet treats $ as a reference
+ * https://github.com/square/javapoet/issues/670
+ */
+fun String.sanitizeJavaDoc(): String {
+    return replace("$", "$$")
 }
 
 fun String.toTypeName(isGenericParam: Boolean = false): TypeName {

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/clientapi/ClientApiGenBuilderTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/clientapi/ClientApiGenBuilderTest.kt
@@ -169,18 +169,12 @@ class ClientApiGenBuilderTest {
             assertThat(codeGenResult.javaQueryTypes[0].typeSpec.typeSpecs).hasSize(1)
             assertThat(codeGenResult.javaQueryTypes[0].typeSpec.typeSpecs[0].methodSpecs).hasSize(4)
             assertThat(codeGenResult.javaQueryTypes[0].typeSpec.typeSpecs[0].methodSpecs[1].name).isEqualTo("nameFilter")
-            assertThat(codeGenResult.javaQueryTypes[0].typeSpec.typeSpecs[0].methodSpecs[1].toString()).isEqualTo(
+            assertThat(codeGenResult.javaQueryTypes[0].typeSpec.typeSpecs[0].methodSpecs[1].toString()).startsWith(
                 """
                     |/**
                     | * @deprecated use idFilter instead
                     | */
                     |@java.lang.Deprecated
-                    |public Builder nameFilter(java.lang.String nameFilter) {
-                    |  this.nameFilter = nameFilter;
-                    |  this.fieldsSet.add("nameFilter");
-                    |  return this;
-                    |}
-                    |
                 """.trimMargin()
             )
         }
@@ -211,15 +205,9 @@ class ClientApiGenBuilderTest {
             assertThat(codeGenResult.javaQueryTypes[0].typeSpec.typeSpecs).hasSize(1)
             assertThat(codeGenResult.javaQueryTypes[0].typeSpec.typeSpecs[0].methodSpecs).hasSize(4)
             assertThat(codeGenResult.javaQueryTypes[0].typeSpec.typeSpecs[0].methodSpecs[1].name).isEqualTo("nameFilter")
-            assertThat(codeGenResult.javaQueryTypes[0].typeSpec.typeSpecs[0].methodSpecs[1].toString()).isEqualTo(
+            assertThat(codeGenResult.javaQueryTypes[0].typeSpec.typeSpecs[0].methodSpecs[1].toString()).startsWith(
                 """
                     |@java.lang.Deprecated
-                    |public Builder nameFilter(java.lang.String nameFilter) {
-                    |  this.nameFilter = nameFilter;
-                    |  this.fieldsSet.add("nameFilter");
-                    |  return this;
-                    |}
-                    |
                 """.trimMargin()
             )
         }
@@ -255,7 +243,7 @@ class ClientApiGenBuilderTest {
             assertThat(codeGenResult.javaQueryTypes[0].typeSpec.typeSpecs).hasSize(1)
             assertThat(codeGenResult.javaQueryTypes[0].typeSpec.typeSpecs[0].methodSpecs).hasSize(4)
             assertThat(codeGenResult.javaQueryTypes[0].typeSpec.typeSpecs[0].methodSpecs[1].name).isEqualTo("nameFilter")
-            assertThat(codeGenResult.javaQueryTypes[0].typeSpec.typeSpecs[0].methodSpecs[1].toString()).isEqualTo(
+            assertThat(codeGenResult.javaQueryTypes[0].typeSpec.typeSpecs[0].methodSpecs[1].toString()).startsWith(
                 """
                     |/**
                     | * Filters by name.
@@ -265,12 +253,6 @@ class ClientApiGenBuilderTest {
                     | * @deprecated use idFilter instead
                     | */
                     |@java.lang.Deprecated
-                    |public Builder nameFilter(java.lang.String nameFilter) {
-                    |  this.nameFilter = nameFilter;
-                    |  this.fieldsSet.add("nameFilter");
-                    |  return this;
-                    |}
-                    |
                 """.trimMargin()
             )
         }
@@ -300,16 +282,8 @@ class ClientApiGenBuilderTest {
             assertThat(codeGenResult.javaQueryTypes[0].typeSpec.typeSpecs).hasSize(1)
             assertThat(codeGenResult.javaQueryTypes[0].typeSpec.typeSpecs[0].methodSpecs).hasSize(4)
             assertThat(codeGenResult.javaQueryTypes[0].typeSpec.typeSpecs[0].methodSpecs[1].name).isEqualTo("nameFilter")
-            assertThat(codeGenResult.javaQueryTypes[0].typeSpec.typeSpecs[0].methodSpecs[1].toString()).isEqualTo(
-                """
-                    |public Builder nameFilter(java.lang.String nameFilter) {
-                    |  this.nameFilter = nameFilter;
-                    |  this.fieldsSet.add("nameFilter");
-                    |  return this;
-                    |}
-                    |
-                """.trimMargin()
-            )
+            assertThat(codeGenResult.javaQueryTypes[0].typeSpec.typeSpecs[0].methodSpecs[1].annotations).isEmpty()
+            assertThat(codeGenResult.javaQueryTypes[0].typeSpec.typeSpecs[0].methodSpecs[1].javadoc.isEmpty).isTrue()
         }
     }
 }

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/clientapi/ClientApiGenBuilderTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/clientapi/ClientApiGenBuilderTest.kt
@@ -21,6 +21,7 @@ package com.netflix.graphql.dgs.codegen.clientapi
 import com.netflix.graphql.dgs.client.codegen.GraphQLQuery
 import com.netflix.graphql.dgs.codegen.*
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 class ClientApiGenBuilderTest {
@@ -137,5 +138,178 @@ class ClientApiGenBuilderTest {
         val result2QueryObject: GraphQLQuery = buildMethod.invoke(builder) as GraphQLQuery
         assertThat(result2QueryObject.name).isNotNull
         assertThat(result2QueryObject.name).isEqualTo("test")
+    }
+
+    @Nested
+    inner class Deprecation {
+
+        @Test
+        fun `adds @Deprecated annotation and reason from schema directives when setting enabled`() {
+            val schema = """
+                type Query {
+                    filter(
+                        nameFilter: String @deprecated(reason: "use idFilter instead"),
+                        idFilter: ID
+                    ): [String]
+                }
+            """.trimIndent()
+
+            val codeGenResult = CodeGen(
+                CodeGenConfig(
+                    schemas = setOf(schema),
+                    packageName = basePackageName,
+                    generateClientApiv2 = true,
+                    maxProjectionDepth = 2,
+                    addDeprecatedAnnotation = true
+                )
+            ).generate()
+
+            assertThat(codeGenResult.javaQueryTypes.size).isEqualTo(1)
+            assertThat(codeGenResult.javaQueryTypes[0].typeSpec.name).isEqualTo("FilterGraphQLQuery")
+            assertThat(codeGenResult.javaQueryTypes[0].typeSpec.typeSpecs).hasSize(1)
+            assertThat(codeGenResult.javaQueryTypes[0].typeSpec.typeSpecs[0].methodSpecs).hasSize(4)
+            assertThat(codeGenResult.javaQueryTypes[0].typeSpec.typeSpecs[0].methodSpecs[1].name).isEqualTo("nameFilter")
+            assertThat(codeGenResult.javaQueryTypes[0].typeSpec.typeSpecs[0].methodSpecs[1].toString()).isEqualTo(
+                """
+                    |/**
+                    | * @deprecated use idFilter instead
+                    | */
+                    |@java.lang.Deprecated
+                    |public Builder nameFilter(java.lang.String nameFilter) {
+                    |  this.nameFilter = nameFilter;
+                    |  this.fieldsSet.add("nameFilter");
+                    |  return this;
+                    |}
+                    |
+                """.trimMargin()
+            )
+        }
+
+        @Test
+        fun `adds @Deprecated annotation without a Javadoc when there is no reason`() {
+            val schema = """
+                type Query {
+                    filter(
+                        nameFilter: String @deprecated,
+                        idFilter: ID
+                    ): [String]
+                }
+            """.trimIndent()
+
+            val codeGenResult = CodeGen(
+                CodeGenConfig(
+                    schemas = setOf(schema),
+                    packageName = basePackageName,
+                    generateClientApiv2 = true,
+                    maxProjectionDepth = 2,
+                    addDeprecatedAnnotation = true
+                )
+            ).generate()
+
+            assertThat(codeGenResult.javaQueryTypes.size).isEqualTo(1)
+            assertThat(codeGenResult.javaQueryTypes[0].typeSpec.name).isEqualTo("FilterGraphQLQuery")
+            assertThat(codeGenResult.javaQueryTypes[0].typeSpec.typeSpecs).hasSize(1)
+            assertThat(codeGenResult.javaQueryTypes[0].typeSpec.typeSpecs[0].methodSpecs).hasSize(4)
+            assertThat(codeGenResult.javaQueryTypes[0].typeSpec.typeSpecs[0].methodSpecs[1].name).isEqualTo("nameFilter")
+            assertThat(codeGenResult.javaQueryTypes[0].typeSpec.typeSpecs[0].methodSpecs[1].toString()).isEqualTo(
+                """
+                    |@java.lang.Deprecated
+                    |public Builder nameFilter(java.lang.String nameFilter) {
+                    |  this.nameFilter = nameFilter;
+                    |  this.fieldsSet.add("nameFilter");
+                    |  return this;
+                    |}
+                    |
+                """.trimMargin()
+            )
+        }
+
+        @Test
+        fun `Deprecation reason and field's description go both into JavaDoc separated by an empty line`() {
+            val schema = """
+                type Query {
+                    filter(
+                        ${"\"\"\""}
+                        Filters by name.
+                        
+                        If not provided, no filter in regards to name is applied.
+                        ${"\"\"\""}
+                        nameFilter: String @deprecated(reason: "use idFilter instead"),
+                        idFilter: ID
+                    ): [String]
+                }
+            """.trimIndent()
+
+            val codeGenResult = CodeGen(
+                CodeGenConfig(
+                    schemas = setOf(schema),
+                    packageName = basePackageName,
+                    generateClientApiv2 = true,
+                    maxProjectionDepth = 2,
+                    addDeprecatedAnnotation = true
+                )
+            ).generate()
+
+            assertThat(codeGenResult.javaQueryTypes.size).isEqualTo(1)
+            assertThat(codeGenResult.javaQueryTypes[0].typeSpec.name).isEqualTo("FilterGraphQLQuery")
+            assertThat(codeGenResult.javaQueryTypes[0].typeSpec.typeSpecs).hasSize(1)
+            assertThat(codeGenResult.javaQueryTypes[0].typeSpec.typeSpecs[0].methodSpecs).hasSize(4)
+            assertThat(codeGenResult.javaQueryTypes[0].typeSpec.typeSpecs[0].methodSpecs[1].name).isEqualTo("nameFilter")
+            assertThat(codeGenResult.javaQueryTypes[0].typeSpec.typeSpecs[0].methodSpecs[1].toString()).isEqualTo(
+                """
+                    |/**
+                    | * Filters by name.
+                    | *         
+                    | * If not provided, no filter in regards to name is applied.
+                    | *
+                    | * @deprecated use idFilter instead
+                    | */
+                    |@java.lang.Deprecated
+                    |public Builder nameFilter(java.lang.String nameFilter) {
+                    |  this.nameFilter = nameFilter;
+                    |  this.fieldsSet.add("nameFilter");
+                    |  return this;
+                    |}
+                    |
+                """.trimMargin()
+            )
+        }
+
+        @Test
+        fun `adds nothing extra when addDeprecatedAnnotation is not enabled`() {
+            val schema = """
+                type Query {
+                    filter(
+                        nameFilter: String @deprecated(reason: "use idFilter instead"),
+                        idFilter: ID
+                    ): [String]
+                }
+            """.trimIndent()
+
+            val codeGenResult = CodeGen(
+                CodeGenConfig(
+                    schemas = setOf(schema),
+                    packageName = basePackageName,
+                    generateClientApiv2 = true,
+                    maxProjectionDepth = 2
+                )
+            ).generate()
+
+            assertThat(codeGenResult.javaQueryTypes.size).isEqualTo(1)
+            assertThat(codeGenResult.javaQueryTypes[0].typeSpec.name).isEqualTo("FilterGraphQLQuery")
+            assertThat(codeGenResult.javaQueryTypes[0].typeSpec.typeSpecs).hasSize(1)
+            assertThat(codeGenResult.javaQueryTypes[0].typeSpec.typeSpecs[0].methodSpecs).hasSize(4)
+            assertThat(codeGenResult.javaQueryTypes[0].typeSpec.typeSpecs[0].methodSpecs[1].name).isEqualTo("nameFilter")
+            assertThat(codeGenResult.javaQueryTypes[0].typeSpec.typeSpecs[0].methodSpecs[1].toString()).isEqualTo(
+                """
+                    |public Builder nameFilter(java.lang.String nameFilter) {
+                    |  this.nameFilter = nameFilter;
+                    |  this.fieldsSet.add("nameFilter");
+                    |  return this;
+                    |}
+                    |
+                """.trimMargin()
+            )
+        }
     }
 }


### PR DESCRIPTION
Client code generation now generates annotation and JavaDoc for deprecations, if enabled by `addDeprecatedAnnotation`.

Example:
```graphql
extend type Query {
    
    foos(ids: [ID!] @deprecated(reason: "Use filters instead"), filters: FooFilters): [Foo!]!
}
```

| Before        | After |
|:-------------:|:-------------:|
| <img width="309" alt="image" src="https://github.com/Netflix/dgs-codegen/assets/7399011/eca4bc4a-ce2b-47c3-8819-bbcd4d0f7f13">   | ![image](https://github.com/Netflix/dgs-codegen/assets/7399011/78c76e36-587a-4440-b47f-2f11a854f560)  |

---

Hi there, 👋

This is my first contribution. I find `createQueryClass()` a very long and therefore unclear method. I did not dare to refactor here 😊 If you are fine with that, I would very much like to improve the code.