### PR TITLE
Clean up ClientApiGenerator

### DIFF
--- a/graphql-dgs-codegen-core/build.gradle
+++ b/graphql-dgs-codegen-core/build.gradle
@@ -50,4 +50,10 @@ application {
     mainClassName = 'com.netflix.graphql.dgs.codegen.CodeGenCliKt'
 }
 
-tasks.lintKotlinIntegTest.enabled = false
+tasks.named("lintKotlinIntegTest") {
+    exclude("**/cases/**/*.kt")
+}
+
+tasks.named("formatKotlinIntegTest") {
+    exclude("**/cases/**/*.kt")
+}

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/EntitiesClientApiGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/EntitiesClientApiGenTest.kt
@@ -20,10 +20,8 @@ package com.netflix.graphql.dgs.codegen
 
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.fail
-import org.junit.Ignore
 import org.junit.jupiter.api.Test
 
-@Ignore
 class EntitiesClientApiGenTest {
 
     @Test

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
@@ -28,10 +28,13 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtensionContext
 import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.*
+import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.Arguments.arguments
+import org.junit.jupiter.params.provider.ArgumentsProvider
+import org.junit.jupiter.params.provider.ArgumentsSource
+import org.junit.jupiter.params.provider.MethodSource
+import org.junit.jupiter.params.provider.ValueSource
 import java.util.stream.Stream
-import java.util.stream.Stream.of
 
 class KotlinCodeGenTest {
 
@@ -1115,7 +1118,7 @@ class KotlinCodeGenTest {
     }
 
     class MappedTypesTestCases : ArgumentsProvider {
-        override fun provideArguments(context: ExtensionContext): Stream<out Arguments> = of(
+        override fun provideArguments(context: ExtensionContext): Stream<Arguments> = Stream.of(
             arguments("java.time.LocalDateTime", "java.time.LocalDateTime"),
             arguments("String", "kotlin.String"),
             arguments("BigDecimal", "java.math.BigDecimal"),
@@ -1862,7 +1865,7 @@ class KotlinCodeGenTest {
     companion object {
         @JvmStatic
         fun generateConstantsArguments(): Stream<Arguments> {
-            return of(
+            return Stream.of(
                 Arguments.of(
                     true,
                     listOf(
@@ -3614,17 +3617,24 @@ It takes a title and such.
         ).generate()
 
         assertThat(codeGenResult.javaQueryTypes.size).isEqualTo(9)
-        assertThat(codeGenResult.javaQueryTypes[0].typeSpec.name).isEqualTo("ShowsGraphQLQuery")
-        assertThat(codeGenResult.javaQueryTypes[1].typeSpec.name).isEqualTo("MovieGraphQLQuery")
-
-        assertThat(codeGenResult.javaQueryTypes[2].typeSpec.name).isEqualTo("ShowsGraphQLMutation")
-        assertThat(codeGenResult.javaQueryTypes[3].typeSpec.name).isEqualTo("MovieGraphQLMutation")
-        assertThat(codeGenResult.javaQueryTypes[4].typeSpec.name).isEqualTo("FooGraphQLQuery")
-
-        assertThat(codeGenResult.javaQueryTypes[5].typeSpec.name).isEqualTo("ShowsGraphQLSubscription")
-        assertThat(codeGenResult.javaQueryTypes[6].typeSpec.name).isEqualTo("MovieGraphQLSubscription")
-        assertThat(codeGenResult.javaQueryTypes[7].typeSpec.name).isEqualTo("FooGraphQLSubscription")
-        assertThat(codeGenResult.javaQueryTypes[8].typeSpec.name).isEqualTo("BarGraphQLQuery")
+        assertThat(codeGenResult.javaQueryTypes).extracting("typeSpec", com.squareup.javapoet.TypeSpec::class.java)
+            .satisfiesOnlyOnce { spec -> assertThat(spec.name).isEqualTo("ShowsGraphQLQuery") }
+        assertThat(codeGenResult.javaQueryTypes).extracting("typeSpec", com.squareup.javapoet.TypeSpec::class.java)
+            .satisfiesOnlyOnce { spec -> assertThat(spec.name).isEqualTo("ShowsGraphQLSubscription") }
+        assertThat(codeGenResult.javaQueryTypes).extracting("typeSpec", com.squareup.javapoet.TypeSpec::class.java)
+            .satisfiesOnlyOnce { spec -> assertThat(spec.name).isEqualTo("ShowsGraphQLMutation") }
+        assertThat(codeGenResult.javaQueryTypes).extracting("typeSpec", com.squareup.javapoet.TypeSpec::class.java)
+            .satisfiesOnlyOnce { spec -> assertThat(spec.name).isEqualTo("MovieGraphQLQuery") }
+        assertThat(codeGenResult.javaQueryTypes).extracting("typeSpec", com.squareup.javapoet.TypeSpec::class.java)
+            .satisfiesOnlyOnce { spec -> assertThat(spec.name).isEqualTo("MovieGraphQLMutation") }
+        assertThat(codeGenResult.javaQueryTypes).extracting("typeSpec", com.squareup.javapoet.TypeSpec::class.java)
+            .satisfiesOnlyOnce { spec -> assertThat(spec.name).isEqualTo("MovieGraphQLSubscription") }
+        assertThat(codeGenResult.javaQueryTypes).extracting("typeSpec", com.squareup.javapoet.TypeSpec::class.java)
+            .satisfiesOnlyOnce { spec -> assertThat(spec.name).isEqualTo("FooGraphQLMutation") }
+        assertThat(codeGenResult.javaQueryTypes).extracting("typeSpec", com.squareup.javapoet.TypeSpec::class.java)
+            .satisfiesOnlyOnce { spec -> assertThat(spec.name).isEqualTo("FooGraphQLSubscription") }
+        assertThat(codeGenResult.javaQueryTypes).extracting("typeSpec", com.squareup.javapoet.TypeSpec::class.java)
+            .satisfiesOnlyOnce { spec -> assertThat(spec.name).isEqualTo("BarGraphQLSubscription") }
 
         assertCompilesJava(codeGenResult.javaQueryTypes)
     }

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/clientapi/ClientApiGenMutationTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/clientapi/ClientApiGenMutationTest.kt
@@ -48,7 +48,7 @@ class ClientApiGenMutationTest {
         ).generate()
 
         assertThat(codeGenResult.javaQueryTypes.size).isEqualTo(1)
-        assertThat(codeGenResult.javaQueryTypes[0].typeSpec.name).isEqualTo("UpdateMovieGraphQLQuery")
+        assertThat(codeGenResult.javaQueryTypes[0].typeSpec.name).isEqualTo("UpdateMovieGraphQLMutation")
 
         assertCompilesJava(codeGenResult.clientProjections + codeGenResult.javaQueryTypes)
     }
@@ -81,7 +81,7 @@ class ClientApiGenMutationTest {
         ).generate()
 
         assertThat(codeGenResult.javaQueryTypes.size).isEqualTo(1)
-        assertThat(codeGenResult.javaQueryTypes[0].typeSpec.name).isEqualTo("UpdateMovieGraphQLQuery")
+        assertThat(codeGenResult.javaQueryTypes[0].typeSpec.name).isEqualTo("UpdateMovieGraphQLMutation")
 
         assertCompilesJava(
             codeGenResult.clientProjections + codeGenResult.javaQueryTypes + codeGenResult.javaDataTypes
@@ -162,15 +162,18 @@ class ClientApiGenMutationTest {
         val expected = """
             |super("mutation", queryName);
             |if (movie != null || fieldsSet.contains("movie")) {
-            |    getInput().put("movie", movie);
-            |}if (reviews != null || fieldsSet.contains("reviews")) {
-            |    getInput().put("reviews", reviews);
-            |}if (uuid != null || fieldsSet.contains("uuid")) {
-            |    getInput().put("uuid", uuid);
+            |  getInput().put("movie", movie);
             |}
+            |if (reviews != null || fieldsSet.contains("reviews")) {
+            |  getInput().put("reviews", reviews);
+            |}
+            |if (uuid != null || fieldsSet.contains("uuid")) {
+            |  getInput().put("uuid", uuid);
+            |}
+            |
         """.trimMargin()
 
-        assert(initMethod.contains(expected))
+        assertThat(initMethod).isEqualTo(expected)
         assertCompilesJava(
             codeGenResult.clientProjections + codeGenResult.javaQueryTypes + codeGenResult.javaDataTypes
         )
@@ -197,11 +200,8 @@ class ClientApiGenMutationTest {
             )
         ).generate()
 
-        assert(
-            codeGenResult.javaQueryTypes[0].typeSpec.methodSpecs
-                .find { it.name == "<init>" }?.code.toString()
-                .contains("super(\"mutation\", queryName);\ngetInput().put(\"movieId\", movieId);")
-        )
+        assertThat(codeGenResult.javaQueryTypes[0].typeSpec.methodSpecs.find { it.name == "<init>" }?.code.toString())
+            .contains("super(\"mutation\", queryName);\ngetInput().put(\"movieId\", movieId);")
 
         assertCompilesJava(
             codeGenResult.clientProjections + codeGenResult.javaQueryTypes + codeGenResult.javaDataTypes
@@ -269,7 +269,7 @@ class ClientApiGenMutationTest {
         assertThat(codeGenResult.javaEnumTypes)
             .extracting("typeSpec").extracting("name").containsExactly("ShowType", "SourceType")
         assertThat(codeGenResult.javaQueryTypes)
-            .extracting("typeSpec").extracting("name").containsExactly("ShowsGraphQLQuery")
+            .extracting("typeSpec").extracting("name").containsExactly("ShowsGraphQLMutation")
         assertThat(codeGenResult.clientProjections)
             .extracting("typeSpec").extracting("name").containsExactly("ShowsProjectionRoot", "BooleanProjection")
 
@@ -295,7 +295,7 @@ class ClientApiGenMutationTest {
         ).generate()
 
         assertThat(codeGenResult.javaQueryTypes.size).isEqualTo(1)
-        assertThat(codeGenResult.javaQueryTypes[0].typeSpec.name).isEqualTo("UpdateMovieTitleGraphQLQuery")
+        assertThat(codeGenResult.javaQueryTypes[0].typeSpec.name).isEqualTo("UpdateMovieTitleGraphQLMutation")
 
         assertCompilesJava(codeGenResult)
     }

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/clientapi/ClientApiGenProjectionTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/clientapi/ClientApiGenProjectionTest.kt
@@ -22,7 +22,7 @@ import com.netflix.graphql.dgs.codegen.CodeGen
 import com.netflix.graphql.dgs.codegen.CodeGenConfig
 import com.netflix.graphql.dgs.codegen.assertCompilesJava
 import com.netflix.graphql.dgs.codegen.basePackageName
-import com.squareup.javapoet.TypeVariableName
+import com.squareup.javapoet.TypeName
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.fail
@@ -754,11 +754,11 @@ class ClientApiGenProjectionTest {
         ).generate()
 
         val methodSpecs = codeGenResult.clientProjections[1].typeSpec.methodSpecs
-        val methodWithArgs = methodSpecs.find { !it.isConstructor && it.parameters.size > 0 }
+        val methodWithArgs = methodSpecs.find { !it.isConstructor && it.parameters.isNotEmpty() }
             ?: fail("Method not found")
-        assertThat(methodWithArgs.returnType).extracting { (it as TypeVariableName).name }
-            .isEqualTo("AwardProjection<ActorProjection<PARENT, ROOT>, ROOT>")
+        assertThat(methodWithArgs.returnType).extracting { it.toString() }
+            .isEqualTo("com.netflix.graphql.dgs.codegen.tests.generated.client.AwardProjection<com.netflix.graphql.dgs.codegen.tests.generated.client.ActorProjection<PARENT, ROOT>, ROOT>")
         assertThat(methodWithArgs.parameters[0].name).isEqualTo("oscarsOnly")
-        assertThat(methodWithArgs.parameters[0].type.toString()).isEqualTo("java.lang.Boolean")
+        assertThat(methodWithArgs.parameters[0].type).isEqualTo(TypeName.BOOLEAN.box())
     }
 }

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/clientapi/ClientApiGenQueryTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/clientapi/ClientApiGenQueryTest.kt
@@ -19,11 +19,10 @@
 package com.netflix.graphql.dgs.codegen.clientapi
 
 import com.netflix.graphql.dgs.codegen.*
+import com.squareup.javapoet.TypeSpec
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Ignore
 import org.junit.jupiter.api.Test
 
-@Ignore
 class ClientApiGenQueryTest {
     @Test
     fun generateQueryType() {
@@ -916,17 +915,24 @@ class ClientApiGenQueryTest {
         ).generate()
 
         assertThat(codeGenResult.javaQueryTypes.size).isEqualTo(9)
-        assertThat(codeGenResult.javaQueryTypes[0].typeSpec.name).isEqualTo("ShowsGraphQLQuery")
-        assertThat(codeGenResult.javaQueryTypes[1].typeSpec.name).isEqualTo("MovieGraphQLQuery")
-
-        assertThat(codeGenResult.javaQueryTypes[2].typeSpec.name).isEqualTo("ShowsGraphQLMutation")
-        assertThat(codeGenResult.javaQueryTypes[3].typeSpec.name).isEqualTo("MovieGraphQLMutation")
-        assertThat(codeGenResult.javaQueryTypes[4].typeSpec.name).isEqualTo("FooGraphQLQuery")
-
-        assertThat(codeGenResult.javaQueryTypes[5].typeSpec.name).isEqualTo("ShowsGraphQLSubscription")
-        assertThat(codeGenResult.javaQueryTypes[6].typeSpec.name).isEqualTo("MovieGraphQLSubscription")
-        assertThat(codeGenResult.javaQueryTypes[7].typeSpec.name).isEqualTo("FooGraphQLSubscription")
-        assertThat(codeGenResult.javaQueryTypes[8].typeSpec.name).isEqualTo("BarGraphQLQuery")
+        assertThat(codeGenResult.javaQueryTypes).extracting("typeSpec", TypeSpec::class.java)
+            .satisfiesOnlyOnce { spec -> assertThat(spec.name).isEqualTo("ShowsGraphQLQuery") }
+        assertThat(codeGenResult.javaQueryTypes).extracting("typeSpec", TypeSpec::class.java)
+            .satisfiesOnlyOnce { spec -> assertThat(spec.name).isEqualTo("ShowsGraphQLSubscription") }
+        assertThat(codeGenResult.javaQueryTypes).extracting("typeSpec", TypeSpec::class.java)
+            .satisfiesOnlyOnce { spec -> assertThat(spec.name).isEqualTo("ShowsGraphQLMutation") }
+        assertThat(codeGenResult.javaQueryTypes).extracting("typeSpec", TypeSpec::class.java)
+            .satisfiesOnlyOnce { spec -> assertThat(spec.name).isEqualTo("MovieGraphQLQuery") }
+        assertThat(codeGenResult.javaQueryTypes).extracting("typeSpec", TypeSpec::class.java)
+            .satisfiesOnlyOnce { spec -> assertThat(spec.name).isEqualTo("MovieGraphQLMutation") }
+        assertThat(codeGenResult.javaQueryTypes).extracting("typeSpec", TypeSpec::class.java)
+            .satisfiesOnlyOnce { spec -> assertThat(spec.name).isEqualTo("MovieGraphQLSubscription") }
+        assertThat(codeGenResult.javaQueryTypes).extracting("typeSpec", TypeSpec::class.java)
+            .satisfiesOnlyOnce { spec -> assertThat(spec.name).isEqualTo("FooGraphQLMutation") }
+        assertThat(codeGenResult.javaQueryTypes).extracting("typeSpec", TypeSpec::class.java)
+            .satisfiesOnlyOnce { spec -> assertThat(spec.name).isEqualTo("FooGraphQLSubscription") }
+        assertThat(codeGenResult.javaQueryTypes).extracting("typeSpec", TypeSpec::class.java)
+            .satisfiesOnlyOnce { spec -> assertThat(spec.name).isEqualTo("BarGraphQLSubscription") }
 
         assertCompilesJava(codeGenResult.javaQueryTypes)
     }

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/clientapi/ClientApiGenSubscriptionTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/clientapi/ClientApiGenSubscriptionTest.kt
@@ -48,7 +48,7 @@ class ClientApiGenSubscriptionTest {
         ).generate()
 
         assertThat(codeGenResult.javaQueryTypes.size).isEqualTo(1)
-        assertThat(codeGenResult.javaQueryTypes[0].typeSpec.name).isEqualTo("MovieGraphQLQuery")
+        assertThat(codeGenResult.javaQueryTypes[0].typeSpec.name).isEqualTo("MovieGraphQLSubscription")
 
         assertCompilesJava(codeGenResult.clientProjections + codeGenResult.javaQueryTypes)
     }
@@ -81,7 +81,7 @@ class ClientApiGenSubscriptionTest {
         ).generate()
 
         assertThat(codeGenResult.javaQueryTypes.size).isEqualTo(1)
-        assertThat(codeGenResult.javaQueryTypes[0].typeSpec.name).isEqualTo("MovieGraphQLQuery")
+        assertThat(codeGenResult.javaQueryTypes[0].typeSpec.name).isEqualTo("MovieGraphQLMutation")
 
         assertCompilesJava(
             codeGenResult.clientProjections + codeGenResult.javaQueryTypes + codeGenResult.javaDataTypes
@@ -107,7 +107,7 @@ class ClientApiGenSubscriptionTest {
         ).generate()
 
         assertThat(codeGenResult.javaQueryTypes.size).isEqualTo(1)
-        assertThat(codeGenResult.javaQueryTypes[0].typeSpec.name).isEqualTo("MovieTitleGraphQLQuery")
+        assertThat(codeGenResult.javaQueryTypes[0].typeSpec.name).isEqualTo("MovieTitleGraphQLSubscription")
 
         assertCompilesJava(codeGenResult)
     }


### PR DESCRIPTION
Leverage JavaPoet features such as CodeBlocks and format specifiers.