### PR TITLE
Set Kotlin api / language version to 1.7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,6 @@
+import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
+
 /*
  *
  *  Copyright 2020 Netflix, Inc.
@@ -39,6 +42,15 @@ allprojects {
     apply plugin: 'com.netflix.nebula.netflixoss'
     apply plugin: 'com.netflix.nebula.info'
     apply plugin: 'org.jetbrains.kotlin.jvm'
+
+    // Set Kotlin api / language version to 1.7 since dgs-framework
+    // is stuck on Gradle 7.x
+    tasks.named('compileKotlin', KotlinCompilationTask.class) {
+      compilerOptions {
+         apiVersion = KotlinVersion.KOTLIN_1_7
+         languageVersion = KotlinVersion.KOTLIN_1_7
+      }
+    }
 
     group = 'com.netflix.graphql.dgs.codegen'
 


### PR DESCRIPTION
To work around dgs-framework being stuck on Gradle 7.x for now, set the Kotlin language / api level to 1.7.