### PR TITLE
feat: allow to set default InputValueSerializer

### DIFF
--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/input/test/QueryTest.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/input/test/QueryTest.kt
@@ -18,12 +18,34 @@
 
 package com.netflix.graphql.dgs.codegen.cases.input.test
 
+import com.netflix.graphql.dgs.client.codegen.InputValueSerializer
+import com.netflix.graphql.dgs.codegen.InputValueSerializerProvider
 import com.netflix.graphql.dgs.codegen.cases.input.expected.DgsClient
 import com.netflix.graphql.dgs.codegen.cases.input.expected.types.MovieFilter
+import graphql.language.StringValue
+import graphql.language.Value
+import graphql.schema.Coercing
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 
 class QueryTest {
+    private val movieCoercing = object : Coercing<MovieFilter, String> {
+        override fun serialize(filter: Any): String {
+            return (filter as? MovieFilter)?.genre ?: ""
+        }
+
+        override fun parseValue(input: Any): MovieFilter {
+            return MovieFilter(input.toString())
+        }
+
+        override fun parseLiteral(input: Any): MovieFilter {
+            return MovieFilter(input.toString())
+        }
+
+        override fun valueToLiteral(input: Any): Value<*> {
+            return StringValue.of(serialize(input))
+        }
+    }
 
     @Test
     fun testQueryWithNoFilter() {
@@ -108,5 +130,54 @@ class QueryTest {
             """.trimMargin(),
             query
         )
+    }
+
+    @Test
+    fun testQueryWithFilterAndCustomCoercing() {
+        try {
+            InputValueSerializerProvider.serializer = InputValueSerializer(
+                mapOf(MovieFilter::class.java to movieCoercing)
+            )
+            val query = DgsClient.buildQuery {
+                movies(filter = MovieFilter(genre = "horror"))
+            }
+
+            Assertions.assertEquals(
+                """{
+            |  __typename
+            |  movies(filter: "horror")
+            |}
+            |
+            """.trimMargin(),
+                query
+            )
+        } finally {
+            InputValueSerializerProvider.reset()
+        }
+    }
+
+    @Test
+    fun testResetInputValueSerializerProvider() {
+        try {
+            InputValueSerializerProvider.serializer = InputValueSerializer(
+                mapOf(MovieFilter::class.java to movieCoercing)
+            )
+            InputValueSerializerProvider.reset()
+
+            val query = DgsClient.buildQuery {
+                movies(filter = MovieFilter(genre = "horror"))
+            }
+            Assertions.assertEquals(
+                """{
+            |  __typename
+            |  movies(filter: {genre : "horror"})
+            |}
+            |
+            """.trimMargin(),
+                query
+            )
+        } finally {
+            InputValueSerializerProvider.reset()
+        }
     }
 }

--- a/graphql-dgs-codegen-shared-core/src/test/kotlin/com/netflix/graphql/dgs/client/codegen/InputValueSerializerTest.kt
+++ b/graphql-dgs-codegen-shared-core/src/test/kotlin/com/netflix/graphql/dgs/client/codegen/InputValueSerializerTest.kt
@@ -16,10 +16,12 @@
 
 package com.netflix.graphql.dgs.client.codegen
 
+import graphql.scalars.id.UUIDScalar
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
 import java.time.LocalDateTime
+import java.util.UUID
 
 class InputValueSerializerTest {
 
@@ -149,6 +151,15 @@ class InputValueSerializerTest {
         val input = EvilGenre.ACTION
         val serialize = InputValueSerializer().serialize(input)
         assertThat(serialize).isEqualTo("ACTION")
+    }
+
+    @Test
+    fun `UUID value`() {
+        val expected = UUID.randomUUID()
+        val actual = InputValueSerializer(
+            mapOf(UUID::class.java to UUIDScalar.INSTANCE.coercing)
+        ).serialize(expected)
+        assertThat(actual).isEqualTo(""""$expected"""")
     }
 
     @Test


### PR DESCRIPTION
Extended `GraphQLProjection` to allow setting custom `InputValueSerializer` per thread.
This change will allow to use any scalars with DgsClient client and setup them once.


```kotlin
@Test
fun test() {
    InputValueSerializerProvider.serializer = InputValueSerializer(
        mapOf(UUID::class.java to UUIDScalar.INSTANCE.coercing)
    )
    /* line below would fail before */
    val query = DgsClient.buildQuery {
        movies(filter = UUID.randomUUID())
    }
}

```

closes #455