### PR TITLE
Fix import for type mapped union sub types

### DIFF
--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
@@ -355,7 +355,7 @@ class CodeGen(private val config: CodeGenConfig) {
                 .excludeSchemaTypeExtension()
                 .map {
                     val extensions = findUnionExtensions(it.name, definitions)
-                    KotlinUnionTypeGenerator(config).generate(it, extensions)
+                    KotlinUnionTypeGenerator(config, document).generate(it, extensions)
                 }
                 .fold(CodeGenResult.EMPTY) { result, next -> result.merge(next) }
 

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinUnionTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinUnionTypeGenerator.kt
@@ -24,13 +24,15 @@ import com.netflix.graphql.dgs.codegen.shouldSkip
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.TypeSpec
+import graphql.language.Document
 import graphql.language.TypeName
 import graphql.language.UnionTypeDefinition
 import graphql.language.UnionTypeExtensionDefinition
 
-class KotlinUnionTypeGenerator(private val config: CodeGenConfig) {
+class KotlinUnionTypeGenerator(private val config: CodeGenConfig, document: Document) {
 
     private val packageName = config.packageNameTypes
+    private val typeUtils = KotlinTypeUtils(packageName, config, document)
 
     fun generate(definition: UnionTypeDefinition, extensions: List<UnionTypeExtensionDefinition>): CodeGenResult {
         if (definition.shouldSkip(config)) {
@@ -42,7 +44,8 @@ class KotlinUnionTypeGenerator(private val config: CodeGenConfig) {
 
         val memberTypes = definition.memberTypes.plus(extensions.flatMap { it.memberTypes }).asSequence()
             .filterIsInstance<TypeName>()
-            .map { member -> ClassName(packageName, member.name) }
+            .map { member -> typeUtils.findKtInterfaceName(member.name, packageName) }
+            .filterIsInstance<ClassName>()
             .toList()
 
         if (memberTypes.isNotEmpty()) {


### PR DESCRIPTION
## Issue
When generating code for union types in Kotlin, type mappings are not taken into consideration. This results in broken Kotlin classes. 

## Steps to reproduce issue
Schema:
```graphql
union Pet = Cat | Dog
type Cat implements Pet {
  name: ID!
}
type Dog implements Pet {
  name: ID!
}
```
And an implementation of Cat
```Kotlin
package com.example.animals.types

data class Cat(val id: String, val color: String)
```
And finally a typeMapping for Cat
```gradle
typeMapping = [
  "Cat": "com.example.animals.types.Cat"
]
```
Which results in errors in the generated Animal interface that complains about the missing type Cat.

## Solution
A solution to this has [already been implemented](https://github.com/Netflix/dgs-codegen/pull/657) in the Java equivalent generator. Follow the same pattern and lookup the full class name of each member type.