### PR TITLE
Fix bug with schema jar files

### DIFF
--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
@@ -131,14 +131,13 @@ class CodeGen(private val config: CodeGenConfig) {
         loadSchemaReaders(readerBuilder, debugReaderBuilder)
         // process schema from dependencies
         config.schemaJarFilesFromDependencies.forEach { file ->
-            ZipFile(file).use { zipFile ->
-                for (entry in zipFile.entries()) {
-                    if (!entry.isDirectory && entry.name.startsWith("META-INF") &&
-                        (entry.name.endsWith(".graphqls") || entry.name.endsWith(".graphql"))
-                    ) {
-                        logger.info("Generating schema from {}: {}", file.name, entry.name)
-                        readerBuilder.reader(zipFile.getInputStream(entry).reader(), "codegen")
-                    }
+            val zipFile = ZipFile(file)
+            for (entry in zipFile.entries()) {
+                if (!entry.isDirectory && entry.name.startsWith("META-INF") &&
+                    (entry.name.endsWith(".graphqls") || entry.name.endsWith(".graphql"))
+                ) {
+                    logger.info("Generating schema from {}: {}", file.name, entry.name)
+                    readerBuilder.reader(zipFile.getInputStream(entry).reader(), "codegen")
                 }
             }
         }


### PR DESCRIPTION
When using schemaJarFilesFromDependencies, the ZipFile was closed before the reader had read the actual schema file, resulting in an IOException being thrown.