### PR TITLE
Use concrete types for JsonSubType annotations on interfaces if available

### DIFF
--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/InterfaceGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/InterfaceGenerator.kt
@@ -89,13 +89,13 @@ class InterfaceGenerator(private val config: CodeGenConfig, private val document
         val implementations = document.getDefinitionsOfType(ObjectTypeDefinition::class.java).asSequence()
             .filter { node -> node.implements.any { it.isEqualTo(TypeName(definition.name)) } }
             .map { node ->
-                val nodeName = if (config.generateInterfaces) "I${node.name}" else node.name
-                typeUtils.findJavaInterfaceName(nodeName, packageName)
+                typeUtils.findJavaInterfaceName(node.name, packageName)
             }
             .filterIsInstance<ClassName>()
             .toList()
 
-        if (implementations.isNotEmpty()) {
+        // Add JsonSubType annotations only if there are no generated concrete types that implement the interface
+        if (implementations.isNotEmpty() && config.generateDataTypes) {
             javaType.addAnnotation(jsonTypeInfoAnnotation())
             javaType.addAnnotation(jsonSubTypeAnnotation(implementations))
         }


### PR DESCRIPTION
This fixes a bug when interface for schema types are generated along with the `generateInterfaces = true` for data types. As a result, the interfaces generated for data types are used in the JsonSubType annotations which do not deserialize due to lack of constructor.

```
            interface Fruit {
              seeds: [Seed]
            }

            type Apple implements Fruit {
              seeds: [Seed]
              truth: Boolean!
            }

            type Seed {
              shape: String
            }
```
The above schema before the fix would produce 3 interfaces - IFruit, IApple and ISeed when generateInterfaces = true. 
IFruit has the JsonSubTypes set to IApple and ISeed interface classes instead of Apple and Seed which are the concrete types.

Because of this issue, jackson cannot properly deserialize into the interface type IFruit. After the fix, the annotations are now:
```
@JsonTypeInfo(
    use = JsonTypeInfo.Id.NAME,
    include = JsonTypeInfo.As.PROPERTY,
    property = "__typename"
)
@JsonSubTypes(@JsonSubTypes.Type(value = Apple.class, name = "Apple"))
public interface Fruit {
  List<? extends ISeed> getSeeds();

  void setSeeds(List<? extends ISeed> seeds);
}
```

Note the value is set to `Apple.class` instead of `IApple.class`