### PR TITLE
Remove workaround, update lock file

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,15 +43,6 @@ allprojects {
     apply plugin: 'com.netflix.nebula.info'
     apply plugin: 'org.jetbrains.kotlin.jvm'
 
-    // Set Kotlin api / language version to 1.7 since dgs-framework
-    // is stuck on Gradle 7.x
-    tasks.named('compileKotlin', KotlinCompilationTask.class) {
-      compilerOptions {
-         apiVersion = KotlinVersion.KOTLIN_1_7
-         languageVersion = KotlinVersion.KOTLIN_1_7
-      }
-    }
-
     group = 'com.netflix.graphql.dgs.codegen'
 
     dependencies {

--- a/graphql-dgs-codegen-gradle/dependencies.lock
+++ b/graphql-dgs-codegen-gradle/dependencies.lock
@@ -15,7 +15,7 @@
             "project": true
         },
         "com.netflix.nebula:gradle-dependency-lock-plugin": {
-            "locked": "14.1.3"
+            "locked": "15.0.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.9.21"
@@ -32,7 +32,7 @@
     },
     "compileOnlyDependenciesMetadata": {
         "com.netflix.nebula:gradle-dependency-lock-plugin": {
-            "locked": "14.1.3"
+            "locked": "15.0.0"
         },
         "org.jetbrains.kotlin:kotlin-gradle-plugin": {
             "locked": "1.9.21"


### PR DESCRIPTION
Now that dgs-framework is on Gradle 8.x, remove unneeded workaround.