### PR TITLE
Added JsonProperty annotation on fields for java data type generator

### DIFF
--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/JavaCodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/JavaCodeGenTest.kt
@@ -1,0 +1,137 @@
+/*
+ *
+ *  Copyright 2020 Netflix, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package com.netflix.graphql.dgs.codegen
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.fail
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.util.stream.Collectors
+import kotlin.io.path.createDirectories
+import kotlin.io.path.exists
+import kotlin.io.path.listDirectoryEntries
+import kotlin.io.path.readText
+
+class JavaCodeGenTest {
+
+    // set this to true to update all expected outputs instead of running tests
+    private val updateExpected = false
+
+    @ParameterizedTest
+    @MethodSource("listTestsToRun")
+    fun testCodeGen(testName: String) {
+        val schema = readResource("/$testName/schema.graphql")
+
+        val codeGenResult = CodeGen(
+            CodeGenConfig(
+                schemas = setOf(schema),
+                packageName = "com.netflix.graphql.dgs.codegen.cases.$testName.expected",
+                language = Language.JAVA,
+                generateClientApi = true,
+                typeMapping = when (testName) {
+                    "dataClassWithMappedTypes" -> mapOf(
+                        "Long" to "java.Long",
+                        "DateTime" to "java.time.OffsetDateTime",
+                        "PageInfo" to "graphql.relay.PageInfo",
+                        "EntityConnection" to "graphql.relay.SimpleListConnection<com.netflix.graphql.dgs.codegen.cases.dataClassWithMappedTypes.expected.types.EntityEdge>"
+                    )
+                    "inputWithDefaultBigDecimal" -> mapOf(
+                        "Decimal" to "java.math.BigDecimal"
+                    )
+                    else -> emptyMap()
+                }
+            )
+        ).generate()
+
+        val fileNames = codeGenResult.javaSources()
+            .groupingBy { it.packageName.substringAfterLast('.') to it.typeSpec.name }
+            .eachCount()
+
+        // fail if any file was defined twice
+        fileNames
+            .filterValues { it > 1 }
+            .keys
+            .forEach { fail("Duplicate file: ${it.first}.${it.second}") }
+
+        // fail if any file was expected that's not generated
+        listAllFiles("/$testName/expected")
+            .map {
+                it.getName(it.nameCount - 2).toString() to it.getName(it.nameCount - 1).toString().removeSuffix(".kt")
+            }
+            .toSet().subtract(fileNames.keys)
+            .forEach { fail("Missing expected file: ${it.first}.${it.second}") }
+
+        codeGenResult.javaSources().forEach { spec ->
+
+            val type = spec.packageName.substringAfterLast("expected").trimStart('.')
+            val fileName = "/$testName/expected/$type/${spec.typeSpec.name}.java"
+            val actual = spec.toString()
+
+            if (updateExpected) {
+                writeExpected(fileName, actual)
+            } else {
+                assertThat(actual).isEqualTo(readResource(fileName))
+            }
+        }
+
+        assertCompilesJava(codeGenResult)
+    }
+
+    companion object {
+
+        @Suppress("unused")
+        @JvmStatic
+        fun listTestsToRun(): List<String> {
+            return getAbsolutePath("")
+                .listDirectoryEntries()
+                .map { it.getName(it.nameCount.dec()).toString() }
+                .sorted()
+        }
+
+        private fun getAbsolutePath(suffix: String): Path {
+            val projectDirAbsolutePath = Paths.get("").toAbsolutePath().toString()
+            return Paths.get(projectDirAbsolutePath, "/src/integTest/java/com/netflix/graphql/dgs/codegen/cases/$suffix")
+        }
+
+        private fun listAllFiles(suffix: String): List<Path> {
+            val path = getAbsolutePath(suffix)
+            if (!path.exists()) return emptyList()
+            return Files.walk(path)
+                .filter { Files.isRegularFile(it) }
+                .collect(Collectors.toList())
+        }
+
+        private fun readResource(fileName: String): String {
+            return getAbsolutePath(fileName).readText()
+        }
+
+        private fun writeExpected(fileName: String, content: String) {
+            val path = getAbsolutePath(fileName)
+
+            if (!path.exists()) {
+                path.parent.createDirectories()
+            }
+
+            path.toFile().writeText(content)
+        }
+    }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/cases/dataClassWithFieldHavingNameInCaps/expected/DgsConstants.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/cases/dataClassWithFieldHavingNameInCaps/expected/DgsConstants.java
@@ -1,0 +1,19 @@
+package com.netflix.graphql.dgs.codegen.cases.dataClassWithFieldHavingNameInCaps.expected;
+
+import java.lang.String;
+
+public class DgsConstants {
+  public static final String QUERY_TYPE = "Query";
+
+  public static class QUERY {
+    public static final String TYPE_NAME = "Query";
+
+    public static final String Test = "test";
+  }
+
+  public static class SOMETYPE {
+    public static final String TYPE_NAME = "SomeType";
+
+    public static final String CAPSField = "CAPSField";
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/cases/dataClassWithFieldHavingNameInCaps/expected/client/TestGraphQLQuery.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/cases/dataClassWithFieldHavingNameInCaps/expected/client/TestGraphQLQuery.java
@@ -1,0 +1,41 @@
+package com.netflix.graphql.dgs.codegen.cases.dataClassWithFieldHavingNameInCaps.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.GraphQLQuery;
+import java.lang.Override;
+import java.lang.String;
+import java.util.HashSet;
+import java.util.Set;
+
+public class TestGraphQLQuery extends GraphQLQuery {
+  public TestGraphQLQuery(String queryName) {
+    super("query", queryName);
+  }
+
+  public TestGraphQLQuery() {
+    super("query");
+  }
+
+  @Override
+  public String getOperationName() {
+    return "test";
+  }
+
+  public static Builder newRequest() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private Set<String> fieldsSet = new HashSet<>();
+
+    private String queryName;
+
+    public TestGraphQLQuery build() {
+      return new TestGraphQLQuery(queryName);                                     
+    }
+
+    public Builder queryName(String queryName) {
+      this.queryName = queryName;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/cases/dataClassWithFieldHavingNameInCaps/expected/client/TestProjectionRoot.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/cases/dataClassWithFieldHavingNameInCaps/expected/client/TestProjectionRoot.java
@@ -1,0 +1,19 @@
+package com.netflix.graphql.dgs.codegen.cases.dataClassWithFieldHavingNameInCaps.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.BaseSubProjectionNode;
+
+public class TestProjectionRoot<PARENT extends BaseSubProjectionNode<?, ?>, ROOT extends BaseSubProjectionNode<?, ?>> extends BaseSubProjectionNode<PARENT, ROOT> {
+  public TestProjectionRoot() {
+    super(null, null, java.util.Optional.of("SomeType"));
+  }
+
+  public TestProjectionRoot<PARENT, ROOT> __typename() {
+    getFields().put("__typename", null);
+    return this;
+  }
+
+  public TestProjectionRoot<PARENT, ROOT> CAPSField() {
+    getFields().put("CAPSField", null);
+    return this;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/cases/dataClassWithFieldHavingNameInCaps/expected/datafetchers/TestDatafetcher.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/cases/dataClassWithFieldHavingNameInCaps/expected/datafetchers/TestDatafetcher.java
@@ -1,0 +1,17 @@
+package com.netflix.graphql.dgs.codegen.cases.dataClassWithFieldHavingNameInCaps.expected.datafetchers;
+
+import com.netflix.graphql.dgs.DgsComponent;
+import com.netflix.graphql.dgs.DgsData;
+import com.netflix.graphql.dgs.codegen.cases.dataClassWithFieldHavingNameInCaps.expected.types.SomeType;
+import graphql.schema.DataFetchingEnvironment;
+
+@DgsComponent
+public class TestDatafetcher {
+  @DgsData(
+      parentType = "Query",
+      field = "test"
+  )
+  public SomeType getTest(DataFetchingEnvironment dataFetchingEnvironment) {
+    return null;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/cases/dataClassWithFieldHavingNameInCaps/expected/types/SomeType.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/cases/dataClassWithFieldHavingNameInCaps/expected/types/SomeType.java
@@ -1,0 +1,65 @@
+package com.netflix.graphql.dgs.codegen.cases.dataClassWithFieldHavingNameInCaps.expected.types;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.util.Objects;
+
+public class SomeType {
+  @JsonProperty("CAPSField")
+  private String CAPSField;
+
+  public SomeType() {
+  }
+
+  public SomeType(String CAPSField) {
+    this.CAPSField = CAPSField;
+  }
+
+  public String getCAPSField() {
+    return CAPSField;
+  }
+
+  public void setCAPSField(String CAPSField) {
+    this.CAPSField = CAPSField;
+  }
+
+  @Override
+  public String toString() {
+    return "SomeType{CAPSField='" + CAPSField + "'}";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    SomeType that = (SomeType) o;
+    return Objects.equals(CAPSField, that.CAPSField);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(CAPSField);
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    @JsonProperty("CAPSField")
+    private String CAPSField;
+
+    public SomeType build() {
+      SomeType result = new SomeType();
+      result.CAPSField = this.CAPSField;
+      return result;
+    }
+
+    public Builder CAPSField(String CAPSField) {
+      this.CAPSField = CAPSField;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/cases/dataClassWithFieldHavingNameInCaps/schema.graphql
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/cases/dataClassWithFieldHavingNameInCaps/schema.graphql
@@ -1,0 +1,7 @@
+type Query {
+  test: SomeType
+}
+
+type SomeType {
+  CAPSField: String
+}

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/DataTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/DataTypeGenerator.kt
@@ -468,6 +468,7 @@ abstract class BaseDataTypeGenerator(
             FieldSpec.builder(returnType, ReservedKeywordSanitizer.sanitize(fieldDefinition.name)).addModifiers(Modifier.PRIVATE)
         }
 
+        fieldBuilder.addAnnotation(jsonPropertyAnnotation(fieldDefinition.name))
         if (fieldDefinition.description != null) {
             fieldBuilder.addJavadoc("\$L", fieldDefinition.description.content)
         }

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/JavaPoetUtils.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/JavaPoetUtils.kt
@@ -65,7 +65,6 @@ fun jsonTypeInfoAnnotation(): AnnotationSpec {
         .build()
 }
 
-
 /**
  * Generate a [JsonProperty] annotation for the supplied
  * field name.
@@ -78,7 +77,7 @@ fun jsonTypeInfoAnnotation(): AnnotationSpec {
 fun jsonPropertyAnnotation(name: String): AnnotationSpec {
     return AnnotationSpec.builder(JsonProperty::class.java)
         .addMember("value", "\$S", name)
-        .build();
+        .build()
 }
 
 /**

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/JavaPoetUtils.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/JavaPoetUtils.kt
@@ -18,6 +18,7 @@
 
 package com.netflix.graphql.dgs.codegen.generators.java
 
+import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonTypeInfo
 import com.netflix.graphql.dgs.codegen.CodeGen
@@ -62,6 +63,22 @@ fun jsonTypeInfoAnnotation(): AnnotationSpec {
         .addMember("include", "\$T.\$L", JsonTypeInfo.As::class.java, JsonTypeInfo.As.PROPERTY.name)
         .addMember("property", "\$S", TypeNameMetaFieldDef.name)
         .build()
+}
+
+
+/**
+ * Generate a [JsonProperty] annotation for the supplied
+ * field name.
+ *
+ * Example generated annotation:
+ * ```
+ * @JsonProperty("fieldName")
+ * ```
+ */
+fun jsonPropertyAnnotation(name: String): AnnotationSpec {
+    return AnnotationSpec.builder(JsonProperty::class.java)
+        .addMember("value", "\$S", name)
+        .build();
 }
 
 /**


### PR DESCRIPTION
Issue: #679 

Kotlin datatype generator does add `@JsonProperty` over the fields [KotlinDataTypeGenerator.kt#L201](https://github.com/Netflix/dgs-codegen/blob/76679a630297c5dd359a34c4282d95edae7d0f1c/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinDataTypeGenerator.kt#L201) . Same was missing in Java data type generator.