### PR TITLE
Handle duplicate types and fields in constants better

### DIFF
--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
@@ -2070,6 +2070,30 @@ class CodeGenTest {
     }
 
     @Test
+    fun `Dedupe type names in Constants to support multiple schema files`() {
+        val schema = """
+            type Query {
+                q1: String
+            }
+            
+            type Query {
+                q2: String
+            }
+        """.trimIndent()
+
+        val result = CodeGen(
+            CodeGenConfig(
+                schemas = setOf(schema),
+                packageName = basePackageName
+            )
+        ).generate()
+        val type = result.javaConstants[0].typeSpec
+        assertThat(type.typeSpecs).extracting("name").containsExactly("QUERY")
+        assertThat(type.typeSpecs[0].fieldSpecs).extracting("name")
+            .contains("Q1", "Q2")
+    }
+
+    @Test
     fun generateUnion() {
         val schema = """
             type Query {


### PR DESCRIPTION
When generating from multiple schema files, for example when generating clients for different services, it's common to find duplicate types in those schemas, starting with Query/Mutation itself.

DgsConstants wouldn't account for this and produce invalid Java code with duplicate classes/fields.
This PR merges duplicate types, which is sufficient for constants.