### PR TITLE
Remove unnecessary javadoc helper methods

### DIFF
--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/DataTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/DataTypeGenerator.kt
@@ -288,7 +288,7 @@ abstract class BaseDataTypeGenerator(
         }
 
         if (description != null) {
-            javaType.addJavadoc(description.sanitizeJavaDoc())
+            javaType.addJavadoc("\$L", description.content)
         }
 
         if (directives.isNotEmpty()) {
@@ -468,7 +468,7 @@ abstract class BaseDataTypeGenerator(
         }
 
         if (fieldDefinition.description != null) {
-            fieldBuilder.addJavadoc(fieldDefinition.description.sanitizeJavaDoc())
+            fieldBuilder.addJavadoc("\$L", fieldDefinition.description.content)
         }
 
         val getterPrefix = if (returnType == com.squareup.javapoet.TypeName.BOOLEAN && config.generateIsGetterForPrimitiveBooleanFields) "is" else "get"
@@ -480,7 +480,7 @@ abstract class BaseDataTypeGenerator(
         }
 
         if (fieldDefinition.description != null) {
-            getterMethodBuilder.addJavadoc(fieldDefinition.description.sanitizeJavaDoc())
+            getterMethodBuilder.addJavadoc("\$L", fieldDefinition.description.content)
         }
 
         val setterName = typeUtils.transformIfDefaultClassMethodExists("set${fieldDefinition.name[0].uppercase()}${fieldDefinition.name.substring(1)}", TypeUtils.setClass)

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/EnumTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/EnumTypeGenerator.kt
@@ -31,14 +31,16 @@ import org.slf4j.LoggerFactory
 import javax.lang.model.element.Modifier
 
 class EnumTypeGenerator(private val config: CodeGenConfig) {
-    private val logger: Logger = LoggerFactory.getLogger(EnumTypeGenerator::class.java)
+    companion object {
+        private val logger: Logger = LoggerFactory.getLogger(EnumTypeGenerator::class.java)
+    }
 
     fun generate(definition: EnumTypeDefinition, extensions: List<EnumTypeDefinition>): CodeGenResult {
         if (definition.shouldSkip(config)) {
             return CodeGenResult()
         }
 
-        logger.info("Generating enum type ${definition.name}")
+        logger.info("Generating enum type {}", definition.name)
 
         val javaType =
             TypeSpec
@@ -47,13 +49,13 @@ class EnumTypeGenerator(private val config: CodeGenConfig) {
                 .addOptionalGeneratedAnnotation(config)
 
         if (definition.description != null) {
-            javaType.addJavadoc(definition.description.sanitizeJavaDoc())
+            javaType.addJavadoc("\$L", definition.description.content)
         }
 
         val mergedEnumDefinitions = definition.enumValueDefinitions + extensions.flatMap { it.enumValueDefinitions }
 
         mergedEnumDefinitions.forEach {
-            var typeSpec = TypeSpec.anonymousClassBuilder("")
+            val typeSpec = TypeSpec.anonymousClassBuilder("")
             if (it.directives.isNotEmpty()) {
                 val (annotations, comments) = applyDirectivesJava(it.directives, config)
                 if (!comments.isNullOrBlank()) {

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/InterfaceGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/InterfaceGenerator.kt
@@ -34,10 +34,13 @@ import javax.lang.model.element.Modifier
 
 class InterfaceGenerator(private val config: CodeGenConfig, private val document: Document) {
 
+    companion object {
+        private val logger: Logger = LoggerFactory.getLogger(InterfaceGenerator::class.java)
+    }
+
     private val packageName = config.packageNameTypes
     private val typeUtils = TypeUtils(packageName, config, document)
     private val useInterfaceType = config.generateInterfaces
-    private val logger: Logger = LoggerFactory.getLogger(InterfaceGenerator::class.java)
 
     fun generate(
         definition: InterfaceTypeDefinition,
@@ -47,13 +50,13 @@ class InterfaceGenerator(private val config: CodeGenConfig, private val document
             return CodeGenResult()
         }
 
-        logger.info("Generating type ${definition.name}")
+        logger.info("Generating type {}", definition.name)
         val javaType = TypeSpec.interfaceBuilder(definition.name)
             .addOptionalGeneratedAnnotation(config)
             .addModifiers(Modifier.PUBLIC)
 
         if (definition.description != null) {
-            javaType.addJavadoc(definition.description.sanitizeJavaDoc())
+            javaType.addJavadoc("\$L", definition.description.content)
         }
 
         definition.implements
@@ -119,7 +122,7 @@ class InterfaceGenerator(private val config: CodeGenConfig, private val document
             .addModifiers(Modifier.ABSTRACT, Modifier.PUBLIC)
             .returns(returnType)
         if (fieldDefinition.description != null) {
-            getterBuilder.addJavadoc(fieldDefinition.description.sanitizeJavaDoc())
+            getterBuilder.addJavadoc("\$L", fieldDefinition.description.content)
         }
         javaType.addMethod(getterBuilder.build())
 
@@ -129,7 +132,7 @@ class InterfaceGenerator(private val config: CodeGenConfig, private val document
                 .addParameter(returnType, ReservedKeywordSanitizer.sanitize(fieldName))
 
             if (fieldDefinition.description != null) {
-                setterBuilder.addJavadoc(fieldDefinition.description.content.lines().joinToString("\n"))
+                setterBuilder.addJavadoc("\$L", fieldDefinition.description.content)
             }
             javaType.addMethod(setterBuilder.build())
         }

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/JavaPoetUtils.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/JavaPoetUtils.kt
@@ -35,7 +35,6 @@ import com.squareup.javapoet.WildcardTypeName
 import graphql.introspection.Introspection.TypeNameMetaFieldDef
 import graphql.language.ArrayValue
 import graphql.language.BooleanValue
-import graphql.language.Description
 import graphql.language.EnumValue
 import graphql.language.FloatValue
 import graphql.language.IntValue
@@ -44,7 +43,6 @@ import graphql.language.ObjectField
 import graphql.language.ObjectValue
 import graphql.language.StringValue
 import graphql.language.Value
-import java.lang.IllegalArgumentException
 
 /**
  * Generate a [JsonTypeInfo] annotation, which allows for Jackson
@@ -58,14 +56,6 @@ import java.lang.IllegalArgumentException
  *   property = "__typename")
  * ```
  */
-
-/**
- * Adds @Deprecated annotation
- */
-fun deprecatedAnnotation(): AnnotationSpec {
-    return AnnotationSpec.builder(java.lang.Deprecated::class.java).build()
-}
-
 fun jsonTypeInfoAnnotation(): AnnotationSpec {
     return AnnotationSpec.builder(JsonTypeInfo::class.java)
         .addMember("use", "\$T.\$L", JsonTypeInfo.Id::class.java, JsonTypeInfo.Id.NAME.name)
@@ -120,22 +110,6 @@ fun jsonSubTypeAnnotation(subTypes: Collection<ClassName>): AnnotationSpec {
     }
 
     return annotationSpec.build()
-}
-
-/**
- * Javapoet treats $ as a reference
- * https://github.com/square/javapoet/issues/670
- */
-fun Description.sanitizeJavaDoc(): String {
-    return this.content.lines().joinToString("\n").sanitizeJavaDoc()
-}
-
-/**
- * Javapoet treats $ as a reference
- * https://github.com/square/javapoet/issues/670
- */
-fun String.sanitizeJavaDoc(): String {
-    return replace("$", "$$")
 }
 
 fun String.toTypeName(isGenericParam: Boolean = false): TypeName {
@@ -219,11 +193,11 @@ fun customAnnotation(annotationArgumentMap: MutableMap<String, Value<Value<*>>>,
  */
 private fun generateCode(config: CodeGenConfig, value: Value<Value<*>>, annotationName: String, prefix: String = ""): CodeBlock =
     when (value) {
-        is BooleanValue -> CodeBlock.of("\$L", (value as BooleanValue).isValue)
-        is IntValue -> CodeBlock.of("\$L", (value as IntValue).value)
+        is BooleanValue -> CodeBlock.of("\$L", value.isValue)
+        is IntValue -> CodeBlock.of("\$L", value.value)
         is StringValue -> {
             // If string value ends with .class and classImports mapping is provided, treat as Java Class
-            val string = (value as StringValue).value
+            val string = value.value
             if (string.endsWith(ParserConstants.CLASS_STRING)) {
                 val className = string.dropLast(ParserConstants.CLASS_LENGTH)
                 // Use annotationName and className in the PackagerParserUtil to get Class Package name.
@@ -232,32 +206,35 @@ private fun generateCode(config: CodeGenConfig, value: Value<Value<*>>, annotati
                 else CodeBlock.of("\$S", string)
             } else CodeBlock.of("\$S", string)
         }
-        is FloatValue -> CodeBlock.of("\$L", (value as FloatValue).value)
+        is FloatValue -> CodeBlock.of("\$L", value.value)
         // In an enum value the prefix (key in the parameters map for the enum) is used to get the package name from the config
         // Limitation: Since it uses the enum key to lookup the package from the configs. 2 enums using different packages cannot have the same keys.
         is EnumValue -> CodeBlock.of(
             "\$T",
-            ClassName.get(PackageParserUtil.getEnumPackage(config, annotationName, prefix), (value as EnumValue).name)
+            ClassName.get(PackageParserUtil.getEnumPackage(config, annotationName, prefix), value.name)
         )
         is ArrayValue ->
-            if ((value as ArrayValue).values.isEmpty()) CodeBlock.of("{}")
-            else CodeBlock.of("{\$L}", (value as ArrayValue).values.joinToString { v -> generateCode(config = config, value = v, annotationName = annotationName, prefix = if (v is EnumValue) prefix else "").toString() })
+            if (value.values.isEmpty()) {
+                CodeBlock.of("{}")
+            } else {
+                CodeBlock.of("{\$L}", value.values.joinToString { v -> generateCode(config = config, value = v, annotationName = annotationName, prefix = if (v is EnumValue) prefix else "").toString() })
+            }
         else -> CodeBlock.of("\$L", value)
     }
 
 private fun typeClassBestGuess(name: String): TypeName {
     return when (name) {
         "String" -> ClassName.get("java.lang", "String")
-        "Integer" -> ClassName.get("java.lang", "Integer")
-        "Long" -> ClassName.get("java.lang", "Long")
-        "Float" -> ClassName.get("java.lang", "Float")
-        "Double" -> ClassName.get("java.lang", "Double")
-        "Character" -> ClassName.get("java.lang", "Character")
-        "Short" -> ClassName.get("java.lang", "Short")
-        "Byte" -> ClassName.get("java.lang", "Byte")
+        "Integer" -> ClassName.INT.box()
+        "Long" -> ClassName.LONG.box()
+        "Float" -> ClassName.FLOAT.box()
+        "Double" -> ClassName.DOUBLE.box()
+        "Character" -> ClassName.CHAR.box()
+        "Short" -> ClassName.SHORT.box()
+        "Byte" -> ClassName.BYTE.box()
         "Number" -> ClassName.get("java.lang", "Number")
-        "Boolean" -> ClassName.get("java.lang", "Boolean")
-        "Object" -> ClassName.get("java.lang", "Object")
+        "Boolean" -> ClassName.BOOLEAN.box()
+        "Object" -> ClassName.OBJECT
         "BigDecimal" -> ClassName.get("java.math", "BigDecimal")
         "List" -> ClassName.get("java.util", "List")
         "ArrayList" -> ClassName.get("java.util", "ArrayList")

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/shared/DirectivesUtils.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/shared/DirectivesUtils.kt
@@ -25,6 +25,7 @@ import com.squareup.kotlinpoet.AnnotationSpec
 import graphql.language.Directive
 import graphql.language.StringValue
 import graphql.language.Value
+import com.squareup.javapoet.AnnotationSpec as JavaAnnotationSpec
 
 fun createArgumentMap(directive: Directive): MutableMap<String, Value<Value<*>>> {
     return directive.arguments.fold(mutableMapOf()) { argMap, argument ->
@@ -60,7 +61,7 @@ fun applyDirectivesKotlin(directives: List<Directive>, config: CodeGenConfig): M
  * @input config: code generator config
  * @return Pair of (map of target site and corresponding annotations) and comments
  */
-fun applyDirectivesJava(directives: List<Directive>, config: CodeGenConfig): Pair<MutableMap<String, MutableList<com.squareup.javapoet.AnnotationSpec>>, String?> {
+fun applyDirectivesJava(directives: List<Directive>, config: CodeGenConfig): Pair<MutableMap<String, MutableList<JavaAnnotationSpec>>, String?> {
     var commentFormat: String? = null
     return Pair(
         directives.fold(mutableMapOf()) { annotations, directive ->
@@ -68,7 +69,7 @@ fun applyDirectivesJava(directives: List<Directive>, config: CodeGenConfig): Pai
             val siteTarget = if (argumentMap.containsKey(ParserConstants.SITE_TARGET)) (argumentMap[ParserConstants.SITE_TARGET] as StringValue).value.uppercase() else SiteTarget.DEFAULT.name
             if (directive.name == ParserConstants.CUSTOM_ANNOTATION && config.generateCustomAnnotations) {
                 annotations[siteTarget] = if (annotations.containsKey(siteTarget)) {
-                    var annotationList: MutableList<com.squareup.javapoet.AnnotationSpec> = annotations[siteTarget]!!
+                    var annotationList: MutableList<JavaAnnotationSpec> = annotations[siteTarget]!!
                     annotationList.add(
                         com.netflix.graphql.dgs.codegen.generators.java.customAnnotation(
                             argumentMap,
@@ -81,7 +82,7 @@ fun applyDirectivesJava(directives: List<Directive>, config: CodeGenConfig): Pai
                 }
             }
             if (directive.name == ParserConstants.DEPRECATED && config.addDeprecatedAnnotation) {
-                annotations[siteTarget] = mutableListOf(com.netflix.graphql.dgs.codegen.generators.java.deprecatedAnnotation())
+                annotations[siteTarget] = mutableListOf(JavaAnnotationSpec.builder(java.lang.Deprecated::class.java).build())
                 if (argumentMap.containsKey(ParserConstants.REASON)) {
                     val reason: String = (argumentMap[ParserConstants.REASON] as StringValue).value
                     val replace = reason.substringAfter(ParserConstants.REPLACE_WITH_STR, "")

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
@@ -3504,6 +3504,9 @@ It takes a title and such.
             Anything with a title!
             ""${'"'}
             interface Titled {
+                ""${'"'}
+                The title field; must not contain '$'
+                ""${'"'}
                 title: String
             }                                 
         """.trimIndent()
@@ -3515,10 +3518,8 @@ It takes a title and such.
             )
         ).generate()
 
-        assertThat(result.javaInterfaces[0].typeSpec.javadoc.toString()).isEqualTo(
-            """Anything with a title!
-            """.trimIndent()
-        )
+        assertThat(result.javaInterfaces[0].typeSpec.javadoc.toString()).isEqualTo("Anything with a title!")
+        assertThat(result.javaInterfaces[0].typeSpec.methodSpecs[0].javadoc.toString()).isEqualTo("The title field; must not contain '\$'")
     }
 
     @Test
@@ -3539,10 +3540,7 @@ It takes a title and such.
             )
         ).generate()
 
-        assertThat(result.javaInterfaces[0].typeSpec.methodSpecs[0].javadoc.toString()).isEqualTo(
-            """The original, non localized title.
-            """.trimIndent()
-        )
+        assertThat(result.javaInterfaces[0].typeSpec.methodSpecs[0].javadoc.toString()).isEqualTo("The original, non localized title.")
     }
 
     @Test


### PR DESCRIPTION
Remove unneeded sanitizeJavaDoc helper methods, and fix the call-site to simply pass in the correct format specifiers to addJavaDoc. Fixes #694.

Other cleanup:

- Remove trivial deprecatedAnnotation helper method
- Use ClassName constants where possible in typeClassBestGuess