### PR TITLE
Fix handling of default values in schema for complex types.

### DIFF
--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/DataTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/DataTypeGenerator.kt
@@ -146,6 +146,7 @@ class InputTypeGenerator(config: CodeGenConfig, document: Document) : BaseDataTy
                             }
                         }.joinToString()
                     )
+                    is ObjectValue -> CodeBlock.of("new \$L()", typeUtils.findReturnType(it.type))
                     else -> CodeBlock.of("\$L", defVal)
                 }
             }

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
@@ -1594,6 +1594,32 @@ class CodeGenTest {
     }
 
     @Test
+    fun generateInputWithDefaultValueForComplexType() {
+        val schema = """
+            enum Color {
+                red
+            }
+            
+            input ColorFilter {
+                color: Color = red
+            }
+            
+            input Car {
+                color: Color = red
+                make: String
+            }
+            
+            input MyCar {
+                car: Car = {color: red}
+            }
+        """.trimIndent()
+
+        val (dataTypes, _, enumTypes) = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName)).generate()
+
+        assertCompilesJava(enumTypes + dataTypes)
+    }
+
+    @Test
     fun generateInputWithDefaultValueForArray() {
         val schema = """
             input SomeType {


### PR DESCRIPTION
The generated code for a schema that sets default values for complex types does not compile. Example test case: 
```
@Test
    fun generateInputWithDefaultValueForComplexType() {
        val schema = """
            enum Color {
                red
            }
            
            input ColorFilter {
                color: Color = red
            }
            
            input Car {
                color: Color = red
                make: String
            }
            
            input MyCar {
                car: Car = {color: red}
            }
        """.trimIndent()

        val (dataTypes, _, enumTypes) = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName)).generate()

        assertCompilesJava(enumTypes + dataTypes)
    }
```
The code generation was not handling input defaults with type ObjectValue. 

This PR fixes this by handling ObjectValue case by instantiating the equivalent class using default constructor. 