### PR TITLE
Add companion object generation for enum classes in kotlin codegen2

### DIFF
--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/enum/expected/types/EmployeeTypes.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/enum/expected/types/EmployeeTypes.kt
@@ -4,4 +4,7 @@ public enum class EmployeeTypes {
   ENGINEER,
   MANAGER,
   DIRECTOR,
+  ;
+
+  public companion object
 }

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/enumDocs/expected/types/Color.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/enumDocs/expected/types/Color.kt
@@ -7,4 +7,7 @@ public enum class Color {
   red,
   white,
   blue,
+  ;
+
+  public companion object
 }

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/enumWithExtendedType/expected/types/EmployeeTypes.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/enumWithExtendedType/expected/types/EmployeeTypes.kt
@@ -5,4 +5,7 @@ public enum class EmployeeTypes {
   MANAGER,
   DIRECTOR,
   QA,
+  ;
+
+  public companion object
 }

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/inputWithDefaultEnumValueForArray/expected/types/Color.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/inputWithDefaultEnumValueForArray/expected/types/Color.kt
@@ -3,4 +3,7 @@ package com.netflix.graphql.dgs.codegen.cases.inputWithDefaultEnumValueForArray.
 public enum class Color {
   red,
   blue,
+  ;
+
+  public companion object
 }

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/inputWithDefaultValueForEnum/expected/types/Color.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/inputWithDefaultValueForEnum/expected/types/Color.kt
@@ -2,4 +2,7 @@ package com.netflix.graphql.dgs.codegen.cases.inputWithDefaultValueForEnum.expec
 
 public enum class Color {
   red,
+  ;
+
+  public companion object
 }

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/projectionWithEnum/expected/types/E.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/projectionWithEnum/expected/types/E.kt
@@ -2,4 +2,7 @@ package com.netflix.graphql.dgs.codegen.cases.projectionWithEnum.expected.types
 
 public enum class E {
   V,
+  ;
+
+  public companion object
 }

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin2/GenerateKotlin2EnumTypes.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin2/GenerateKotlin2EnumTypes.kt
@@ -54,6 +54,10 @@ fun generateKotlin2EnumTypes(
                 .plus(extensionTypes)
                 .flatMap { it.enumValueDefinitions }
 
+             val companionObject = TypeSpec.companionObjectBuilder()
+                .addOptionalGeneratedAnnotation(config)
+                .build()
+
             // create the enum class
             val enumSpec = TypeSpec.classBuilder(enumDefinition.name)
                 .addOptionalGeneratedAnnotation(config)
@@ -80,6 +84,7 @@ fun generateKotlin2EnumTypes(
                             .build()
                     }
                 )
+                .addType(companionObject)
                 .build()
 
             // return a file per enum

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/Kotline2CodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/Kotline2CodeGenTest.kt
@@ -85,6 +85,9 @@ class Kotline2CodeGenTest {
                 |public enum class TownJobTypes {
                 |  @Deprecated(message = "town switched to electric lights")
                 |  LAMPLIGHTER,
+                |  ;
+                |
+                |  public companion object
                 |}
                 |
             """.trimMargin()

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/Kotline2CodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/Kotline2CodeGenTest.kt
@@ -92,4 +92,43 @@ class Kotline2CodeGenTest {
         )
         assertCompilesKotlin(result.kotlinEnumTypes)
     }
+
+    @Test
+    fun `Add companion object to enum class`() {
+        val schema = """
+            enum MyEnum {
+                A
+                B
+                C
+            }
+        """.trimIndent()
+
+        val result = CodeGen(
+            CodeGenConfig(
+                schemas = setOf(schema),
+                packageName = basePackageName,
+                language = Language.KOTLIN
+            )
+        ).generate()
+
+        val type = result.kotlinEnumTypes[0].members[0] as TypeSpec
+
+        assertThat(FileSpec.get("$basePackageName.enums", type).toString()).isEqualTo(
+            """
+                |package com.netflix.graphql.dgs.codegen.tests.generated.enums
+                |
+                |public enum class MyEnum {
+                |  A,
+                |  B,
+                |  C,
+                |  ;
+                |
+                |  public companion object
+                |}
+                |
+            """.trimMargin()
+        )
+
+        assertCompilesKotlin(result.kotlinEnumTypes)
+    }
 }


### PR DESCRIPTION
This PR adds the generation of a companion object into enum classes for the experimental Kotlin code gen.

This behaviour was present in the normal kotlin codegen but dissapears once 

```kotlin
generateKotlinClosureProjections = true 
generateKotlinNullableClasses = true
```

Is enabled.