### PR TITLE
Fix import of typemapped types in generated union classes.

### DIFF
--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
@@ -210,7 +210,7 @@ class CodeGen(private val config: CodeGenConfig) {
             .filterIsInstance<UnionTypeDefinition>()
             .excludeSchemaTypeExtension()
             .filter { config.generateDataTypes || config.generateInterfaces || it.name in requiredTypeCollector.requiredTypes }
-            .map { UnionTypeGenerator(config).generate(it, findUnionExtensions(it.name, definitions)) }
+            .map { UnionTypeGenerator(config, document).generate(it, findUnionExtensions(it.name, definitions)) }
             .fold(CodeGenResult()) { t: CodeGenResult, u: CodeGenResult -> t.merge(u) }
     }
 

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
@@ -4531,6 +4531,36 @@ It takes a title and such.
     }
 
     @Test
+    fun `Supports typeMapping in union type generation`() {
+        val schema = """
+            type A {
+                name: String
+            }
+        
+            type B {
+                count: Int
+            }
+        
+            union C = A | B
+        """.trimIndent()
+
+        val result = CodeGen(
+            CodeGenConfig(
+                schemas = setOf(schema),
+                packageName = basePackageName,
+                typeMapping = mapOf(
+                    "A" to "java.lang.String"
+                )
+            )
+        ).generate()
+
+        assertThat(result.javaDataTypes.size).isEqualTo(1)
+
+        assertThat(result.javaDataTypes[0].typeSpec.superinterfaces[0].toString()).isEqualTo("com.netflix.graphql.dgs.codegen.tests.generated.types.C")
+        assertCompilesJava(result)
+    }
+
+    @Test
     fun `The default value for Locale should be overridden and wrapped`() {
         val schema = """
             scalar Locale @specifiedBy(url:"https://tools.ietf.org/html/bcp47")


### PR DESCRIPTION
For generated union types, typemapped types are not imported properly.

```

            type A {
                name: String
            }
        
            type B {
                count: Int
            }
        
            union C = A | B
```
with config:
```
CodeGenConfig(
                schemas = setOf(schema),
                packageName = basePackageName,
                typeMapping = mapOf(
                    "A" to "java.lang.String"
                )
            )
```

Generated class for C does not have the proper import for A
