### PR TITLE
Use jakarta package for @Generated annotation

### DIFF
--- a/graphql-dgs-codegen-core/build.gradle
+++ b/graphql-dgs-codegen-core/build.gradle
@@ -39,6 +39,8 @@ dependencies {
     implementation 'com.github.ajalt.clikt:clikt:4.4.+'
 
     implementation 'org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.+'
+    implementation 'jakarta.annotation:jakarta.annotation-api:2.1.1'
+
 
     testImplementation 'com.google.testing.compile:compile-testing:0.+'
     testImplementation "org.jetbrains.kotlin:kotlin-compiler"

--- a/graphql-dgs-codegen-core/dependencies.lock
+++ b/graphql-dgs-codegen-core/dependencies.lock
@@ -116,6 +116,12 @@
                 "com.squareup:kotlinpoet"
             ]
         },
+        "jakarta.annotation:jakarta.annotation-api": {
+            "locked": "2.1.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform-dependencies"
+            ]
+        },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.9.25"
         },
@@ -286,6 +292,12 @@
         },
         "com.squareup:kotlinpoet": {
             "locked": "1.17.0"
+        },
+        "jakarta.annotation:jakarta.annotation-api": {
+            "locked": "2.1.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform-dependencies"
+            ]
         },
         "net.java.dev.jna:jna": {
             "locked": "5.14.0",
@@ -528,6 +540,12 @@
             "locked": "1.17.0",
             "transitive": [
                 "com.squareup:kotlinpoet"
+            ]
+        },
+        "jakarta.annotation:jakarta.annotation-api": {
+            "locked": "2.1.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform-dependencies"
             ]
         },
         "junit:junit": {
@@ -928,6 +946,12 @@
         },
         "com.squareup:kotlinpoet": {
             "locked": "1.17.0"
+        },
+        "jakarta.annotation:jakarta.annotation-api": {
+            "locked": "2.1.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform-dependencies"
+            ]
         },
         "junit:junit": {
             "locked": "4.13.2",
@@ -1335,6 +1359,12 @@
             "locked": "8.5.12",
             "transitive": [
                 "org.jetbrains:markdown-jvm"
+            ]
+        },
+        "jakarta.annotation:jakarta.annotation-api": {
+            "locked": "2.1.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform-dependencies"
             ]
         },
         "junit:junit": {
@@ -2042,6 +2072,12 @@
                 "org.jetbrains:markdown-jvm"
             ]
         },
+        "jakarta.annotation:jakarta.annotation-api": {
+            "locked": "2.1.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform-dependencies"
+            ]
+        },
         "net.java.dev.jna:jna": {
             "locked": "5.14.0",
             "transitive": [
@@ -2334,6 +2370,12 @@
             "locked": "1.17.0",
             "transitive": [
                 "com.squareup:kotlinpoet"
+            ]
+        },
+        "jakarta.annotation:jakarta.annotation-api": {
+            "locked": "2.1.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform-dependencies"
             ]
         },
         "junit:junit": {
@@ -2734,6 +2776,12 @@
         },
         "com.squareup:kotlinpoet": {
             "locked": "1.17.0"
+        },
+        "jakarta.annotation:jakarta.annotation-api": {
+            "locked": "2.1.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform-dependencies"
+            ]
         },
         "junit:junit": {
             "locked": "4.13.2",
@@ -3141,6 +3189,12 @@
             "locked": "8.5.12",
             "transitive": [
                 "org.jetbrains:markdown-jvm"
+            ]
+        },
+        "jakarta.annotation:jakarta.annotation-api": {
+            "locked": "2.1.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform-dependencies"
             ]
         },
         "junit:junit": {

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
@@ -507,6 +507,7 @@ class CodeGenConfig(
     var javaGenerateAllConstructor: Boolean = true,
     var implementSerializable: Boolean = false,
     var addGeneratedAnnotation: Boolean = false,
+    var disableDatesInGeneratedAnnotation: Boolean = false,
     var addDeprecatedAnnotation: Boolean = false
 ) {
     val packageNameClient: String = "$packageName.$subPackageNameClient"

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/JavaPoetUtils.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/JavaPoetUtils.kt
@@ -156,7 +156,7 @@ fun String.toTypeName(isGenericParam: Boolean = false): TypeName {
     }
 }
 
-private fun generatedAnnotation(packageName: String): List<AnnotationSpec> {
+private fun generatedAnnotation(packageName: String, generateDate: Boolean): List<AnnotationSpec> {
     val graphqlGenerated = AnnotationSpec
         .builder(ClassName.get(packageName, "Generated"))
         .build()
@@ -166,19 +166,21 @@ private fun generatedAnnotation(packageName: String): List<AnnotationSpec> {
     } else {
         val generatedAnnotation = ClassName.bestGuess(generatedAnnotationClassName)
 
-        val javaxGenerated = AnnotationSpec.builder(generatedAnnotation)
+        var jakartaGeneratedBuilder = AnnotationSpec.builder(generatedAnnotation)
             .addMember("value", "${'$'}S", CodeGen::class.qualifiedName!!)
-            .addMember("date", "${'$'}S", generatedDate)
-            .build()
 
-        listOf(javaxGenerated, graphqlGenerated)
+        if (generateDate) {
+            jakartaGeneratedBuilder = jakartaGeneratedBuilder.addMember("date", "${'$'}S", generatedDate)
+        }
+
+        listOf(jakartaGeneratedBuilder.build(), graphqlGenerated)
     }
 }
 
 fun TypeSpec.Builder.addOptionalGeneratedAnnotation(config: CodeGenConfig): TypeSpec.Builder =
     apply {
         if (config.addGeneratedAnnotation) {
-            generatedAnnotation(config.packageName).forEach { addAnnotation(it) }
+            generatedAnnotation(config.packageName, !config.disableDatesInGeneratedAnnotation).forEach { addAnnotation(it) }
         }
     }
 

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/shared/SharedTypeUtils.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/shared/SharedTypeUtils.kt
@@ -158,10 +158,7 @@ internal fun findSchemaTypeMapping(document: Document, typeName: String): String
 }
 
 internal val generatedAnnotationClassName: String? = runCatching {
-    Class.forName("javax.annotation.processing.Generated").canonicalName
-}.getOrElse {
-    runCatching {
-        Class.forName("javax.annotation.Generated").canonicalName
-    }.getOrNull()
-}
+    Class.forName("jakarta.annotation.Generated").canonicalName
+}.getOrNull()
+
 internal val generatedDate: String = Instant.now().toString()

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
@@ -3671,7 +3671,7 @@ It takes a title and such.
             .partition { it.name == "Generated" }
 
         allKotlinSources.assertKotlinGeneratedAnnotation()
-        codeGenResult.javaSources().assertJavaGeneratedAnnotation()
+        codeGenResult.javaSources().assertJavaGeneratedAnnotation(true)
 
         assertThat(generatedAnnotationFile.single().toString())
             .contains("@Retention(value = AnnotationRetention.BINARY)")

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/TestUtils.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/TestUtils.kt
@@ -126,8 +126,8 @@ fun List<FileSpec>.assertKotlinGeneratedAnnotation() = onEach {
         .forEach { typeSpec -> typeSpec.assertKotlinGeneratedAnnotation(it) }
 }
 
-fun List<JavaFile>.assertJavaGeneratedAnnotation() = onEach {
-    it.typeSpec.assertJavaGeneratedAnnotation()
+fun List<JavaFile>.assertJavaGeneratedAnnotation(shouldHaveDate: Boolean) = onEach {
+    it.typeSpec.assertJavaGeneratedAnnotation(shouldHaveDate)
 }
 
 fun KTypeSpec.assertKotlinGeneratedAnnotation(fileSpec: FileSpec) {
@@ -146,20 +146,26 @@ fun KTypeSpec.assertKotlinGeneratedAnnotation(fileSpec: FileSpec) {
     typeSpecs.forEach { it.assertKotlinGeneratedAnnotation(fileSpec) }
 }
 
-fun TypeSpec.assertJavaGeneratedAnnotation() {
+fun TypeSpec.assertJavaGeneratedAnnotation(shouldHaveDate: Boolean) {
     val generatedSpec = annotations
         .firstOrNull { it.canonicalName() == "$basePackageName.Generated" }
     assertThat(generatedSpec)
         .`as`("@Generated annotation exists in %s", this)
         .isNotNull
 
-    val javaxGeneratedSpec =
+    val jakartaGeneratedSpec =
         annotations.firstOrNull { it.canonicalName() == generatedAnnotationClassName }
-    assertThat(javaxGeneratedSpec)
+    assertThat(jakartaGeneratedSpec)
         .`as`("$generatedAnnotationClassName annotation exists in %s", this)
         .isNotNull
 
-    this.typeSpecs.forEach { it.assertJavaGeneratedAnnotation() }
+    if (shouldHaveDate) {
+        assertThat(jakartaGeneratedSpec!!.members.keys).contains("date")
+    } else {
+        assertThat(jakartaGeneratedSpec!!.members.keys).doesNotContain("date")
+    }
+
+    this.typeSpecs.forEach { it.assertJavaGeneratedAnnotation(shouldHaveDate) }
 }
 
 fun AnnotationSpec.canonicalName(): String = (type as ClassName).canonicalName()

--- a/graphql-dgs-codegen-gradle/dependencies.lock
+++ b/graphql-dgs-codegen-gradle/dependencies.lock
@@ -637,6 +637,13 @@
                 "org.jetbrains:markdown-jvm"
             ]
         },
+        "jakarta.annotation:jakarta.annotation-api": {
+            "locked": "2.1.1",
+            "transitive": [
+                "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core",
+                "com.netflix.graphql.dgs:graphql-dgs-platform-dependencies"
+            ]
+        },
         "net.java.dev.jna:jna": {
             "locked": "5.14.0",
             "transitive": [
@@ -1284,6 +1291,13 @@
             "locked": "8.5.12",
             "transitive": [
                 "org.jetbrains:markdown-jvm"
+            ]
+        },
+        "jakarta.annotation:jakarta.annotation-api": {
+            "locked": "2.1.1",
+            "transitive": [
+                "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core",
+                "com.netflix.graphql.dgs:graphql-dgs-platform-dependencies"
             ]
         },
         "net.bytebuddy:byte-buddy": {

--- a/graphql-dgs-codegen-gradle/src/main/kotlin/com/netflix/graphql/dgs/codegen/gradle/GenerateJavaTask.kt
+++ b/graphql-dgs-codegen-gradle/src/main/kotlin/com/netflix/graphql/dgs/codegen/gradle/GenerateJavaTask.kt
@@ -142,6 +142,9 @@ open class GenerateJavaTask @Inject constructor(
     var addGeneratedAnnotation = false
 
     @Input
+    var disableDatesInGeneratedAnnotation = false
+
+    @Input
     var addDeprecatedAnnotation = false
 
     @Input
@@ -208,6 +211,7 @@ open class GenerateJavaTask @Inject constructor(
             snakeCaseConstantNames = snakeCaseConstantNames,
             implementSerializable = implementSerializable,
             addGeneratedAnnotation = addGeneratedAnnotation,
+            disableDatesInGeneratedAnnotation = disableDatesInGeneratedAnnotation,
             addDeprecatedAnnotation = addDeprecatedAnnotation,
             includeImports = includeImports,
             includeEnumImports = includeEnumImports,


### PR DESCRIPTION
Fix for #702, use `jakarta.annotation.Generated` instead of `javax`. Also made generating dates configurable through `disableDatesInGeneratedAnnotation`. 

Note that this might break compilation for Spring Boot 2.x apps, because they likely don't have `jakarta.annotation` on the classpath. This can fixed by explicitly adding `jakarta.annotation:jakarta.annotation-api` to the build file.