### PR TITLE
feat: annotate kotlin input type to enable deserialization

### DIFF
--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/constantsForInputTypes/expected/types/PersonFilter.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/constantsForInputTypes/expected/types/PersonFilter.kt
@@ -1,12 +1,15 @@
 package com.netflix.graphql.dgs.codegen.cases.constantsForInputTypes.expected.types
 
+import com.fasterxml.jackson.`annotation`.JsonCreator
+import com.fasterxml.jackson.`annotation`.JsonProperty
 import com.netflix.graphql.dgs.codegen.GraphQLInput
 import kotlin.Any
 import kotlin.Pair
 import kotlin.String
 import kotlin.collections.List
 
-public class PersonFilter(
+public class PersonFilter @JsonCreator constructor(
+  @JsonProperty("email")
   public val email: String? = default<PersonFilter, String?>("email"),
 ) : GraphQLInput() {
   override fun fields(): List<Pair<String, Any?>> = listOf("email" to email)

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/constantsWithExtendedInputTypes/expected/types/PersonFilter.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/constantsWithExtendedInputTypes/expected/types/PersonFilter.kt
@@ -1,5 +1,7 @@
 package com.netflix.graphql.dgs.codegen.cases.constantsWithExtendedInputTypes.expected.types
 
+import com.fasterxml.jackson.`annotation`.JsonCreator
+import com.fasterxml.jackson.`annotation`.JsonProperty
 import com.netflix.graphql.dgs.codegen.GraphQLInput
 import kotlin.Any
 import kotlin.Int
@@ -7,8 +9,10 @@ import kotlin.Pair
 import kotlin.String
 import kotlin.collections.List
 
-public class PersonFilter(
+public class PersonFilter @JsonCreator constructor(
+  @JsonProperty("email")
   public val email: String? = default<PersonFilter, String?>("email"),
+  @JsonProperty("birthYear")
   public val birthYear: Int? = default<PersonFilter, Int?>("birthYear"),
 ) : GraphQLInput() {
   override fun fields(): List<Pair<String, Any?>> = listOf("email" to email, "birthYear" to

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassDocs/expected/types/MovieFilter.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassDocs/expected/types/MovieFilter.kt
@@ -1,5 +1,7 @@
 package com.netflix.graphql.dgs.codegen.cases.dataClassDocs.expected.types
 
+import com.fasterxml.jackson.`annotation`.JsonCreator
+import com.fasterxml.jackson.`annotation`.JsonProperty
 import com.netflix.graphql.dgs.codegen.GraphQLInput
 import kotlin.Any
 import kotlin.Pair
@@ -11,7 +13,8 @@ import kotlin.collections.List
  *
  * It takes a title and such.
  */
-public class MovieFilter(
+public class MovieFilter @JsonCreator constructor(
+  @JsonProperty("titleFilter")
   public val titleFilter: String? = default<MovieFilter, String?>("titleFilter"),
 ) : GraphQLInput() {
   override fun fields(): List<Pair<String, Any?>> = listOf("titleFilter" to titleFilter)

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassFieldDocs/expected/types/MovieFilter.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassFieldDocs/expected/types/MovieFilter.kt
@@ -1,12 +1,15 @@
 package com.netflix.graphql.dgs.codegen.cases.dataClassFieldDocs.expected.types
 
+import com.fasterxml.jackson.`annotation`.JsonCreator
+import com.fasterxml.jackson.`annotation`.JsonProperty
 import com.netflix.graphql.dgs.codegen.GraphQLInput
 import kotlin.Any
 import kotlin.Pair
 import kotlin.String
 import kotlin.collections.List
 
-public class MovieFilter(
+public class MovieFilter @JsonCreator constructor(
+  @JsonProperty("titleFilter")
   public val titleFilter: String? = default<MovieFilter, String?>("titleFilter"),
 ) : GraphQLInput() {
   override fun fields(): List<Pair<String, Any?>> = listOf("titleFilter" to titleFilter)

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/input/expected/types/MovieFilter.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/input/expected/types/MovieFilter.kt
@@ -1,12 +1,15 @@
 package com.netflix.graphql.dgs.codegen.cases.input.expected.types
 
+import com.fasterxml.jackson.`annotation`.JsonCreator
+import com.fasterxml.jackson.`annotation`.JsonProperty
 import com.netflix.graphql.dgs.codegen.GraphQLInput
 import kotlin.Any
 import kotlin.Pair
 import kotlin.String
 import kotlin.collections.List
 
-public class MovieFilter(
+public class MovieFilter @JsonCreator constructor(
+  @JsonProperty("genre")
   public val genre: String? = default<MovieFilter, String?>("genre"),
 ) : GraphQLInput() {
   override fun fields(): List<Pair<String, Any?>> = listOf("genre" to genre)

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/inputWithDefaultEnumValueForArray/expected/types/SomeType.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/inputWithDefaultEnumValueForArray/expected/types/SomeType.kt
@@ -1,12 +1,15 @@
 package com.netflix.graphql.dgs.codegen.cases.inputWithDefaultEnumValueForArray.expected.types
 
+import com.fasterxml.jackson.`annotation`.JsonCreator
+import com.fasterxml.jackson.`annotation`.JsonProperty
 import com.netflix.graphql.dgs.codegen.GraphQLInput
 import kotlin.Any
 import kotlin.Pair
 import kotlin.String
 import kotlin.collections.List
 
-public class SomeType(
+public class SomeType @JsonCreator constructor(
+  @JsonProperty("colors")
   public val colors: List<Color?>? = default<SomeType, List<Color?>?>("colors"),
 ) : GraphQLInput() {
   override fun fields(): List<Pair<String, Any?>> = listOf("colors" to colors)

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/inputWithDefaultIntValueForArray/expected/types/SomeType.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/inputWithDefaultIntValueForArray/expected/types/SomeType.kt
@@ -1,5 +1,7 @@
 package com.netflix.graphql.dgs.codegen.cases.inputWithDefaultIntValueForArray.expected.types
 
+import com.fasterxml.jackson.`annotation`.JsonCreator
+import com.fasterxml.jackson.`annotation`.JsonProperty
 import com.netflix.graphql.dgs.codegen.GraphQLInput
 import kotlin.Any
 import kotlin.Int
@@ -7,7 +9,8 @@ import kotlin.Pair
 import kotlin.String
 import kotlin.collections.List
 
-public class SomeType(
+public class SomeType @JsonCreator constructor(
+  @JsonProperty("numbers")
   public val numbers: List<Int?>? = default<SomeType, List<Int?>?>("numbers"),
 ) : GraphQLInput() {
   override fun fields(): List<Pair<String, Any?>> = listOf("numbers" to numbers)

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/inputWithDefaultStringValueForArray/expected/types/SomeType.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/inputWithDefaultStringValueForArray/expected/types/SomeType.kt
@@ -1,12 +1,15 @@
 package com.netflix.graphql.dgs.codegen.cases.inputWithDefaultStringValueForArray.expected.types
 
+import com.fasterxml.jackson.`annotation`.JsonCreator
+import com.fasterxml.jackson.`annotation`.JsonProperty
 import com.netflix.graphql.dgs.codegen.GraphQLInput
 import kotlin.Any
 import kotlin.Pair
 import kotlin.String
 import kotlin.collections.List
 
-public class SomeType(
+public class SomeType @JsonCreator constructor(
+  @JsonProperty("names")
   public val names: List<String?>? = default<SomeType, List<String?>?>("names"),
 ) : GraphQLInput() {
   override fun fields(): List<Pair<String, Any?>> = listOf("names" to names)

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/inputWithDefaultValueForArray/expected/types/SomeType.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/inputWithDefaultValueForArray/expected/types/SomeType.kt
@@ -1,12 +1,15 @@
 package com.netflix.graphql.dgs.codegen.cases.inputWithDefaultValueForArray.expected.types
 
+import com.fasterxml.jackson.`annotation`.JsonCreator
+import com.fasterxml.jackson.`annotation`.JsonProperty
 import com.netflix.graphql.dgs.codegen.GraphQLInput
 import kotlin.Any
 import kotlin.Pair
 import kotlin.String
 import kotlin.collections.List
 
-public class SomeType(
+public class SomeType @JsonCreator constructor(
+  @JsonProperty("names")
   public val names: List<String?>? = default<SomeType, List<String?>?>("names"),
 ) : GraphQLInput() {
   override fun fields(): List<Pair<String, Any?>> = listOf("names" to names)

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/inputWithDefaultValueForEnum/expected/types/ColorFilter.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/inputWithDefaultValueForEnum/expected/types/ColorFilter.kt
@@ -1,12 +1,15 @@
 package com.netflix.graphql.dgs.codegen.cases.inputWithDefaultValueForEnum.expected.types
 
+import com.fasterxml.jackson.`annotation`.JsonCreator
+import com.fasterxml.jackson.`annotation`.JsonProperty
 import com.netflix.graphql.dgs.codegen.GraphQLInput
 import kotlin.Any
 import kotlin.Pair
 import kotlin.String
 import kotlin.collections.List
 
-public class ColorFilter(
+public class ColorFilter @JsonCreator constructor(
+  @JsonProperty("color")
   public val color: Color? = default<ColorFilter, Color?>("color"),
 ) : GraphQLInput() {
   override fun fields(): List<Pair<String, Any?>> = listOf("color" to color)

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/inputWithExtendedType/expected/types/MovieFilter.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/inputWithExtendedType/expected/types/MovieFilter.kt
@@ -1,5 +1,7 @@
 package com.netflix.graphql.dgs.codegen.cases.inputWithExtendedType.expected.types
 
+import com.fasterxml.jackson.`annotation`.JsonCreator
+import com.fasterxml.jackson.`annotation`.JsonProperty
 import com.netflix.graphql.dgs.codegen.GraphQLInput
 import kotlin.Any
 import kotlin.Int
@@ -7,8 +9,10 @@ import kotlin.Pair
 import kotlin.String
 import kotlin.collections.List
 
-public class MovieFilter(
+public class MovieFilter @JsonCreator constructor(
+  @JsonProperty("genre")
   public val genre: String? = default<MovieFilter, String?>("genre"),
+  @JsonProperty("releaseYear")
   public val releaseYear: Int? = default<MovieFilter, Int?>("releaseYear"),
 ) : GraphQLInput() {
   override fun fields(): List<Pair<String, Any?>> = listOf("genre" to genre, "releaseYear" to

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/inputWithReservedWord/expected/types/SampleInput.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/inputWithReservedWord/expected/types/SampleInput.kt
@@ -1,12 +1,15 @@
 package com.netflix.graphql.dgs.codegen.cases.inputWithReservedWord.expected.types
 
+import com.fasterxml.jackson.`annotation`.JsonCreator
+import com.fasterxml.jackson.`annotation`.JsonProperty
 import com.netflix.graphql.dgs.codegen.GraphQLInput
 import kotlin.Any
 import kotlin.Pair
 import kotlin.String
 import kotlin.collections.List
 
-public class SampleInput(
+public class SampleInput @JsonCreator constructor(
+  @JsonProperty("return")
   public val `return`: String,
 ) : GraphQLInput() {
   override fun fields(): List<Pair<String, Any?>> = listOf("return" to `return`)

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/projectionWithNestedInputs/expected/types/I1.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/projectionWithNestedInputs/expected/types/I1.kt
@@ -1,13 +1,17 @@
 package com.netflix.graphql.dgs.codegen.cases.projectionWithNestedInputs.expected.types
 
+import com.fasterxml.jackson.`annotation`.JsonCreator
+import com.fasterxml.jackson.`annotation`.JsonProperty
 import com.netflix.graphql.dgs.codegen.GraphQLInput
 import kotlin.Any
 import kotlin.Pair
 import kotlin.String
 import kotlin.collections.List
 
-public class I1(
+public class I1 @JsonCreator constructor(
+  @JsonProperty("arg1")
   public val arg1: I1? = default<I1, I1?>("arg1"),
+  @JsonProperty("arg2")
   public val arg2: I2? = default<I1, I2?>("arg2"),
 ) : GraphQLInput() {
   override fun fields(): List<Pair<String, Any?>> = listOf("arg1" to arg1, "arg2" to arg2)

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/projectionWithNestedInputs/expected/types/I2.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/projectionWithNestedInputs/expected/types/I2.kt
@@ -1,13 +1,17 @@
 package com.netflix.graphql.dgs.codegen.cases.projectionWithNestedInputs.expected.types
 
+import com.fasterxml.jackson.`annotation`.JsonCreator
+import com.fasterxml.jackson.`annotation`.JsonProperty
 import com.netflix.graphql.dgs.codegen.GraphQLInput
 import kotlin.Any
 import kotlin.Pair
 import kotlin.String
 import kotlin.collections.List
 
-public class I2(
+public class I2 @JsonCreator constructor(
+  @JsonProperty("arg1")
   public val arg1: String? = default<I2, String?>("arg1"),
+  @JsonProperty("arg2")
   public val arg2: String? = default<I2, String?>("arg2"),
 ) : GraphQLInput() {
   override fun fields(): List<Pair<String, Any?>> = listOf("arg1" to arg1, "arg2" to arg2)

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/projectionWithPrimitiveAndArgs/expected/types/I.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/projectionWithPrimitiveAndArgs/expected/types/I.kt
@@ -1,12 +1,15 @@
 package com.netflix.graphql.dgs.codegen.cases.projectionWithPrimitiveAndArgs.expected.types
 
+import com.fasterxml.jackson.`annotation`.JsonCreator
+import com.fasterxml.jackson.`annotation`.JsonProperty
 import com.netflix.graphql.dgs.codegen.GraphQLInput
 import kotlin.Any
 import kotlin.Pair
 import kotlin.String
 import kotlin.collections.List
 
-public class I(
+public class I @JsonCreator constructor(
+  @JsonProperty("arg")
   public val arg: String? = default<I, String?>("arg"),
 ) : GraphQLInput() {
   override fun fields(): List<Pair<String, Any?>> = listOf("arg" to arg)

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/projectionWithTypeAndArgs/expected/types/I.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/projectionWithTypeAndArgs/expected/types/I.kt
@@ -1,12 +1,15 @@
 package com.netflix.graphql.dgs.codegen.cases.projectionWithTypeAndArgs.expected.types
 
+import com.fasterxml.jackson.`annotation`.JsonCreator
+import com.fasterxml.jackson.`annotation`.JsonProperty
 import com.netflix.graphql.dgs.codegen.GraphQLInput
 import kotlin.Any
 import kotlin.Pair
 import kotlin.String
 import kotlin.collections.List
 
-public class I(
+public class I @JsonCreator constructor(
+  @JsonProperty("arg")
   public val arg: String? = default<I, String?>("arg"),
 ) : GraphQLInput() {
   override fun fields(): List<Pair<String, Any?>> = listOf("arg" to arg)

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/projectionWithTypeAndArgs/test/QueryTest.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/projectionWithTypeAndArgs/test/QueryTest.kt
@@ -78,10 +78,10 @@ class QueryTest {
     @Test
     fun testQueryWithAlias() {
         val query = DgsClient.buildQuery {
-            person(_alias= "person1", a2 = "person1") {
+            person(_alias = "person1", a2 = "person1") {
                 firstname
             }
-            person(_alias= "person2", a2 = "person2") {
+            person(_alias = "person2", a2 = "person2") {
                 firstname
             }
         }

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin2/GenerateKotlin2InputTypes.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin2/GenerateKotlin2InputTypes.kt
@@ -18,6 +18,8 @@
 
 package com.netflix.graphql.dgs.codegen.generators.kotlin2
 
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonProperty
 import com.netflix.graphql.dgs.codegen.CodeGenConfig
 import com.netflix.graphql.dgs.codegen.GraphQLInput
 import com.netflix.graphql.dgs.codegen.generators.kotlin.ReservedKeywordFilter
@@ -26,6 +28,7 @@ import com.netflix.graphql.dgs.codegen.generators.kotlin.sanitizeKdoc
 import com.netflix.graphql.dgs.codegen.generators.shared.SchemaExtensionsUtils.findInputExtensions
 import com.netflix.graphql.dgs.codegen.generators.shared.excludeSchemaTypeExtension
 import com.netflix.graphql.dgs.codegen.shouldSkip
+import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.FileSpec
@@ -82,13 +85,14 @@ fun generateKotlin2InputTypes(
                 // add a constructor with a parameter for every field
                 .primaryConstructor(
                     FunSpec.constructorBuilder()
+                        .addAnnotation(JsonCreator::class)
                         .addParameters(
                             fields.map { field ->
                                 val type = type(field)
                                 ParameterSpec.builder(
                                     name = field.name,
                                     type = type
-                                )
+                                ).addAnnotation(AnnotationSpec.builder(JsonProperty::class).addMember("%S", field.name).build())
                                     .apply {
                                         if (type.isNullable) {
                                             defaultValue("default<%T, %T>(%S)", typeName, type, field.name)


### PR DESCRIPTION
**Motivation**
We are migrating from java to kotlin codegen types. We have few quite complex input types. In our test suite we deserialise JSON files and we validate them. We'd like to keep that functionality after migration as it really simplifies our test suite.

**Generated input type before changes**
```kotlin
public class TestInput(
    public val workspaceKey: String,
    public val name: String,
) : GraphQLInput() {
    override fun fields(): List<Pair<String, Any?>> = listOf("workspaceKey" to workspaceKey, "name" to
        name)
}
```

**Test**
```kotlin
@Test
fun `should deserialize`() {
    val json = """
        {
            "workspaceKey": "KEY",
            "name": "Damian"
        }
    """.trimIndent()
    ObjectMapper().readValue(json, TestInput::class.java)
}
```

**Error during deserialization**
```
com.fasterxml.jackson.databind.exc.InvalidDefinitionException: Cannot construct instance of `com.example.TestInput` (no Creators, like default constructor, exist): cannot deserialize from Object value (no delegate- or property-based Creator)
 at [Source: (String)"{
    "workspaceKey": "KEY",
    "name": "Damian"
}"; line: 2, column: 5]
```

**Generated input type after PR changes**
```kotlin
public class TestInput @JsonCreator constructor(
    @JsonProperty("workspaceKey") 
    public val workspaceKey: String,
    @JsonProperty("name") 
    public val name: String,
 ) : GraphQLInput() {
    override fun fields(): List<Pair<String, Any?>> = listOf("workspaceKey" to workspaceKey, "name" to
        name)
}
```



