### PR TITLE
Use a double underscore to escape backing field names

### DIFF
--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/constantsForInputTypes/expected/types/Person.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/constantsForInputTypes/expected/types/Person.kt
@@ -15,17 +15,17 @@ public class Person(
   firstname: () -> String? = firstnameDefault,
   lastname: () -> String? = lastnameDefault,
 ) {
-  private val _firstname: () -> String? = firstname
+  private val __firstname: () -> String? = firstname
 
-  private val _lastname: () -> String? = lastname
+  private val __lastname: () -> String? = lastname
 
   @get:JvmName("getFirstname")
   public val firstname: String?
-    get() = _firstname.invoke()
+    get() = __firstname.invoke()
 
   @get:JvmName("getLastname")
   public val lastname: String?
-    get() = _lastname.invoke()
+    get() = __lastname.invoke()
 
   public companion object {
     private val firstnameDefault: () -> String? = 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/constantsForInputTypes/expected/types/Query.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/constantsForInputTypes/expected/types/Query.kt
@@ -14,11 +14,11 @@ import kotlin.jvm.JvmName
 public class Query(
   people: () -> List<Person?>? = peopleDefault,
 ) {
-  private val _people: () -> List<Person?>? = people
+  private val __people: () -> List<Person?>? = people
 
   @get:JvmName("getPeople")
   public val people: List<Person?>?
-    get() = _people.invoke()
+    get() = __people.invoke()
 
   public companion object {
     private val peopleDefault: () -> List<Person?>? = 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/constantsWithExtendedInputTypes/expected/types/Person.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/constantsWithExtendedInputTypes/expected/types/Person.kt
@@ -15,17 +15,17 @@ public class Person(
   firstname: () -> String? = firstnameDefault,
   lastname: () -> String? = lastnameDefault,
 ) {
-  private val _firstname: () -> String? = firstname
+  private val __firstname: () -> String? = firstname
 
-  private val _lastname: () -> String? = lastname
+  private val __lastname: () -> String? = lastname
 
   @get:JvmName("getFirstname")
   public val firstname: String?
-    get() = _firstname.invoke()
+    get() = __firstname.invoke()
 
   @get:JvmName("getLastname")
   public val lastname: String?
-    get() = _lastname.invoke()
+    get() = __lastname.invoke()
 
   public companion object {
     private val firstnameDefault: () -> String? = 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/constantsWithExtendedInputTypes/expected/types/Query.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/constantsWithExtendedInputTypes/expected/types/Query.kt
@@ -14,11 +14,11 @@ import kotlin.jvm.JvmName
 public class Query(
   people: () -> List<Person?>? = peopleDefault,
 ) {
-  private val _people: () -> List<Person?>? = people
+  private val __people: () -> List<Person?>? = people
 
   @get:JvmName("getPeople")
   public val people: List<Person?>?
-    get() = _people.invoke()
+    get() = __people.invoke()
 
   public companion object {
     private val peopleDefault: () -> List<Person?>? = 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/constantsWithExtendedInterface/expected/types/Query.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/constantsWithExtendedInterface/expected/types/Query.kt
@@ -14,11 +14,11 @@ import kotlin.jvm.JvmName
 public class Query(
   people: () -> List<Person?>? = peopleDefault,
 ) {
-  private val _people: () -> List<Person?>? = people
+  private val __people: () -> List<Person?>? = people
 
   @get:JvmName("getPeople")
   public val people: List<Person?>?
-    get() = _people.invoke()
+    get() = __people.invoke()
 
   public companion object {
     private val peopleDefault: () -> List<Person?>? = 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/constantsWithExtendedQuery/expected/types/Person.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/constantsWithExtendedQuery/expected/types/Person.kt
@@ -15,17 +15,17 @@ public class Person(
   firstname: () -> String? = firstnameDefault,
   lastname: () -> String? = lastnameDefault,
 ) {
-  private val _firstname: () -> String? = firstname
+  private val __firstname: () -> String? = firstname
 
-  private val _lastname: () -> String? = lastname
+  private val __lastname: () -> String? = lastname
 
   @get:JvmName("getFirstname")
   public val firstname: String?
-    get() = _firstname.invoke()
+    get() = __firstname.invoke()
 
   @get:JvmName("getLastname")
   public val lastname: String?
-    get() = _lastname.invoke()
+    get() = __lastname.invoke()
 
   public companion object {
     private val firstnameDefault: () -> String? = 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/constantsWithExtendedQuery/expected/types/Query.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/constantsWithExtendedQuery/expected/types/Query.kt
@@ -15,17 +15,17 @@ public class Query(
   people: () -> List<Person?>? = peopleDefault,
   friends: () -> List<Person?>? = friendsDefault,
 ) {
-  private val _people: () -> List<Person?>? = people
+  private val __people: () -> List<Person?>? = people
 
-  private val _friends: () -> List<Person?>? = friends
+  private val __friends: () -> List<Person?>? = friends
 
   @get:JvmName("getPeople")
   public val people: List<Person?>?
-    get() = _people.invoke()
+    get() = __people.invoke()
 
   @get:JvmName("getFriends")
   public val friends: List<Person?>?
-    get() = _friends.invoke()
+    get() = __friends.invoke()
 
   public companion object {
     private val peopleDefault: () -> List<Person?>? = 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/constantsWithExtendedTypes/expected/types/Person.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/constantsWithExtendedTypes/expected/types/Person.kt
@@ -16,23 +16,23 @@ public class Person(
   lastname: () -> String? = lastnameDefault,
   email: () -> String? = emailDefault,
 ) {
-  private val _firstname: () -> String? = firstname
+  private val __firstname: () -> String? = firstname
 
-  private val _lastname: () -> String? = lastname
+  private val __lastname: () -> String? = lastname
 
-  private val _email: () -> String? = email
+  private val __email: () -> String? = email
 
   @get:JvmName("getFirstname")
   public val firstname: String?
-    get() = _firstname.invoke()
+    get() = __firstname.invoke()
 
   @get:JvmName("getLastname")
   public val lastname: String?
-    get() = _lastname.invoke()
+    get() = __lastname.invoke()
 
   @get:JvmName("getEmail")
   public val email: String?
-    get() = _email.invoke()
+    get() = __email.invoke()
 
   public companion object {
     private val firstnameDefault: () -> String? = 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/constantsWithExtendedTypes/expected/types/Query.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/constantsWithExtendedTypes/expected/types/Query.kt
@@ -14,11 +14,11 @@ import kotlin.jvm.JvmName
 public class Query(
   people: () -> List<Person?>? = peopleDefault,
 ) {
-  private val _people: () -> List<Person?>? = people
+  private val __people: () -> List<Person?>? = people
 
   @get:JvmName("getPeople")
   public val people: List<Person?>?
-    get() = _people.invoke()
+    get() = __people.invoke()
 
   public companion object {
     private val peopleDefault: () -> List<Person?>? = 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassDocs/expected/types/Movie.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassDocs/expected/types/Movie.kt
@@ -18,11 +18,11 @@ import kotlin.jvm.JvmName
 public class Movie(
   title: () -> String? = titleDefault,
 ) {
-  private val _title: () -> String? = title
+  private val __title: () -> String? = title
 
   @get:JvmName("getTitle")
   public val title: String?
-    get() = _title.invoke()
+    get() = __title.invoke()
 
   public companion object {
     private val titleDefault: () -> String? = 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassDocs/expected/types/Query.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassDocs/expected/types/Query.kt
@@ -13,11 +13,11 @@ import kotlin.jvm.JvmName
 public class Query(
   search: () -> Movie? = searchDefault,
 ) {
-  private val _search: () -> Movie? = search
+  private val __search: () -> Movie? = search
 
   @get:JvmName("getSearch")
   public val search: Movie?
-    get() = _search.invoke()
+    get() = __search.invoke()
 
   public companion object {
     private val searchDefault: () -> Movie? = 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassFieldDocs/expected/types/Movie.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassFieldDocs/expected/types/Movie.kt
@@ -14,14 +14,14 @@ import kotlin.jvm.JvmName
 public class Movie(
   title: () -> String? = titleDefault,
 ) {
-  private val _title: () -> String? = title
+  private val __title: () -> String? = title
 
   /**
    * The original, non localized title with some specials characters : %!({[*$,.:;.
    */
   @get:JvmName("getTitle")
   public val title: String?
-    get() = _title.invoke()
+    get() = __title.invoke()
 
   public companion object {
     private val titleDefault: () -> String? = 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassFieldDocs/expected/types/Query.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassFieldDocs/expected/types/Query.kt
@@ -13,11 +13,11 @@ import kotlin.jvm.JvmName
 public class Query(
   search: () -> Movie? = searchDefault,
 ) {
-  private val _search: () -> Movie? = search
+  private val __search: () -> Movie? = search
 
   @get:JvmName("getSearch")
   public val search: Movie?
-    get() = _search.invoke()
+    get() = __search.invoke()
 
   public companion object {
     private val searchDefault: () -> Movie? = 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWIthNoFields/expected/types/Query.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWIthNoFields/expected/types/Query.kt
@@ -13,11 +13,11 @@ import kotlin.jvm.JvmName
 public class Query(
   me: () -> Person? = meDefault,
 ) {
-  private val _me: () -> Person? = me
+  private val __me: () -> Person? = me
 
   @get:JvmName("getMe")
   public val me: Person?
-    get() = _me.invoke()
+    get() = __me.invoke()
 
   public companion object {
     private val meDefault: () -> Person? = 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithBooleanField/expected/types/Query.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithBooleanField/expected/types/Query.kt
@@ -13,11 +13,11 @@ import kotlin.jvm.JvmName
 public class Query(
   test: () -> RequiredTestType? = testDefault,
 ) {
-  private val _test: () -> RequiredTestType? = test
+  private val __test: () -> RequiredTestType? = test
 
   @get:JvmName("getTest")
   public val test: RequiredTestType?
-    get() = _test.invoke()
+    get() = __test.invoke()
 
   public companion object {
     private val testDefault: () -> RequiredTestType? = 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithBooleanField/expected/types/RequiredTestType.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithBooleanField/expected/types/RequiredTestType.kt
@@ -14,11 +14,11 @@ import kotlin.jvm.JvmName
 public class RequiredTestType(
   isRequired: () -> Boolean = isRequiredDefault,
 ) {
-  private val _isRequired: () -> Boolean = isRequired
+  private val __isRequired: () -> Boolean = isRequired
 
   @get:JvmName("getIsRequired")
   public val isRequired: Boolean
-    get() = _isRequired.invoke()
+    get() = __isRequired.invoke()
 
   public companion object {
     private val isRequiredDefault: () -> Boolean = 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithDeclaredScalars/expected/types/Entity.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithDeclaredScalars/expected/types/Entity.kt
@@ -16,17 +16,17 @@ public class Entity(
   long: () -> Long? = longDefault,
   dateTime: () -> OffsetDateTime? = dateTimeDefault,
 ) {
-  private val _long: () -> Long? = long
+  private val __long: () -> Long? = long
 
-  private val _dateTime: () -> OffsetDateTime? = dateTime
+  private val __dateTime: () -> OffsetDateTime? = dateTime
 
   @get:JvmName("getLong")
   public val long: Long?
-    get() = _long.invoke()
+    get() = __long.invoke()
 
   @get:JvmName("getDateTime")
   public val dateTime: OffsetDateTime?
-    get() = _dateTime.invoke()
+    get() = __dateTime.invoke()
 
   public companion object {
     private val longDefault: () -> Long? = 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithDeclaredScalars/expected/types/EntityConnection.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithDeclaredScalars/expected/types/EntityConnection.kt
@@ -15,17 +15,17 @@ public class EntityConnection(
   pageInfo: () -> PageInfo = pageInfoDefault,
   edges: () -> List<EntityEdge?>? = edgesDefault,
 ) {
-  private val _pageInfo: () -> PageInfo = pageInfo
+  private val __pageInfo: () -> PageInfo = pageInfo
 
-  private val _edges: () -> List<EntityEdge?>? = edges
+  private val __edges: () -> List<EntityEdge?>? = edges
 
   @get:JvmName("getPageInfo")
   public val pageInfo: PageInfo
-    get() = _pageInfo.invoke()
+    get() = __pageInfo.invoke()
 
   @get:JvmName("getEdges")
   public val edges: List<EntityEdge?>?
-    get() = _edges.invoke()
+    get() = __edges.invoke()
 
   public companion object {
     private val pageInfoDefault: () -> PageInfo = 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithDeclaredScalars/expected/types/EntityEdge.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithDeclaredScalars/expected/types/EntityEdge.kt
@@ -15,17 +15,17 @@ public class EntityEdge(
   cursor: () -> String = cursorDefault,
   node: () -> Entity? = nodeDefault,
 ) {
-  private val _cursor: () -> String = cursor
+  private val __cursor: () -> String = cursor
 
-  private val _node: () -> Entity? = node
+  private val __node: () -> Entity? = node
 
   @get:JvmName("getCursor")
   public val cursor: String
-    get() = _cursor.invoke()
+    get() = __cursor.invoke()
 
   @get:JvmName("getNode")
   public val node: Entity?
-    get() = _node.invoke()
+    get() = __node.invoke()
 
   public companion object {
     private val cursorDefault: () -> String = 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithDeclaredScalars/expected/types/PageInfo.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithDeclaredScalars/expected/types/PageInfo.kt
@@ -18,29 +18,29 @@ public class PageInfo(
   hasNextPage: () -> Boolean = hasNextPageDefault,
   hasPreviousPage: () -> Boolean = hasPreviousPageDefault,
 ) {
-  private val _startCursor: () -> String? = startCursor
+  private val __startCursor: () -> String? = startCursor
 
-  private val _endCursor: () -> String? = endCursor
+  private val __endCursor: () -> String? = endCursor
 
-  private val _hasNextPage: () -> Boolean = hasNextPage
+  private val __hasNextPage: () -> Boolean = hasNextPage
 
-  private val _hasPreviousPage: () -> Boolean = hasPreviousPage
+  private val __hasPreviousPage: () -> Boolean = hasPreviousPage
 
   @get:JvmName("getStartCursor")
   public val startCursor: String?
-    get() = _startCursor.invoke()
+    get() = __startCursor.invoke()
 
   @get:JvmName("getEndCursor")
   public val endCursor: String?
-    get() = _endCursor.invoke()
+    get() = __endCursor.invoke()
 
   @get:JvmName("getHasNextPage")
   public val hasNextPage: Boolean
-    get() = _hasNextPage.invoke()
+    get() = __hasNextPage.invoke()
 
   @get:JvmName("getHasPreviousPage")
   public val hasPreviousPage: Boolean
-    get() = _hasPreviousPage.invoke()
+    get() = __hasPreviousPage.invoke()
 
   public companion object {
     private val startCursorDefault: () -> String? = 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithDeclaredScalars/expected/types/Query.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithDeclaredScalars/expected/types/Query.kt
@@ -15,17 +15,17 @@ public class Query(
   entity: () -> List<Entity?>? = entityDefault,
   entityConnection: () -> EntityConnection? = entityConnectionDefault,
 ) {
-  private val _entity: () -> List<Entity?>? = entity
+  private val __entity: () -> List<Entity?>? = entity
 
-  private val _entityConnection: () -> EntityConnection? = entityConnection
+  private val __entityConnection: () -> EntityConnection? = entityConnection
 
   @get:JvmName("getEntity")
   public val entity: List<Entity?>?
-    get() = _entity.invoke()
+    get() = __entity.invoke()
 
   @get:JvmName("getEntityConnection")
   public val entityConnection: EntityConnection?
-    get() = _entityConnection.invoke()
+    get() = __entityConnection.invoke()
 
   public companion object {
     private val entityDefault: () -> List<Entity?>? = 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithDeeplyNestedComplexField/expected/types/Car.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithDeeplyNestedComplexField/expected/types/Car.kt
@@ -16,23 +16,23 @@ public class Car(
   model: () -> String? = modelDefault,
   engine: () -> Engine? = engineDefault,
 ) {
-  private val _make: () -> String? = make
+  private val __make: () -> String? = make
 
-  private val _model: () -> String? = model
+  private val __model: () -> String? = model
 
-  private val _engine: () -> Engine? = engine
+  private val __engine: () -> Engine? = engine
 
   @get:JvmName("getMake")
   public val make: String?
-    get() = _make.invoke()
+    get() = __make.invoke()
 
   @get:JvmName("getModel")
   public val model: String?
-    get() = _model.invoke()
+    get() = __model.invoke()
 
   @get:JvmName("getEngine")
   public val engine: Engine?
-    get() = _engine.invoke()
+    get() = __engine.invoke()
 
   public companion object {
     private val makeDefault: () -> String? = 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithDeeplyNestedComplexField/expected/types/Engine.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithDeeplyNestedComplexField/expected/types/Engine.kt
@@ -19,29 +19,29 @@ public class Engine(
   size: () -> Double? = sizeDefault,
   performance: () -> Performance? = performanceDefault,
 ) {
-  private val _type: () -> String? = type
+  private val __type: () -> String? = type
 
-  private val _bhp: () -> Int? = bhp
+  private val __bhp: () -> Int? = bhp
 
-  private val _size: () -> Double? = size
+  private val __size: () -> Double? = size
 
-  private val _performance: () -> Performance? = performance
+  private val __performance: () -> Performance? = performance
 
   @get:JvmName("getType")
   public val type: String?
-    get() = _type.invoke()
+    get() = __type.invoke()
 
   @get:JvmName("getBhp")
   public val bhp: Int?
-    get() = _bhp.invoke()
+    get() = __bhp.invoke()
 
   @get:JvmName("getSize")
   public val size: Double?
-    get() = _size.invoke()
+    get() = __size.invoke()
 
   @get:JvmName("getPerformance")
   public val performance: Performance?
-    get() = _performance.invoke()
+    get() = __performance.invoke()
 
   public companion object {
     private val typeDefault: () -> String? = 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithDeeplyNestedComplexField/expected/types/Performance.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithDeeplyNestedComplexField/expected/types/Performance.kt
@@ -15,17 +15,17 @@ public class Performance(
   zeroToSixty: () -> Double? = zeroToSixtyDefault,
   quarterMile: () -> Double? = quarterMileDefault,
 ) {
-  private val _zeroToSixty: () -> Double? = zeroToSixty
+  private val __zeroToSixty: () -> Double? = zeroToSixty
 
-  private val _quarterMile: () -> Double? = quarterMile
+  private val __quarterMile: () -> Double? = quarterMile
 
   @get:JvmName("getZeroToSixty")
   public val zeroToSixty: Double?
-    get() = _zeroToSixty.invoke()
+    get() = __zeroToSixty.invoke()
 
   @get:JvmName("getQuarterMile")
   public val quarterMile: Double?
-    get() = _quarterMile.invoke()
+    get() = __quarterMile.invoke()
 
   public companion object {
     private val zeroToSixtyDefault: () -> Double? = 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithDeeplyNestedComplexField/expected/types/Query.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithDeeplyNestedComplexField/expected/types/Query.kt
@@ -14,11 +14,11 @@ import kotlin.jvm.JvmName
 public class Query(
   cars: () -> List<Car?>? = carsDefault,
 ) {
-  private val _cars: () -> List<Car?>? = cars
+  private val __cars: () -> List<Car?>? = cars
 
   @get:JvmName("getCars")
   public val cars: List<Car?>?
-    get() = _cars.invoke()
+    get() = __cars.invoke()
 
   public companion object {
     private val carsDefault: () -> List<Car?>? = 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithExtendedInterface/expected/types/Query.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithExtendedInterface/expected/types/Query.kt
@@ -14,11 +14,11 @@ import kotlin.jvm.JvmName
 public class Query(
   people: () -> List<Person?>? = peopleDefault,
 ) {
-  private val _people: () -> List<Person?>? = people
+  private val __people: () -> List<Person?>? = people
 
   @get:JvmName("getPeople")
   public val people: List<Person?>?
-    get() = _people.invoke()
+    get() = __people.invoke()
 
   public companion object {
     private val peopleDefault: () -> List<Person?>? = 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithInterface/expected/types/Employee.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithInterface/expected/types/Employee.kt
@@ -17,25 +17,25 @@ public class Employee(
   lastname: () -> String? = lastnameDefault,
   company: () -> String? = companyDefault,
 ) : Person {
-  private val _firstname: () -> String? = firstname
+  private val __firstname: () -> String? = firstname
 
-  private val _lastname: () -> String? = lastname
+  private val __lastname: () -> String? = lastname
 
-  private val _company: () -> String? = company
+  private val __company: () -> String? = company
 
   @Suppress("INAPPLICABLE_JVM_NAME")
   @get:JvmName("getFirstname")
   override val firstname: String?
-    get() = _firstname.invoke()
+    get() = __firstname.invoke()
 
   @Suppress("INAPPLICABLE_JVM_NAME")
   @get:JvmName("getLastname")
   override val lastname: String?
-    get() = _lastname.invoke()
+    get() = __lastname.invoke()
 
   @get:JvmName("getCompany")
   public val company: String?
-    get() = _company.invoke()
+    get() = __company.invoke()
 
   public companion object {
     private val firstnameDefault: () -> String? = 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithInterface/expected/types/Query.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithInterface/expected/types/Query.kt
@@ -14,11 +14,11 @@ import kotlin.jvm.JvmName
 public class Query(
   people: () -> List<Person?>? = peopleDefault,
 ) {
-  private val _people: () -> List<Person?>? = people
+  private val __people: () -> List<Person?>? = people
 
   @get:JvmName("getPeople")
   public val people: List<Person?>?
-    get() = _people.invoke()
+    get() = __people.invoke()
 
   public companion object {
     private val peopleDefault: () -> List<Person?>? = 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithInterfaceInheritance/expected/types/Query.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithInterfaceInheritance/expected/types/Query.kt
@@ -14,11 +14,11 @@ import kotlin.jvm.JvmName
 public class Query(
   people: () -> List<Person?>? = peopleDefault,
 ) {
-  private val _people: () -> List<Person?>? = people
+  private val __people: () -> List<Person?>? = people
 
   @get:JvmName("getPeople")
   public val people: List<Person?>?
-    get() = _people.invoke()
+    get() = __people.invoke()
 
   public companion object {
     private val peopleDefault: () -> List<Person?>? = 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithInterfaceInheritance/expected/types/Talent.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithInterfaceInheritance/expected/types/Talent.kt
@@ -18,32 +18,32 @@ public class Talent(
   company: () -> String? = companyDefault,
   imdbProfile: () -> String? = imdbProfileDefault,
 ) : Employee {
-  private val _firstname: () -> String = firstname
+  private val __firstname: () -> String = firstname
 
-  private val _lastname: () -> String? = lastname
+  private val __lastname: () -> String? = lastname
 
-  private val _company: () -> String? = company
+  private val __company: () -> String? = company
 
-  private val _imdbProfile: () -> String? = imdbProfile
+  private val __imdbProfile: () -> String? = imdbProfile
 
   @Suppress("INAPPLICABLE_JVM_NAME")
   @get:JvmName("getFirstname")
   override val firstname: String
-    get() = _firstname.invoke()
+    get() = __firstname.invoke()
 
   @Suppress("INAPPLICABLE_JVM_NAME")
   @get:JvmName("getLastname")
   override val lastname: String?
-    get() = _lastname.invoke()
+    get() = __lastname.invoke()
 
   @Suppress("INAPPLICABLE_JVM_NAME")
   @get:JvmName("getCompany")
   override val company: String?
-    get() = _company.invoke()
+    get() = __company.invoke()
 
   @get:JvmName("getImdbProfile")
   public val imdbProfile: String?
-    get() = _imdbProfile.invoke()
+    get() = __imdbProfile.invoke()
 
   public companion object {
     private val firstnameDefault: () -> String = 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithListProperties/expected/types/Person.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithListProperties/expected/types/Person.kt
@@ -16,17 +16,17 @@ public class Person(
   name: () -> String? = nameDefault,
   email: () -> List<String?>? = emailDefault,
 ) {
-  private val _name: () -> String? = name
+  private val __name: () -> String? = name
 
-  private val _email: () -> List<String?>? = email
+  private val __email: () -> List<String?>? = email
 
   @get:JvmName("getName")
   public val name: String?
-    get() = _name.invoke()
+    get() = __name.invoke()
 
   @get:JvmName("getEmail")
   public val email: List<String?>?
-    get() = _email.invoke()
+    get() = __email.invoke()
 
   public companion object {
     private val nameDefault: () -> String? = 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithListProperties/expected/types/Query.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithListProperties/expected/types/Query.kt
@@ -14,11 +14,11 @@ import kotlin.jvm.JvmName
 public class Query(
   people: () -> List<Person?>? = peopleDefault,
 ) {
-  private val _people: () -> List<Person?>? = people
+  private val __people: () -> List<Person?>? = people
 
   @get:JvmName("getPeople")
   public val people: List<Person?>?
-    get() = _people.invoke()
+    get() = __people.invoke()
 
   public companion object {
     private val peopleDefault: () -> List<Person?>? = 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithMappedInterfaces/expected/types/Product.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithMappedInterfaces/expected/types/Product.kt
@@ -16,12 +16,12 @@ import kotlin.jvm.JvmName
 public class Product(
   id: () -> String = idDefault,
 ) : Entity, Node {
-  private val _id: () -> String = id
+  private val __id: () -> String = id
 
   @Suppress("INAPPLICABLE_JVM_NAME")
   @get:JvmName("getId")
   override val id: String
-    get() = _id.invoke()
+    get() = __id.invoke()
 
   public companion object {
     private val idDefault: () -> String = 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithMappedInterfaces/expected/types/Query.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithMappedInterfaces/expected/types/Query.kt
@@ -14,11 +14,11 @@ import kotlin.jvm.JvmName
 public class Query(
   products: () -> List<Product?>? = productsDefault,
 ) {
-  private val _products: () -> List<Product?>? = products
+  private val __products: () -> List<Product?>? = products
 
   @get:JvmName("getProducts")
   public val products: List<Product?>?
-    get() = _products.invoke()
+    get() = __products.invoke()
 
   public companion object {
     private val productsDefault: () -> List<Product?>? = 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithMappedTypes/expected/types/Entity.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithMappedTypes/expected/types/Entity.kt
@@ -16,17 +16,17 @@ public class Entity(
   long: () -> Long? = longDefault,
   dateTime: () -> OffsetDateTime? = dateTimeDefault,
 ) {
-  private val _long: () -> Long? = long
+  private val __long: () -> Long? = long
 
-  private val _dateTime: () -> OffsetDateTime? = dateTime
+  private val __dateTime: () -> OffsetDateTime? = dateTime
 
   @get:JvmName("getLong")
   public val long: Long?
-    get() = _long.invoke()
+    get() = __long.invoke()
 
   @get:JvmName("getDateTime")
   public val dateTime: OffsetDateTime?
-    get() = _dateTime.invoke()
+    get() = __dateTime.invoke()
 
   public companion object {
     private val longDefault: () -> Long? = 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithMappedTypes/expected/types/EntityEdge.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithMappedTypes/expected/types/EntityEdge.kt
@@ -15,17 +15,17 @@ public class EntityEdge(
   cursor: () -> String = cursorDefault,
   node: () -> Entity? = nodeDefault,
 ) {
-  private val _cursor: () -> String = cursor
+  private val __cursor: () -> String = cursor
 
-  private val _node: () -> Entity? = node
+  private val __node: () -> Entity? = node
 
   @get:JvmName("getCursor")
   public val cursor: String
-    get() = _cursor.invoke()
+    get() = __cursor.invoke()
 
   @get:JvmName("getNode")
   public val node: Entity?
-    get() = _node.invoke()
+    get() = __node.invoke()
 
   public companion object {
     private val cursorDefault: () -> String = 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithMappedTypes/expected/types/Query.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithMappedTypes/expected/types/Query.kt
@@ -16,17 +16,17 @@ public class Query(
   entity: () -> List<Entity?>? = entityDefault,
   entityConnection: () -> SimpleListConnection<EntityEdge>? = entityConnectionDefault,
 ) {
-  private val _entity: () -> List<Entity?>? = entity
+  private val __entity: () -> List<Entity?>? = entity
 
-  private val _entityConnection: () -> SimpleListConnection<EntityEdge>? = entityConnection
+  private val __entityConnection: () -> SimpleListConnection<EntityEdge>? = entityConnection
 
   @get:JvmName("getEntity")
   public val entity: List<Entity?>?
-    get() = _entity.invoke()
+    get() = __entity.invoke()
 
   @get:JvmName("getEntityConnection")
   public val entityConnection: SimpleListConnection<EntityEdge>?
-    get() = _entityConnection.invoke()
+    get() = __entityConnection.invoke()
 
   public companion object {
     private val entityDefault: () -> List<Entity?>? = 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithNonNullableAndInterface/expected/types/Employee.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithNonNullableAndInterface/expected/types/Employee.kt
@@ -17,26 +17,26 @@ public class Employee(
   lastname: () -> String = lastnameDefault,
   company: () -> String? = companyDefault,
 ) : Person {
-  private val _firstname: () -> String = firstname
+  private val __firstname: () -> String = firstname
 
-  private val _lastname: () -> String = lastname
+  private val __lastname: () -> String = lastname
 
-  private val _company: () -> String? = company
+  private val __company: () -> String? = company
 
   @Suppress("INAPPLICABLE_JVM_NAME")
   @get:JvmName("getFirstname")
   override val firstname: String
-    get() = _firstname.invoke()
+    get() = __firstname.invoke()
 
   @Suppress("INAPPLICABLE_JVM_NAME")
   @get:JvmName("getLastname")
   override val lastname: String
-    get() = _lastname.invoke()
+    get() = __lastname.invoke()
 
   @Suppress("INAPPLICABLE_JVM_NAME")
   @get:JvmName("getCompany")
   override val company: String?
-    get() = _company.invoke()
+    get() = __company.invoke()
 
   public companion object {
     private val firstnameDefault: () -> String = 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithNonNullableAndInterface/expected/types/Query.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithNonNullableAndInterface/expected/types/Query.kt
@@ -14,11 +14,11 @@ import kotlin.jvm.JvmName
 public class Query(
   people: () -> List<Person?>? = peopleDefault,
 ) {
-  private val _people: () -> List<Person?>? = people
+  private val __people: () -> List<Person?>? = people
 
   @get:JvmName("getPeople")
   public val people: List<Person?>?
-    get() = _people.invoke()
+    get() = __people.invoke()
 
   public companion object {
     private val peopleDefault: () -> List<Person?>? = 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithNonNullableComplexType/expected/types/MyType.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithNonNullableComplexType/expected/types/MyType.kt
@@ -13,11 +13,11 @@ import kotlin.jvm.JvmName
 public class MyType(
   other: () -> OtherType = otherDefault,
 ) {
-  private val _other: () -> OtherType = other
+  private val __other: () -> OtherType = other
 
   @get:JvmName("getOther")
   public val other: OtherType
-    get() = _other.invoke()
+    get() = __other.invoke()
 
   public companion object {
     private val otherDefault: () -> OtherType = 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithNonNullableComplexType/expected/types/OtherType.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithNonNullableComplexType/expected/types/OtherType.kt
@@ -14,11 +14,11 @@ import kotlin.jvm.JvmName
 public class OtherType(
   name: () -> String = nameDefault,
 ) {
-  private val _name: () -> String = name
+  private val __name: () -> String = name
 
   @get:JvmName("getName")
   public val name: String
-    get() = _name.invoke()
+    get() = __name.invoke()
 
   public companion object {
     private val nameDefault: () -> String = 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithNonNullableListOfNullableValues/expected/types/Person.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithNonNullableListOfNullableValues/expected/types/Person.kt
@@ -16,17 +16,17 @@ public class Person(
   name: () -> String = nameDefault,
   email: () -> List<String?> = emailDefault,
 ) {
-  private val _name: () -> String = name
+  private val __name: () -> String = name
 
-  private val _email: () -> List<String?> = email
+  private val __email: () -> List<String?> = email
 
   @get:JvmName("getName")
   public val name: String
-    get() = _name.invoke()
+    get() = __name.invoke()
 
   @get:JvmName("getEmail")
   public val email: List<String?>
-    get() = _email.invoke()
+    get() = __email.invoke()
 
   public companion object {
     private val nameDefault: () -> String = 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithNonNullableListOfNullableValues/expected/types/Query.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithNonNullableListOfNullableValues/expected/types/Query.kt
@@ -14,11 +14,11 @@ import kotlin.jvm.JvmName
 public class Query(
   people: () -> List<Person?>? = peopleDefault,
 ) {
-  private val _people: () -> List<Person?>? = people
+  private val __people: () -> List<Person?>? = people
 
   @get:JvmName("getPeople")
   public val people: List<Person?>?
-    get() = _people.invoke()
+    get() = __people.invoke()
 
   public companion object {
     private val peopleDefault: () -> List<Person?>? = 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithNonNullablePrimitive/expected/types/MyType.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithNonNullablePrimitive/expected/types/MyType.kt
@@ -18,23 +18,23 @@ public class MyType(
   truth: () -> Boolean = truthDefault,
   floaty: () -> Double = floatyDefault,
 ) {
-  private val _count: () -> Int = count
+  private val __count: () -> Int = count
 
-  private val _truth: () -> Boolean = truth
+  private val __truth: () -> Boolean = truth
 
-  private val _floaty: () -> Double = floaty
+  private val __floaty: () -> Double = floaty
 
   @get:JvmName("getCount")
   public val count: Int
-    get() = _count.invoke()
+    get() = __count.invoke()
 
   @get:JvmName("getTruth")
   public val truth: Boolean
-    get() = _truth.invoke()
+    get() = __truth.invoke()
 
   @get:JvmName("getFloaty")
   public val floaty: Double
-    get() = _floaty.invoke()
+    get() = __floaty.invoke()
 
   public companion object {
     private val countDefault: () -> Int = 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithNonNullablePrimitiveInList/expected/types/MyType.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithNonNullablePrimitiveInList/expected/types/MyType.kt
@@ -19,23 +19,23 @@ public class MyType(
   truth: () -> List<Boolean>? = truthDefault,
   floaty: () -> List<Double>? = floatyDefault,
 ) {
-  private val _count: () -> List<Int>? = count
+  private val __count: () -> List<Int>? = count
 
-  private val _truth: () -> List<Boolean>? = truth
+  private val __truth: () -> List<Boolean>? = truth
 
-  private val _floaty: () -> List<Double>? = floaty
+  private val __floaty: () -> List<Double>? = floaty
 
   @get:JvmName("getCount")
   public val count: List<Int>?
-    get() = _count.invoke()
+    get() = __count.invoke()
 
   @get:JvmName("getTruth")
   public val truth: List<Boolean>?
-    get() = _truth.invoke()
+    get() = __truth.invoke()
 
   @get:JvmName("getFloaty")
   public val floaty: List<Double>?
-    get() = _floaty.invoke()
+    get() = __floaty.invoke()
 
   public companion object {
     private val countDefault: () -> List<Int>? = 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithNonNullableProperties/expected/types/Person.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithNonNullableProperties/expected/types/Person.kt
@@ -16,17 +16,17 @@ public class Person(
   name: () -> String = nameDefault,
   email: () -> List<String> = emailDefault,
 ) {
-  private val _name: () -> String = name
+  private val __name: () -> String = name
 
-  private val _email: () -> List<String> = email
+  private val __email: () -> List<String> = email
 
   @get:JvmName("getName")
   public val name: String
-    get() = _name.invoke()
+    get() = __name.invoke()
 
   @get:JvmName("getEmail")
   public val email: List<String>
-    get() = _email.invoke()
+    get() = __email.invoke()
 
   public companion object {
     private val nameDefault: () -> String = 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithNonNullableProperties/expected/types/Query.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithNonNullableProperties/expected/types/Query.kt
@@ -14,11 +14,11 @@ import kotlin.jvm.JvmName
 public class Query(
   people: () -> List<Person>? = peopleDefault,
 ) {
-  private val _people: () -> List<Person>? = people
+  private val __people: () -> List<Person>? = people
 
   @get:JvmName("getPeople")
   public val people: List<Person>?
-    get() = _people.invoke()
+    get() = __people.invoke()
 
   public companion object {
     private val peopleDefault: () -> List<Person>? = 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithNullablePrimitive/expected/types/MyType.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithNullablePrimitive/expected/types/MyType.kt
@@ -18,23 +18,23 @@ public class MyType(
   truth: () -> Boolean? = truthDefault,
   floaty: () -> Double? = floatyDefault,
 ) {
-  private val _count: () -> Int? = count
+  private val __count: () -> Int? = count
 
-  private val _truth: () -> Boolean? = truth
+  private val __truth: () -> Boolean? = truth
 
-  private val _floaty: () -> Double? = floaty
+  private val __floaty: () -> Double? = floaty
 
   @get:JvmName("getCount")
   public val count: Int?
-    get() = _count.invoke()
+    get() = __count.invoke()
 
   @get:JvmName("getTruth")
   public val truth: Boolean?
-    get() = _truth.invoke()
+    get() = __truth.invoke()
 
   @get:JvmName("getFloaty")
   public val floaty: Double?
-    get() = _floaty.invoke()
+    get() = __floaty.invoke()
 
   public companion object {
     private val countDefault: () -> Int? = 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithRecursiveField/expected/types/Person.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithRecursiveField/expected/types/Person.kt
@@ -17,23 +17,23 @@ public class Person(
   lastname: () -> String? = lastnameDefault,
   friends: () -> List<Person?>? = friendsDefault,
 ) {
-  private val _firstname: () -> String? = firstname
+  private val __firstname: () -> String? = firstname
 
-  private val _lastname: () -> String? = lastname
+  private val __lastname: () -> String? = lastname
 
-  private val _friends: () -> List<Person?>? = friends
+  private val __friends: () -> List<Person?>? = friends
 
   @get:JvmName("getFirstname")
   public val firstname: String?
-    get() = _firstname.invoke()
+    get() = __firstname.invoke()
 
   @get:JvmName("getLastname")
   public val lastname: String?
-    get() = _lastname.invoke()
+    get() = __lastname.invoke()
 
   @get:JvmName("getFriends")
   public val friends: List<Person?>?
-    get() = _friends.invoke()
+    get() = __friends.invoke()
 
   public companion object {
     private val firstnameDefault: () -> String? = 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithRecursiveField/expected/types/Query.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithRecursiveField/expected/types/Query.kt
@@ -14,11 +14,11 @@ import kotlin.jvm.JvmName
 public class Query(
   people: () -> List<Person?>? = peopleDefault,
 ) {
-  private val _people: () -> List<Person?>? = people
+  private val __people: () -> List<Person?>? = people
 
   @get:JvmName("getPeople")
   public val people: List<Person?>?
-    get() = _people.invoke()
+    get() = __people.invoke()
 
   public companion object {
     private val peopleDefault: () -> List<Person?>? = 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithReservedWord/expected/types/SampleType.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithReservedWord/expected/types/SampleType.kt
@@ -14,11 +14,11 @@ import kotlin.jvm.JvmName
 public class SampleType(
   `return`: () -> String = returnDefault,
 ) {
-  private val _return: () -> String = `return`
+  private val __return: () -> String = `return`
 
   @get:JvmName("getReturn")
   public val `return`: String
-    get() = _return.invoke()
+    get() = __return.invoke()
 
   public companion object {
     private val returnDefault: () -> String = 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithStringProperties/expected/types/Person.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithStringProperties/expected/types/Person.kt
@@ -15,17 +15,17 @@ public class Person(
   firstname: () -> String? = firstnameDefault,
   lastname: () -> String? = lastnameDefault,
 ) {
-  private val _firstname: () -> String? = firstname
+  private val __firstname: () -> String? = firstname
 
-  private val _lastname: () -> String? = lastname
+  private val __lastname: () -> String? = lastname
 
   @get:JvmName("getFirstname")
   public val firstname: String?
-    get() = _firstname.invoke()
+    get() = __firstname.invoke()
 
   @get:JvmName("getLastname")
   public val lastname: String?
-    get() = _lastname.invoke()
+    get() = __lastname.invoke()
 
   public companion object {
     private val firstnameDefault: () -> String? = 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithStringProperties/expected/types/Query.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassWithStringProperties/expected/types/Query.kt
@@ -14,11 +14,11 @@ import kotlin.jvm.JvmName
 public class Query(
   people: () -> List<Person?>? = peopleDefault,
 ) {
-  private val _people: () -> List<Person?>? = people
+  private val __people: () -> List<Person?>? = people
 
   @get:JvmName("getPeople")
   public val people: List<Person?>?
-    get() = _people.invoke()
+    get() = __people.invoke()
 
   public companion object {
     private val peopleDefault: () -> List<Person?>? = 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/enum/expected/types/Query.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/enum/expected/types/Query.kt
@@ -14,11 +14,11 @@ import kotlin.jvm.JvmName
 public class Query(
   types: () -> List<EmployeeTypes?>? = typesDefault,
 ) {
-  private val _types: () -> List<EmployeeTypes?>? = types
+  private val __types: () -> List<EmployeeTypes?>? = types
 
   @get:JvmName("getTypes")
   public val types: List<EmployeeTypes?>?
-    get() = _types.invoke()
+    get() = __types.invoke()
 
   public companion object {
     private val typesDefault: () -> List<EmployeeTypes?>? = 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/enumWithExtendedType/expected/types/Query.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/enumWithExtendedType/expected/types/Query.kt
@@ -14,11 +14,11 @@ import kotlin.jvm.JvmName
 public class Query(
   types: () -> List<EmployeeTypes?>? = typesDefault,
 ) {
-  private val _types: () -> List<EmployeeTypes?>? = types
+  private val __types: () -> List<EmployeeTypes?>? = types
 
   @get:JvmName("getTypes")
   public val types: List<EmployeeTypes?>?
-    get() = _types.invoke()
+    get() = __types.invoke()
 
   public companion object {
     private val typesDefault: () -> List<EmployeeTypes?>? = 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/input/expected/types/Query.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/input/expected/types/Query.kt
@@ -15,11 +15,11 @@ import kotlin.jvm.JvmName
 public class Query(
   movies: () -> List<String?>? = moviesDefault,
 ) {
-  private val _movies: () -> List<String?>? = movies
+  private val __movies: () -> List<String?>? = movies
 
   @get:JvmName("getMovies")
   public val movies: List<String?>?
-    get() = _movies.invoke()
+    get() = __movies.invoke()
 
   public companion object {
     private val moviesDefault: () -> List<String?>? = 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/inputWithExtendedType/expected/types/Query.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/inputWithExtendedType/expected/types/Query.kt
@@ -15,11 +15,11 @@ import kotlin.jvm.JvmName
 public class Query(
   movies: () -> List<String?>? = moviesDefault,
 ) {
-  private val _movies: () -> List<String?>? = movies
+  private val __movies: () -> List<String?>? = movies
 
   @get:JvmName("getMovies")
   public val movies: List<String?>?
-    get() = _movies.invoke()
+    get() = __movies.invoke()
 
   public companion object {
     private val moviesDefault: () -> List<String?>? = 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/interfaceClassWithInterfaceFields/expected/types/Bird.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/interfaceClassWithInterfaceFields/expected/types/Bird.kt
@@ -21,47 +21,47 @@ public class Bird(
   father: () -> Bird? = fatherDefault,
   parents: () -> List<Bird?>? = parentsDefault,
 ) : Pet {
-  private val _id: () -> String = id
+  private val __id: () -> String = id
 
-  private val _name: () -> String? = name
+  private val __name: () -> String? = name
 
-  private val _address: () -> List<String> = address
+  private val __address: () -> List<String> = address
 
-  private val _mother: () -> Bird = mother
+  private val __mother: () -> Bird = mother
 
-  private val _father: () -> Bird? = father
+  private val __father: () -> Bird? = father
 
-  private val _parents: () -> List<Bird?>? = parents
+  private val __parents: () -> List<Bird?>? = parents
 
   @Suppress("INAPPLICABLE_JVM_NAME")
   @get:JvmName("getId")
   override val id: String
-    get() = _id.invoke()
+    get() = __id.invoke()
 
   @Suppress("INAPPLICABLE_JVM_NAME")
   @get:JvmName("getName")
   override val name: String?
-    get() = _name.invoke()
+    get() = __name.invoke()
 
   @Suppress("INAPPLICABLE_JVM_NAME")
   @get:JvmName("getAddress")
   override val address: List<String>
-    get() = _address.invoke()
+    get() = __address.invoke()
 
   @Suppress("INAPPLICABLE_JVM_NAME")
   @get:JvmName("getMother")
   override val mother: Bird
-    get() = _mother.invoke()
+    get() = __mother.invoke()
 
   @Suppress("INAPPLICABLE_JVM_NAME")
   @get:JvmName("getFather")
   override val father: Bird?
-    get() = _father.invoke()
+    get() = __father.invoke()
 
   @Suppress("INAPPLICABLE_JVM_NAME")
   @get:JvmName("getParents")
   override val parents: List<Bird?>?
-    get() = _parents.invoke()
+    get() = __parents.invoke()
 
   public companion object {
     private val idDefault: () -> String = 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/interfaceClassWithInterfaceFields/expected/types/Dog.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/interfaceClassWithInterfaceFields/expected/types/Dog.kt
@@ -21,47 +21,47 @@ public class Dog(
   father: () -> Dog? = fatherDefault,
   parents: () -> List<Dog?>? = parentsDefault,
 ) : Pet {
-  private val _id: () -> String = id
+  private val __id: () -> String = id
 
-  private val _name: () -> String? = name
+  private val __name: () -> String? = name
 
-  private val _address: () -> List<String> = address
+  private val __address: () -> List<String> = address
 
-  private val _mother: () -> Dog = mother
+  private val __mother: () -> Dog = mother
 
-  private val _father: () -> Dog? = father
+  private val __father: () -> Dog? = father
 
-  private val _parents: () -> List<Dog?>? = parents
+  private val __parents: () -> List<Dog?>? = parents
 
   @Suppress("INAPPLICABLE_JVM_NAME")
   @get:JvmName("getId")
   override val id: String
-    get() = _id.invoke()
+    get() = __id.invoke()
 
   @Suppress("INAPPLICABLE_JVM_NAME")
   @get:JvmName("getName")
   override val name: String?
-    get() = _name.invoke()
+    get() = __name.invoke()
 
   @Suppress("INAPPLICABLE_JVM_NAME")
   @get:JvmName("getAddress")
   override val address: List<String>
-    get() = _address.invoke()
+    get() = __address.invoke()
 
   @Suppress("INAPPLICABLE_JVM_NAME")
   @get:JvmName("getMother")
   override val mother: Dog
-    get() = _mother.invoke()
+    get() = __mother.invoke()
 
   @Suppress("INAPPLICABLE_JVM_NAME")
   @get:JvmName("getFather")
   override val father: Dog?
-    get() = _father.invoke()
+    get() = __father.invoke()
 
   @Suppress("INAPPLICABLE_JVM_NAME")
   @get:JvmName("getParents")
   override val parents: List<Dog?>?
-    get() = _parents.invoke()
+    get() = __parents.invoke()
 
   public companion object {
     private val idDefault: () -> String = 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/interfaceClassWithInterfaceFieldsOfDifferentType/expected/types/Dog.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/interfaceClassWithInterfaceFieldsOfDifferentType/expected/types/Dog.kt
@@ -16,19 +16,19 @@ public class Dog(
   name: () -> String? = nameDefault,
   diet: () -> Vegetarian? = dietDefault,
 ) : Pet {
-  private val _name: () -> String? = name
+  private val __name: () -> String? = name
 
-  private val _diet: () -> Vegetarian? = diet
+  private val __diet: () -> Vegetarian? = diet
 
   @Suppress("INAPPLICABLE_JVM_NAME")
   @get:JvmName("getName")
   override val name: String?
-    get() = _name.invoke()
+    get() = __name.invoke()
 
   @Suppress("INAPPLICABLE_JVM_NAME")
   @get:JvmName("getDiet")
   override val diet: Vegetarian?
-    get() = _diet.invoke()
+    get() = __diet.invoke()
 
   public companion object {
     private val nameDefault: () -> String? = 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/interfaceClassWithInterfaceFieldsOfDifferentType/expected/types/Vegetarian.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/interfaceClassWithInterfaceFieldsOfDifferentType/expected/types/Vegetarian.kt
@@ -17,18 +17,18 @@ public class Vegetarian(
   calories: () -> String? = caloriesDefault,
   vegetables: () -> List<String?>? = vegetablesDefault,
 ) : Diet {
-  private val _calories: () -> String? = calories
+  private val __calories: () -> String? = calories
 
-  private val _vegetables: () -> List<String?>? = vegetables
+  private val __vegetables: () -> List<String?>? = vegetables
 
   @Suppress("INAPPLICABLE_JVM_NAME")
   @get:JvmName("getCalories")
   override val calories: String?
-    get() = _calories.invoke()
+    get() = __calories.invoke()
 
   @get:JvmName("getVegetables")
   public val vegetables: List<String?>?
-    get() = _vegetables.invoke()
+    get() = __vegetables.invoke()
 
   public companion object {
     private val caloriesDefault: () -> String? = 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/interfaceClassWithNonNullableFields/expected/types/Employee.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/interfaceClassWithNonNullableFields/expected/types/Employee.kt
@@ -17,25 +17,25 @@ public class Employee(
   lastname: () -> String? = lastnameDefault,
   company: () -> String? = companyDefault,
 ) : Person {
-  private val _firstname: () -> String = firstname
+  private val __firstname: () -> String = firstname
 
-  private val _lastname: () -> String? = lastname
+  private val __lastname: () -> String? = lastname
 
-  private val _company: () -> String? = company
+  private val __company: () -> String? = company
 
   @Suppress("INAPPLICABLE_JVM_NAME")
   @get:JvmName("getFirstname")
   override val firstname: String
-    get() = _firstname.invoke()
+    get() = __firstname.invoke()
 
   @Suppress("INAPPLICABLE_JVM_NAME")
   @get:JvmName("getLastname")
   override val lastname: String?
-    get() = _lastname.invoke()
+    get() = __lastname.invoke()
 
   @get:JvmName("getCompany")
   public val company: String?
-    get() = _company.invoke()
+    get() = __company.invoke()
 
   public companion object {
     private val firstnameDefault: () -> String = 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/interfaceClassWithNonNullableFields/expected/types/Query.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/interfaceClassWithNonNullableFields/expected/types/Query.kt
@@ -14,11 +14,11 @@ import kotlin.jvm.JvmName
 public class Query(
   people: () -> List<Person?>? = peopleDefault,
 ) {
-  private val _people: () -> List<Person?>? = people
+  private val __people: () -> List<Person?>? = people
 
   @get:JvmName("getPeople")
   public val people: List<Person?>?
-    get() = _people.invoke()
+    get() = __people.invoke()
 
   public companion object {
     private val peopleDefault: () -> List<Person?>? = 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/interfaceWithInterfaceInheritance/expected/types/Query.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/interfaceWithInterfaceInheritance/expected/types/Query.kt
@@ -14,11 +14,11 @@ import kotlin.jvm.JvmName
 public class Query(
   fruits: () -> List<Fruit?>? = fruitsDefault,
 ) {
-  private val _fruits: () -> List<Fruit?>? = fruits
+  private val __fruits: () -> List<Fruit?>? = fruits
 
   @get:JvmName("getFruits")
   public val fruits: List<Fruit?>?
-    get() = _fruits.invoke()
+    get() = __fruits.invoke()
 
   public companion object {
     private val fruitsDefault: () -> List<Fruit?>? = 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/interfaceWithInterfaceInheritance/expected/types/Seed.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/interfaceWithInterfaceInheritance/expected/types/Seed.kt
@@ -14,11 +14,11 @@ import kotlin.jvm.JvmName
 public class Seed(
   name: () -> String? = nameDefault,
 ) {
-  private val _name: () -> String? = name
+  private val __name: () -> String? = name
 
   @get:JvmName("getName")
   public val name: String?
-    get() = _name.invoke()
+    get() = __name.invoke()
 
   public companion object {
     private val nameDefault: () -> String? = 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/interfaceWithUnderscoreFields/expected/DgsClient.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/interfaceWithUnderscoreFields/expected/DgsClient.kt
@@ -1,0 +1,11 @@
+package com.netflix.graphql.dgs.codegen.cases.interfaceWithUnderscoreFields.expected
+
+import com.netflix.graphql.dgs.codegen.GraphQLProjection
+import com.netflix.graphql.dgs.codegen.cases.interfaceWithUnderscoreFields.expected.client.QueryProjection
+import graphql.language.OperationDefinition
+import kotlin.String
+
+public object DgsClient {
+  public fun buildQuery(_projection: QueryProjection.() -> QueryProjection): String =
+      GraphQLProjection.asQuery(OperationDefinition.Operation.QUERY, QueryProjection(), _projection)
+}

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/interfaceWithUnderscoreFields/expected/DgsConstants.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/interfaceWithUnderscoreFields/expected/DgsConstants.kt
@@ -1,0 +1,27 @@
+package com.netflix.graphql.dgs.codegen.cases.interfaceWithUnderscoreFields.expected
+
+import kotlin.String
+
+public object DgsConstants {
+  public const val QUERY_TYPE: String = "Query"
+
+  public object QUERY {
+    public const val TYPE_NAME: String = "Query"
+
+    public const val Is: String = "is"
+  }
+
+  public object T {
+    public const val TYPE_NAME: String = "T"
+
+    public const val _id: String = "_id"
+
+    public const val Id: String = "id"
+  }
+
+  public object I {
+    public const val TYPE_NAME: String = "I"
+
+    public const val _id: String = "_id"
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/interfaceWithUnderscoreFields/expected/client/IProjection.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/interfaceWithUnderscoreFields/expected/client/IProjection.kt
@@ -1,0 +1,16 @@
+package com.netflix.graphql.dgs.codegen.cases.interfaceWithUnderscoreFields.expected.client
+
+import com.netflix.graphql.dgs.codegen.GraphQLProjection
+
+public class IProjection : GraphQLProjection() {
+  public val _id: IProjection
+    get() {
+      field("_id")
+      return this
+    }
+
+  public fun onT(_projection: TProjection.() -> TProjection): IProjection {
+    fragment("T", TProjection(), _projection)
+    return this
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/interfaceWithUnderscoreFields/expected/client/QueryProjection.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/interfaceWithUnderscoreFields/expected/client/QueryProjection.kt
@@ -1,0 +1,10 @@
+package com.netflix.graphql.dgs.codegen.cases.interfaceWithUnderscoreFields.expected.client
+
+import com.netflix.graphql.dgs.codegen.GraphQLProjection
+
+public class QueryProjection : GraphQLProjection() {
+  public fun `is`(_projection: IProjection.() -> IProjection): QueryProjection {
+    field("is", IProjection(), _projection)
+    return this
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/interfaceWithUnderscoreFields/expected/client/TProjection.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/interfaceWithUnderscoreFields/expected/client/TProjection.kt
@@ -1,0 +1,17 @@
+package com.netflix.graphql.dgs.codegen.cases.interfaceWithUnderscoreFields.expected.client
+
+import com.netflix.graphql.dgs.codegen.GraphQLProjection
+
+public class TProjection : GraphQLProjection() {
+  public val _id: TProjection
+    get() {
+      field("_id")
+      return this
+    }
+
+  public val id: TProjection
+    get() {
+      field("id")
+      return this
+    }
+}

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/interfaceWithUnderscoreFields/expected/types/I.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/interfaceWithUnderscoreFields/expected/types/I.kt
@@ -1,0 +1,21 @@
+package com.netflix.graphql.dgs.codegen.cases.interfaceWithUnderscoreFields.expected.types
+
+import com.fasterxml.jackson.`annotation`.JsonSubTypes
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlin.String
+import kotlin.Suppress
+import kotlin.jvm.JvmName
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "__typename",
+)
+@JsonSubTypes(value = [
+  JsonSubTypes.Type(value = T::class, name = "T")
+])
+public sealed interface I {
+  @Suppress("INAPPLICABLE_JVM_NAME")
+  @get:JvmName("get_id")
+  public val _id: String?
+}

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/interfaceWithUnderscoreFields/expected/types/Query.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/interfaceWithUnderscoreFields/expected/types/Query.kt
@@ -1,0 +1,43 @@
+package com.netflix.graphql.dgs.codegen.cases.interfaceWithUnderscoreFields.expected.types
+
+import com.fasterxml.jackson.`annotation`.JsonIgnoreProperties
+import com.fasterxml.jackson.`annotation`.JsonProperty
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import com.fasterxml.jackson.databind.`annotation`.JsonDeserialize
+import com.fasterxml.jackson.databind.`annotation`.JsonPOJOBuilder
+import java.lang.IllegalStateException
+import kotlin.collections.List
+import kotlin.jvm.JvmName
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
+@JsonDeserialize(builder = Query.Builder::class)
+public class Query(
+  `is`: () -> List<I?>? = isDefault,
+) {
+  private val __is: () -> List<I?>? = `is`
+
+  @get:JvmName("getIs")
+  public val `is`: List<I?>?
+    get() = __is.invoke()
+
+  public companion object {
+    private val isDefault: () -> List<I?>? = 
+        { throw IllegalStateException("Field `is` was not requested") }
+
+  }
+
+  @JsonPOJOBuilder
+  @JsonIgnoreProperties("__typename")
+  public class Builder {
+    private var `is`: () -> List<I?>? = isDefault
+
+    @JsonProperty("is")
+    public fun withIs(`is`: List<I?>?): Builder = this.apply {
+      this.`is` = { `is` }
+    }
+
+    public fun build(): Query = Query(
+      `is` = `is`,
+    )
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/interfaceWithUnderscoreFields/expected/types/T.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/interfaceWithUnderscoreFields/expected/types/T.kt
@@ -1,0 +1,64 @@
+package com.netflix.graphql.dgs.codegen.cases.interfaceWithUnderscoreFields.expected.types
+
+import com.fasterxml.jackson.`annotation`.JsonIgnoreProperties
+import com.fasterxml.jackson.`annotation`.JsonProperty
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import com.fasterxml.jackson.databind.`annotation`.JsonDeserialize
+import com.fasterxml.jackson.databind.`annotation`.JsonPOJOBuilder
+import java.lang.IllegalStateException
+import kotlin.String
+import kotlin.Suppress
+import kotlin.jvm.JvmName
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
+@JsonDeserialize(builder = T.Builder::class)
+public class T(
+  _id: () -> String? = _idDefault,
+  id: () -> String? = idDefault,
+) : I {
+  private val ___id: () -> String? = _id
+
+  private val __id: () -> String? = id
+
+  @Suppress("INAPPLICABLE_JVM_NAME")
+  @get:JvmName("get_id")
+  override val _id: String?
+    get() = ___id.invoke()
+
+  @get:JvmName("getId")
+  public val id: String?
+    get() = __id.invoke()
+
+  public companion object {
+    private val _idDefault: () -> String? = 
+        { throw IllegalStateException("Field `_id` was not requested") }
+
+
+    private val idDefault: () -> String? = 
+        { throw IllegalStateException("Field `id` was not requested") }
+
+  }
+
+  @JsonPOJOBuilder
+  @JsonIgnoreProperties("__typename")
+  public class Builder {
+    private var _id: () -> String? = _idDefault
+
+    private var id: () -> String? = idDefault
+
+    @JsonProperty("_id")
+    public fun with_id(_id: String?): Builder = this.apply {
+      this._id = { _id }
+    }
+
+    @JsonProperty("id")
+    public fun withId(id: String?): Builder = this.apply {
+      this.id = { id }
+    }
+
+    public fun build(): T = T(
+      _id = _id,
+      id = id,
+    )
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/interfaceWithUnderscoreFields/schema.graphql
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/interfaceWithUnderscoreFields/schema.graphql
@@ -1,0 +1,12 @@
+type Query {
+  is: [I]
+}
+
+interface I {
+  _id: ID
+}
+
+type T implements I {
+  _id: ID
+  id: ID
+}

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/projectionWithEnum/expected/types/Query.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/projectionWithEnum/expected/types/Query.kt
@@ -15,17 +15,17 @@ public class Query(
   e: () -> E? = eDefault,
   es: () -> List<E?>? = esDefault,
 ) {
-  private val _e: () -> E? = e
+  private val __e: () -> E? = e
 
-  private val _es: () -> List<E?>? = es
+  private val __es: () -> List<E?>? = es
 
   @get:JvmName("getE")
   public val e: E?
-    get() = _e.invoke()
+    get() = __e.invoke()
 
   @get:JvmName("getEs")
   public val es: List<E?>?
-    get() = _es.invoke()
+    get() = __es.invoke()
 
   public companion object {
     private val eDefault: () -> E? = 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/projectionWithNestedInputs/expected/types/Query.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/projectionWithNestedInputs/expected/types/Query.kt
@@ -15,17 +15,17 @@ public class Query(
   q1: () -> String? = q1Default,
   q2: () -> String? = q2Default,
 ) {
-  private val _q1: () -> String? = q1
+  private val __q1: () -> String? = q1
 
-  private val _q2: () -> String? = q2
+  private val __q2: () -> String? = q2
 
   @get:JvmName("getQ1")
   public val q1: String?
-    get() = _q1.invoke()
+    get() = __q1.invoke()
 
   @get:JvmName("getQ2")
   public val q2: String?
-    get() = _q2.invoke()
+    get() = __q2.invoke()
 
   public companion object {
     private val q1Default: () -> String? = 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/projectionWithPrimitiveAndArgs/expected/types/Query.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/projectionWithPrimitiveAndArgs/expected/types/Query.kt
@@ -14,11 +14,11 @@ import kotlin.jvm.JvmName
 public class Query(
   string: () -> String? = stringDefault,
 ) {
-  private val _string: () -> String? = string
+  private val __string: () -> String? = string
 
   @get:JvmName("getString")
   public val string: String?
-    get() = _string.invoke()
+    get() = __string.invoke()
 
   public companion object {
     private val stringDefault: () -> String? = 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/projectionWithPrimitives/expected/types/Query.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/projectionWithPrimitives/expected/types/Query.kt
@@ -16,17 +16,17 @@ public class Query(
   string: () -> String? = stringDefault,
   strings: () -> List<String?>? = stringsDefault,
 ) {
-  private val _string: () -> String? = string
+  private val __string: () -> String? = string
 
-  private val _strings: () -> List<String?>? = strings
+  private val __strings: () -> List<String?>? = strings
 
   @get:JvmName("getString")
   public val string: String?
-    get() = _string.invoke()
+    get() = __string.invoke()
 
   @get:JvmName("getStrings")
   public val strings: List<String?>?
-    get() = _strings.invoke()
+    get() = __strings.invoke()
 
   public companion object {
     private val stringDefault: () -> String? = 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/projectionWithType/expected/types/Employee.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/projectionWithType/expected/types/Employee.kt
@@ -16,18 +16,18 @@ public class Employee(
   firstname: () -> String? = firstnameDefault,
   company: () -> String? = companyDefault,
 ) : Person {
-  private val _firstname: () -> String? = firstname
+  private val __firstname: () -> String? = firstname
 
-  private val _company: () -> String? = company
+  private val __company: () -> String? = company
 
   @Suppress("INAPPLICABLE_JVM_NAME")
   @get:JvmName("getFirstname")
   override val firstname: String?
-    get() = _firstname.invoke()
+    get() = __firstname.invoke()
 
   @get:JvmName("getCompany")
   public val company: String?
-    get() = _company.invoke()
+    get() = __company.invoke()
 
   public companion object {
     private val firstnameDefault: () -> String? = 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/projectionWithType/expected/types/Query.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/projectionWithType/expected/types/Query.kt
@@ -15,17 +15,17 @@ public class Query(
   person: () -> Person? = personDefault,
   people: () -> List<Person?>? = peopleDefault,
 ) {
-  private val _person: () -> Person? = person
+  private val __person: () -> Person? = person
 
-  private val _people: () -> List<Person?>? = people
+  private val __people: () -> List<Person?>? = people
 
   @get:JvmName("getPerson")
   public val person: Person?
-    get() = _person.invoke()
+    get() = __person.invoke()
 
   @get:JvmName("getPeople")
   public val people: List<Person?>?
-    get() = _people.invoke()
+    get() = __people.invoke()
 
   public companion object {
     private val personDefault: () -> Person? = 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/projectionWithTypeAndArgs/expected/types/Employee.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/projectionWithTypeAndArgs/expected/types/Employee.kt
@@ -16,18 +16,18 @@ public class Employee(
   firstname: () -> String? = firstnameDefault,
   company: () -> String? = companyDefault,
 ) : Person {
-  private val _firstname: () -> String? = firstname
+  private val __firstname: () -> String? = firstname
 
-  private val _company: () -> String? = company
+  private val __company: () -> String? = company
 
   @Suppress("INAPPLICABLE_JVM_NAME")
   @get:JvmName("getFirstname")
   override val firstname: String?
-    get() = _firstname.invoke()
+    get() = __firstname.invoke()
 
   @get:JvmName("getCompany")
   public val company: String?
-    get() = _company.invoke()
+    get() = __company.invoke()
 
   public companion object {
     private val firstnameDefault: () -> String? = 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/projectionWithTypeAndArgs/expected/types/Query.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/projectionWithTypeAndArgs/expected/types/Query.kt
@@ -13,11 +13,11 @@ import kotlin.jvm.JvmName
 public class Query(
   person: () -> Person? = personDefault,
 ) {
-  private val _person: () -> Person? = person
+  private val __person: () -> Person? = person
 
   @get:JvmName("getPerson")
   public val person: Person?
-    get() = _person.invoke()
+    get() = __person.invoke()
 
   public companion object {
     private val personDefault: () -> Person? = 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/projectionWithUnion/expected/types/Employee.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/projectionWithUnion/expected/types/Employee.kt
@@ -16,18 +16,18 @@ public class Employee(
   firstname: () -> String? = firstnameDefault,
   company: () -> String? = companyDefault,
 ) : Person, U {
-  private val _firstname: () -> String? = firstname
+  private val __firstname: () -> String? = firstname
 
-  private val _company: () -> String? = company
+  private val __company: () -> String? = company
 
   @Suppress("INAPPLICABLE_JVM_NAME")
   @get:JvmName("getFirstname")
   override val firstname: String?
-    get() = _firstname.invoke()
+    get() = __firstname.invoke()
 
   @get:JvmName("getCompany")
   public val company: String?
-    get() = _company.invoke()
+    get() = __company.invoke()
 
   public companion object {
     private val firstnameDefault: () -> String? = 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/projectionWithUnion/expected/types/Query.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/projectionWithUnion/expected/types/Query.kt
@@ -15,17 +15,17 @@ public class Query(
   u: () -> U? = uDefault,
   us: () -> List<U?>? = usDefault,
 ) {
-  private val _u: () -> U? = u
+  private val __u: () -> U? = u
 
-  private val _us: () -> List<U?>? = us
+  private val __us: () -> List<U?>? = us
 
   @get:JvmName("getU")
   public val u: U?
-    get() = _u.invoke()
+    get() = __u.invoke()
 
   @get:JvmName("getUs")
   public val us: List<U?>?
-    get() = _us.invoke()
+    get() = __us.invoke()
 
   public companion object {
     private val uDefault: () -> U? = 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/skipCodegenOnFields/expected/types/Person.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/skipCodegenOnFields/expected/types/Person.kt
@@ -14,11 +14,11 @@ import kotlin.jvm.JvmName
 public class Person(
   name: () -> String? = nameDefault,
 ) {
-  private val _name: () -> String? = name
+  private val __name: () -> String? = name
 
   @get:JvmName("getName")
   public val name: String?
-    get() = _name.invoke()
+    get() = __name.invoke()
 
   public companion object {
     private val nameDefault: () -> String? = 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/skipCodegenOnTypes/expected/types/Person.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/skipCodegenOnTypes/expected/types/Person.kt
@@ -14,11 +14,11 @@ import kotlin.jvm.JvmName
 public class Person(
   name: () -> String? = nameDefault,
 ) {
-  private val _name: () -> String? = name
+  private val __name: () -> String? = name
 
   @get:JvmName("getName")
   public val name: String?
-    get() = _name.invoke()
+    get() = __name.invoke()
 
   public companion object {
     private val nameDefault: () -> String? = 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/union/expected/types/Actor.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/union/expected/types/Actor.kt
@@ -14,11 +14,11 @@ import kotlin.jvm.JvmName
 public class Actor(
   name: () -> String? = nameDefault,
 ) : SearchResult {
-  private val _name: () -> String? = name
+  private val __name: () -> String? = name
 
   @get:JvmName("getName")
   public val name: String?
-    get() = _name.invoke()
+    get() = __name.invoke()
 
   public companion object {
     private val nameDefault: () -> String? = 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/union/expected/types/Movie.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/union/expected/types/Movie.kt
@@ -14,11 +14,11 @@ import kotlin.jvm.JvmName
 public class Movie(
   title: () -> String? = titleDefault,
 ) : SearchResult {
-  private val _title: () -> String? = title
+  private val __title: () -> String? = title
 
   @get:JvmName("getTitle")
   public val title: String?
-    get() = _title.invoke()
+    get() = __title.invoke()
 
   public companion object {
     private val titleDefault: () -> String? = 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/union/expected/types/Query.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/union/expected/types/Query.kt
@@ -14,11 +14,11 @@ import kotlin.jvm.JvmName
 public class Query(
   search: () -> List<SearchResult?>? = searchDefault,
 ) {
-  private val _search: () -> List<SearchResult?>? = search
+  private val __search: () -> List<SearchResult?>? = search
 
   @get:JvmName("getSearch")
   public val search: List<SearchResult?>?
-    get() = _search.invoke()
+    get() = __search.invoke()
 
   public companion object {
     private val searchDefault: () -> List<SearchResult?>? = 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/unionTypesWithoutInterfaceCanDeserialize/expected/types/Droid.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/unionTypesWithoutInterfaceCanDeserialize/expected/types/Droid.kt
@@ -16,23 +16,23 @@ public class Droid(
   name: () -> String = nameDefault,
   primaryFunction: () -> String? = primaryFunctionDefault,
 ) : SearchResult {
-  private val _id: () -> String = id
+  private val __id: () -> String = id
 
-  private val _name: () -> String = name
+  private val __name: () -> String = name
 
-  private val _primaryFunction: () -> String? = primaryFunction
+  private val __primaryFunction: () -> String? = primaryFunction
 
   @get:JvmName("getId")
   public val id: String
-    get() = _id.invoke()
+    get() = __id.invoke()
 
   @get:JvmName("getName")
   public val name: String
-    get() = _name.invoke()
+    get() = __name.invoke()
 
   @get:JvmName("getPrimaryFunction")
   public val primaryFunction: String?
-    get() = _primaryFunction.invoke()
+    get() = __primaryFunction.invoke()
 
   public companion object {
     private val idDefault: () -> String = 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/unionTypesWithoutInterfaceCanDeserialize/expected/types/Human.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/unionTypesWithoutInterfaceCanDeserialize/expected/types/Human.kt
@@ -17,23 +17,23 @@ public class Human(
   name: () -> String = nameDefault,
   totalCredits: () -> Int? = totalCreditsDefault,
 ) : SearchResult {
-  private val _id: () -> String = id
+  private val __id: () -> String = id
 
-  private val _name: () -> String = name
+  private val __name: () -> String = name
 
-  private val _totalCredits: () -> Int? = totalCredits
+  private val __totalCredits: () -> Int? = totalCredits
 
   @get:JvmName("getId")
   public val id: String
-    get() = _id.invoke()
+    get() = __id.invoke()
 
   @get:JvmName("getName")
   public val name: String
-    get() = _name.invoke()
+    get() = __name.invoke()
 
   @get:JvmName("getTotalCredits")
   public val totalCredits: Int?
-    get() = _totalCredits.invoke()
+    get() = __totalCredits.invoke()
 
   public companion object {
     private val idDefault: () -> String = 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/unionTypesWithoutInterfaceCanDeserialize/expected/types/Query.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/unionTypesWithoutInterfaceCanDeserialize/expected/types/Query.kt
@@ -13,11 +13,11 @@ import kotlin.jvm.JvmName
 public class Query(
   search: () -> SearchResultPage? = searchDefault,
 ) {
-  private val _search: () -> SearchResultPage? = search
+  private val __search: () -> SearchResultPage? = search
 
   @get:JvmName("getSearch")
   public val search: SearchResultPage?
-    get() = _search.invoke()
+    get() = __search.invoke()
 
   public companion object {
     private val searchDefault: () -> SearchResultPage? = 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/unionTypesWithoutInterfaceCanDeserialize/expected/types/SearchResultPage.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/unionTypesWithoutInterfaceCanDeserialize/expected/types/SearchResultPage.kt
@@ -14,11 +14,11 @@ import kotlin.jvm.JvmName
 public class SearchResultPage(
   items: () -> List<SearchResult?>? = itemsDefault,
 ) {
-  private val _items: () -> List<SearchResult?>? = items
+  private val __items: () -> List<SearchResult?>? = items
 
   @get:JvmName("getItems")
   public val items: List<SearchResult?>?
-    get() = _items.invoke()
+    get() = __items.invoke()
 
   public companion object {
     private val itemsDefault: () -> List<SearchResult?>? = 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/unionWithExtendedType/expected/types/Actor.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/unionWithExtendedType/expected/types/Actor.kt
@@ -14,11 +14,11 @@ import kotlin.jvm.JvmName
 public class Actor(
   name: () -> String? = nameDefault,
 ) : SearchResult {
-  private val _name: () -> String? = name
+  private val __name: () -> String? = name
 
   @get:JvmName("getName")
   public val name: String?
-    get() = _name.invoke()
+    get() = __name.invoke()
 
   public companion object {
     private val nameDefault: () -> String? = 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/unionWithExtendedType/expected/types/Movie.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/unionWithExtendedType/expected/types/Movie.kt
@@ -14,11 +14,11 @@ import kotlin.jvm.JvmName
 public class Movie(
   title: () -> String? = titleDefault,
 ) : SearchResult {
-  private val _title: () -> String? = title
+  private val __title: () -> String? = title
 
   @get:JvmName("getTitle")
   public val title: String?
-    get() = _title.invoke()
+    get() = __title.invoke()
 
   public companion object {
     private val titleDefault: () -> String? = 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/unionWithExtendedType/expected/types/Query.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/unionWithExtendedType/expected/types/Query.kt
@@ -14,11 +14,11 @@ import kotlin.jvm.JvmName
 public class Query(
   search: () -> List<SearchResult?>? = searchDefault,
 ) {
-  private val _search: () -> List<SearchResult?>? = search
+  private val __search: () -> List<SearchResult?>? = search
 
   @get:JvmName("getSearch")
   public val search: List<SearchResult?>?
-    get() = _search.invoke()
+    get() = __search.invoke()
 
   public companion object {
     private val searchDefault: () -> List<SearchResult?>? = 

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/unionWithExtendedType/expected/types/Rating.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/unionWithExtendedType/expected/types/Rating.kt
@@ -14,11 +14,11 @@ import kotlin.jvm.JvmName
 public class Rating(
   stars: () -> Int? = starsDefault,
 ) : SearchResult {
-  private val _stars: () -> Int? = stars
+  private val __stars: () -> Int? = stars
 
   @get:JvmName("getStars")
   public val stars: Int?
-    get() = _stars.invoke()
+    get() = __stars.invoke()
 
   public companion object {
     private val starsDefault: () -> Int? = 

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin2/GenerateKotlin2DataTypes.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin2/GenerateKotlin2DataTypes.kt
@@ -213,7 +213,7 @@ fun generateKotlin2DataTypes(
                 .addProperties(
                     fields.map { field ->
                         PropertySpec.builder(
-                            name = "_${field.name}",
+                            name = "__${field.name}",
                             type = LambdaTypeName.get(returnType = type(field))
                         )
                             .addModifiers(KModifier.PRIVATE)
@@ -242,7 +242,7 @@ fun generateKotlin2DataTypes(
                             .addAnnotation(jvmNameAnnotation(field.name))
                             .getter(
                                 FunSpec.getterBuilder()
-                                    .addStatement("return _${field.name}.invoke()")
+                                    .addStatement("return __${field.name}.invoke()")
                                     .build()
                             )
                             .build()


### PR DESCRIPTION
A single underscore can collide when an interface declares a field of the same name with a single underscore.