### PR TITLE
Fix capitalization for Mutation type

### DIFF
--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ConstantsGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ConstantsGenerator.kt
@@ -104,7 +104,7 @@ class ConstantsGenerator(private val config: CodeGenConfig, private val document
         if (document.definitions.any { it is ObjectTypeDefinition && it.name == "Query" }) {
             javaType.addField(FieldSpec.builder(TypeName.get(String::class.java), "QUERY_TYPE").addModifiers(Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL).initializer(""""Query"""").build())
         }
-        if (document.definitions.any { it is ObjectTypeDefinition && it.name == "MUTATION" }) {
+        if (document.definitions.any { it is ObjectTypeDefinition && it.name == "Mutation" }) {
             javaType.addField(FieldSpec.builder(TypeName.get(String::class.java), "MUTATION_TYPE").addModifiers(Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL).initializer(""""Mutation"""").build())
         }
         if (document.definitions.any { it is ObjectTypeDefinition && it.name == "Subscription" }) {


### PR DESCRIPTION
The Java ConstantsGenerator class was looking for an object type definition named "MUTATION" instead of "Mutation".

See #486 