### PR TITLE
Handled reserved keywords for enum constants.

### DIFF
--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/EnumTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/EnumTypeGenerator.kt
@@ -66,7 +66,7 @@ class EnumTypeGenerator(private val config: CodeGenConfig) {
                     }
                 }
             }
-            javaType.addEnumConstant(it.name, typeSpec.build())
+            javaType.addEnumConstant(ReservedKeywordSanitizer.sanitize(it.name), typeSpec.build())
         }
 
         val javaFile = JavaFile.builder(getPackageName(), javaType.build()).build()

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinEnumTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinEnumTypeGenerator.kt
@@ -21,6 +21,7 @@ package com.netflix.graphql.dgs.codegen.generators.kotlin
 import com.netflix.graphql.dgs.codegen.CodeGenConfig
 import com.netflix.graphql.dgs.codegen.CodeGenResult
 import com.netflix.graphql.dgs.codegen.generators.java.EnumTypeGenerator
+import com.netflix.graphql.dgs.codegen.generators.java.ReservedKeywordSanitizer
 import com.netflix.graphql.dgs.codegen.generators.shared.applyDirectivesKotlin
 import com.netflix.graphql.dgs.codegen.shouldSkip
 import com.squareup.kotlinpoet.FileSpec
@@ -59,7 +60,7 @@ class KotlinEnumTypeGenerator(private val config: CodeGenConfig) {
                     applyDirectivesKotlin(it.directives, config)
                 )
             }
-            kotlinType.addEnumConstant(it.name, typeSpec.build())
+            kotlinType.addEnumConstant(ReservedKeywordSanitizer.sanitize(it.name), typeSpec.build())
         }
 
         kotlinType.addType(TypeSpec.companionObjectBuilder().addOptionalGeneratedAnnotation(config).build())

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
@@ -965,6 +965,36 @@ class CodeGenTest {
         assertCompilesJava(codeGenResult.javaEnumTypes)
     }
 
+    @Test
+    fun generateEnumWithReservedKeywords() {
+        val schema = """
+            type Query {
+                people: [Person]
+            }
+            
+            enum EmployeeTypes {
+                default
+                root
+                new
+            }
+        """.trimIndent()
+
+        val codeGenResult = CodeGen(
+            CodeGenConfig(
+                schemas = setOf(schema),
+                packageName = basePackageName
+            )
+        ).generate()
+
+        // Check generated enum type
+        assertThat(codeGenResult.javaEnumTypes.size).isEqualTo(1)
+        assertThat(codeGenResult.javaEnumTypes[0].typeSpec.name).isEqualTo("EmployeeTypes")
+        assertThat(codeGenResult.javaEnumTypes[0].typeSpec.enumConstants.size).isEqualTo(3)
+        assertThat(codeGenResult.javaEnumTypes[0].typeSpec.enumConstants).containsKeys("_default", "_root", "_new")
+
+        assertCompilesJava(codeGenResult.javaEnumTypes)
+    }
+
     @Nested
     inner class EnumAnnotationTest {
         @Test

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
@@ -883,6 +883,38 @@ class KotlinCodeGenTest {
         assertCompilesKotlin(result.kotlinDataTypes + result.kotlinEnumTypes)
     }
 
+    @Test
+    fun generateEnumWithReservedKeywords() {
+        val schema = """
+            type Query {
+                people: [Person]
+            }
+
+            enum EmployeeTypes {
+                default
+                root
+                new
+            }
+        """.trimIndent()
+
+        val result = CodeGen(
+            CodeGenConfig(
+                schemas = setOf(schema),
+                packageName = basePackageName,
+                language = Language.KOTLIN
+            )
+        ).generate()
+        val type = result.kotlinEnumTypes[0].members[0] as TypeSpec
+
+        // Check generated enum type
+        assertThat(type.name).isEqualTo("EmployeeTypes")
+        assertThat(type.enumConstants.size).isEqualTo(3)
+        assertThat(type.enumConstants).containsKeys("_default", "_root", "_new")
+        assertThat(type.typeSpecs[0].isCompanion).isTrue
+
+        assertCompilesKotlin(result.kotlinDataTypes + result.kotlinEnumTypes)
+    }
+
     @Nested
     inner class EnumAnnotationTests {
         @Test


### PR DESCRIPTION
Generated Enum classes for schema definitiions  use reserved keywords as fields names don't compile. We need to handle them just like we handle reserved keywords in other cases by sanitizing the name. By default, we add a "_" to the name:
E.g.
```public enum NodeDependencyType {
  default,

  loop
}
```
would now instead be generated as 
```
public enum NodeDependencyType {
  _default,

  _loop
}
```