### PR TITLE
Clean up DataTypeGenerator

### DIFF
--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ReservedKeywordSanitizer.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ReservedKeywordSanitizer.kt
@@ -34,7 +34,7 @@ class ReservedKeywordSanitizer {
         private const val prefix = "_"
 
         fun sanitize(originalName: String): String {
-            return if (reservedKeywords.contains(originalName) || SourceVersion.isKeyword(originalName)) {
+            return if (originalName in reservedKeywords || SourceVersion.isKeyword(originalName)) {
                 "$prefix$originalName"
             } else {
                 originalName

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/TypeUtils.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/TypeUtils.kt
@@ -242,7 +242,7 @@ class TypeUtils(private val packageName: String, private val config: CodeGenConf
 
     fun transformIfDefaultClassMethodExists(originName: String, defaultMethodName: String): String {
         return if (defaultMethodName == originName) {
-            return originName.plus("Field")
+            return originName + "Field"
         } else {
             originName
         }

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
@@ -19,17 +19,28 @@
 package com.netflix.graphql.dgs.codegen
 
 import com.netflix.graphql.dgs.codegen.generators.java.disableJsonTypeInfoAnnotation
-import com.squareup.javapoet.*
-import org.assertj.core.api.Assertions
+import com.squareup.javapoet.AnnotationSpec
+import com.squareup.javapoet.ClassName
+import com.squareup.javapoet.CodeBlock
+import com.squareup.javapoet.JavaFile
+import com.squareup.javapoet.MethodSpec
+import com.squareup.javapoet.ParameterizedTypeName
+import com.squareup.javapoet.TypeSpec
+import com.squareup.javapoet.WildcardTypeName
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtensionContext
 import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.*
+import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.Arguments.arguments
+import org.junit.jupiter.params.provider.ArgumentsProvider
+import org.junit.jupiter.params.provider.ArgumentsSource
+import org.junit.jupiter.params.provider.MethodSource
+import org.junit.jupiter.params.provider.ValueSource
 import java.io.Serializable
 import java.util.stream.Stream
 
@@ -48,7 +59,7 @@ class CodeGenTest {
             type Mutation {
         """.trimIndent()
 
-        Assertions.assertThatThrownBy {
+        assertThatThrownBy {
             CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName)).generate()
         }.isInstanceOf(CodeGenSchemaParsingException::class.java)
             .hasMessageContainingAll(
@@ -77,24 +88,22 @@ class CodeGenTest {
 
     @Test
     fun `When the schema is empty, there is no parsing error`() {
-        val schema = """"""
-
-        CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName)).generate()
+        assertDoesNotThrow {
+            CodeGen(CodeGenConfig(schemas = setOf(""), packageName = basePackageName)).generate()
+        }
     }
 
     @Test
     fun `When the schema contains just whitespace, there is no parsing error`() {
-        val schema = """     """
-
-        CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName)).generate()
+        assertDoesNotThrow {
+            CodeGen(CodeGenConfig(schemas = setOf("     "), packageName = basePackageName)).generate()
+        }
     }
 
     @Test
     fun `When the schema is just an opening bracket, a parsing error is thrown`() {
-        val schema = """{""".trimIndent()
-
-        Assertions.assertThatThrownBy {
-            CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName)).generate()
+        assertThatThrownBy {
+            CodeGen(CodeGenConfig(schemas = setOf("{"), packageName = basePackageName)).generate()
         }.isInstanceOf(CodeGenSchemaParsingException::class.java)
     }
 
@@ -316,7 +325,6 @@ class CodeGenTest {
 
         assertThat(dataTypes.size).isEqualTo(1)
         assertThat(dataTypes[0].typeSpec.name).isEqualTo("Person")
-        assertThat(dataTypes[0].typeSpec.methodSpecs).extracting("name").contains("equals")
 
         assertCompilesJava(dataTypes)
     }
@@ -347,7 +355,7 @@ class CodeGenTest {
         val builderType = dataTypes[0].typeSpec.typeSpecs[0]
         assertThat(builderType.name).isEqualTo("Builder")
         assertThat(builderType.methodSpecs).extracting("name").contains("firstname", "lastname", "build")
-        assertThat(builderType.methodSpecs).filteredOn("name", "firstname").extracting("returnType.simpleName").contains("com.netflix.graphql.dgs.codegen.tests.generated.types.Person.Builder")
+        assertThat(builderType.methodSpecs).filteredOn("name", "firstname").extracting("returnType.simpleName").contains("Builder")
         assertThat(builderType.methodSpecs).filteredOn("name", "build").extracting("returnType.simpleName").contains("Person")
         assertCompilesJava(dataTypes)
     }
@@ -1813,11 +1821,9 @@ class CodeGenTest {
         ).generate()
 
         assertThat(dataTypes[0].typeSpec.methodSpecs).extracting("name").contains("toString")
-        val expectedString = """
-            return "Person{" + "firstname='" + firstname + "'," +"lastname='" + lastname + "'" +"}";
-        """.trimIndent()
+        val expectedString = """return "Person{firstname='" + firstname + "', lastname='" + lastname + "'}";"""
         val generatedString = dataTypes[0].typeSpec.methodSpecs.single { it.name == "toString" }.code.toString().trimIndent()
-        assertThat(expectedString).isEqualTo(generatedString)
+        assertThat(generatedString).isEqualTo(expectedString)
         assertCompilesJava(dataTypes)
     }
 
@@ -1844,11 +1850,9 @@ class CodeGenTest {
         ).generate()
 
         assertThat(dataTypes[0].typeSpec.methodSpecs).extracting("name").contains("toString")
-        val expectedString = """
-            return "Person{" + "firstname='" + firstname + "'," +"lastname='" + lastname + "'," +"password='" + "*****" + "'" +"}";
-        """.trimIndent()
+        val expectedString = """return "Person{firstname='" + firstname + "', lastname='" + lastname + "', password='*****'}";"""
         val generatedString = dataTypes[0].typeSpec.methodSpecs.single { it.name == "toString" }.code.toString().trimIndent()
-        assertThat(expectedString).isEqualTo(generatedString)
+        assertThat(generatedString).isEqualTo(expectedString)
         assertCompilesJava(dataTypes)
     }
 
@@ -1872,11 +1876,9 @@ class CodeGenTest {
         ).generate()
 
         assertThat(dataTypes[0].typeSpec.methodSpecs).extracting("name").contains("toString")
-        val expectedString = """
-            return "PersonFilter{" + "email='" + "*****" + "'" +"}";
-        """.trimIndent()
+        val expectedString = """return "PersonFilter{email='*****'}";"""
         val generatedString = dataTypes[0].typeSpec.methodSpecs.single { it.name == "toString" }.code.toString().trimIndent()
-        assertThat(expectedString).isEqualTo(generatedString)
+        assertThat(generatedString).isEqualTo(expectedString)
         assertCompilesJava(dataTypes)
     }
 
@@ -2496,6 +2498,7 @@ class CodeGenTest {
                 |import java.lang.Object;
                 |import java.lang.Override;
                 |import java.lang.String;
+                |import java.util.Objects;
                 |
                 |@JsonTypeInfo(
                 |    use = JsonTypeInfo.Id.NONE
@@ -2553,26 +2556,26 @@ class CodeGenTest {
                 |
                 |  @Override
                 |  public String toString() {
-                |    return "Talent{" + "firstname='" + firstname + "'," +"lastname='" + lastname + "'," +"company='" + company + "'," +"imdbProfile='" + imdbProfile + "'" +"}";
+                |    return "Talent{firstname='" + firstname + "', lastname='" + lastname + "', company='" + company + "', imdbProfile='" + imdbProfile + "'}";
                 |  }
                 |
                 |  @Override
                 |  public boolean equals(Object o) {
                 |    if (this == o) return true;
-                |        if (o == null || getClass() != o.getClass()) return false;
-                |        Talent that = (Talent) o;
-                |        return java.util.Objects.equals(firstname, that.firstname) &&
-                |                            java.util.Objects.equals(lastname, that.lastname) &&
-                |                            java.util.Objects.equals(company, that.company) &&
-                |                            java.util.Objects.equals(imdbProfile, that.imdbProfile);
+                |    if (o == null || getClass() != o.getClass()) return false;
+                |    Talent that = (Talent) o;
+                |    return Objects.equals(firstname, that.firstname) &&
+                |        Objects.equals(lastname, that.lastname) &&
+                |        Objects.equals(company, that.company) &&
+                |        Objects.equals(imdbProfile, that.imdbProfile);
                 |  }
                 |
                 |  @Override
                 |  public int hashCode() {
-                |    return java.util.Objects.hash(firstname, lastname, company, imdbProfile);
+                |    return Objects.hash(firstname, lastname, company, imdbProfile);
                 |  }
                 |
-                |  public static com.netflix.graphql.dgs.codegen.tests.generated.types.Talent.Builder newBuilder() {
+                |  public static Builder newBuilder() {
                 |    return new Builder();
                 |  }
                 |
@@ -2586,34 +2589,30 @@ class CodeGenTest {
                 |    private String imdbProfile;
                 |
                 |    public Talent build() {
-                |                  com.netflix.graphql.dgs.codegen.tests.generated.types.Talent result = new com.netflix.graphql.dgs.codegen.tests.generated.types.Talent();
-                |                      result.firstname = this.firstname;
-                |          result.lastname = this.lastname;
-                |          result.company = this.company;
-                |          result.imdbProfile = this.imdbProfile;
-                |                      return result;
+                |      Talent result = new Talent();
+                |      result.firstname = this.firstname;
+                |      result.lastname = this.lastname;
+                |      result.company = this.company;
+                |      result.imdbProfile = this.imdbProfile;
+                |      return result;
                 |    }
                 |
-                |    public com.netflix.graphql.dgs.codegen.tests.generated.types.Talent.Builder firstname(
-                |        String firstname) {
+                |    public Builder firstname(String firstname) {
                 |      this.firstname = firstname;
                 |      return this;
                 |    }
                 |
-                |    public com.netflix.graphql.dgs.codegen.tests.generated.types.Talent.Builder lastname(
-                |        String lastname) {
+                |    public Builder lastname(String lastname) {
                 |      this.lastname = lastname;
                 |      return this;
                 |    }
                 |
-                |    public com.netflix.graphql.dgs.codegen.tests.generated.types.Talent.Builder company(
-                |        String company) {
+                |    public Builder company(String company) {
                 |      this.company = company;
                 |      return this;
                 |    }
                 |
-                |    public com.netflix.graphql.dgs.codegen.tests.generated.types.Talent.Builder imdbProfile(
-                |        String imdbProfile) {
+                |    public Builder imdbProfile(String imdbProfile) {
                 |      this.imdbProfile = imdbProfile;
                 |      return this;
                 |    }
@@ -4645,7 +4644,7 @@ It takes a title and such.
         ).generate()
 
         val dataTypes = codeGenResult.javaDataTypes
-        assertThat(dataTypes[0].typeSpec.fieldSpecs[0].initializer.toString()).isEqualTo("Locale.forLanguageTag(\"en-US\")")
+        assertThat(dataTypes[0].typeSpec.fieldSpecs[0].initializer.toString()).isEqualTo("java.util.Locale.forLanguageTag(\"en-US\")")
         assertCompilesJava(dataTypes)
     }
 


### PR DESCRIPTION
- Make use of JavaPoet CodeBlock format specifiers
- Don't generate hashCode / equals for classes with no fields