### PR TITLE
fix: respect disableDatesInGeneratedAnnotation when generating Kotlin code (#778)

### DIFF
--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinPoetUtils.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinPoetUtils.kt
@@ -177,8 +177,12 @@ fun suppressInapplicableJvmNameAnnotation(): AnnotationSpec =
         .addMember("%S", "INAPPLICABLE_JVM_NAME")
         .build()
 
-private fun generatedAnnotation(packageName: String, generateDate: Boolean): List<AnnotationSpec> {
-    val graphqlGenerated = AnnotationSpec
+private fun generatedAnnotation(
+    packageName: String,
+    generateDate: Boolean,
+): List<AnnotationSpec> {
+    val graphqlGenerated =
+        AnnotationSpec
             .builder(ClassName(packageName, "Generated"))
             .build()
 
@@ -187,7 +191,9 @@ private fun generatedAnnotation(packageName: String, generateDate: Boolean): Lis
     } else {
         val generatedAnnotation = ClassName.bestGuess(generatedAnnotationClassName)
 
-        var javaxGenerated = AnnotationSpec.builder(generatedAnnotation)
+        val javaxGenerated =
+            AnnotationSpec
+                .builder(generatedAnnotation)
                 .addMember("value = [%S]", CodeGen::class.qualifiedName!!)
 
         if (generateDate) {
@@ -216,18 +222,20 @@ fun jsonPropertyAnnotation(name: String): AnnotationSpec =
 fun deprecatedAnnotation(reason: String): AnnotationSpec {
     // TODO support for level
     val replace = reason.substringAfter(ParserConstants.REPLACE_WITH_STR, "")
-    val builder: AnnotationSpec.Builder = AnnotationSpec.builder(Deprecated::class)
-        .addMember(
-            "${ParserConstants.MESSAGE}${ParserConstants.ASSIGNMENT_OPERATOR}%S",
-            reason.substringBefore(ParserConstants.REPLACE_WITH_STR)
-        )
+    val builder: AnnotationSpec.Builder =
+        AnnotationSpec
+            .builder(Deprecated::class)
+            .addMember(
+                "${ParserConstants.MESSAGE}${ParserConstants.ASSIGNMENT_OPERATOR}%S",
+                reason.substringBefore(ParserConstants.REPLACE_WITH_STR),
+            )
     if (replace.isNotEmpty()) {
         builder.addMember(
             CodeBlock.of(
                 "${ParserConstants.REPLACE_WITH}${ParserConstants.ASSIGNMENT_OPERATOR}%M(%S)",
                 MemberName("kotlin", ParserConstants.REPLACE_WITH_CLASS),
-                reason.substringAfter(ParserConstants.REPLACE_WITH_STR)
-            )
+                reason.substringAfter(ParserConstants.REPLACE_WITH_STR),
+            ),
         )
     }
     return builder.build()
@@ -332,11 +340,12 @@ fun customAnnotation(
         )
     }
     if (annotationArgumentMap.containsKey(ParserConstants.INPUTS)) {
-        val codeBlocks: List<CodeBlock> = parseInputs(
-            config,
-            annotationArgumentMap[ParserConstants.INPUTS] as ObjectValue,
-            (annotationArgumentMap[ParserConstants.NAME] as StringValue).value,
-        )
+        val codeBlocks: List<CodeBlock> =
+            parseInputs(
+                config,
+                annotationArgumentMap[ParserConstants.INPUTS] as ObjectValue,
+                (annotationArgumentMap[ParserConstants.NAME] as StringValue).value,
+            )
         codeBlocks.forEach { codeBlock ->
             annotation.addMember(codeBlock)
         }
@@ -373,7 +382,6 @@ private fun generateCode(
                 CodeBlock.of("$prefix%S", string)
             }
         }
-
         is FloatValue -> CodeBlock.of("$prefix%L", (value as FloatValue).value)
         // In an enum value the prefix/type (key in the parameters map for the enum) is used to get the package name from the config
         is EnumValue ->
@@ -393,7 +401,6 @@ private fun generateCode(
                     (value as EnumValue).name,
                 ),
             )
-
         is ArrayValue ->
             if ((value as ArrayValue).values.isEmpty()) {
                 CodeBlock.of("[]")
@@ -428,8 +435,8 @@ private fun parseInputs(
                 config,
                 objectField.value,
                 annotationName,
-                objectField.name + ParserConstants.ASSIGNMENT_OPERATOR
-            )
+                objectField.name + ParserConstants.ASSIGNMENT_OPERATOR,
+            ),
         )
         codeBlocks
     }

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinPoetUtils.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinPoetUtils.kt
@@ -177,9 +177,8 @@ fun suppressInapplicableJvmNameAnnotation(): AnnotationSpec =
         .addMember("%S", "INAPPLICABLE_JVM_NAME")
         .build()
 
-private fun generatedAnnotation(packageName: String): List<AnnotationSpec> {
-    val graphqlGenerated =
-        AnnotationSpec
+private fun generatedAnnotation(packageName: String, generateDate: Boolean): List<AnnotationSpec> {
+    val graphqlGenerated = AnnotationSpec
             .builder(ClassName(packageName, "Generated"))
             .build()
 
@@ -188,14 +187,14 @@ private fun generatedAnnotation(packageName: String): List<AnnotationSpec> {
     } else {
         val generatedAnnotation = ClassName.bestGuess(generatedAnnotationClassName)
 
-        val javaxGenerated =
-            AnnotationSpec
-                .builder(generatedAnnotation)
+        var javaxGenerated = AnnotationSpec.builder(generatedAnnotation)
                 .addMember("value = [%S]", CodeGen::class.qualifiedName!!)
-                .addMember("date = %S", generatedDate)
-                .build()
 
-        listOf(javaxGenerated, graphqlGenerated)
+        if (generateDate) {
+            javaxGenerated.addMember("date = %S", generatedDate)
+        }
+
+        listOf(javaxGenerated.build(), graphqlGenerated)
     }
 }
 
@@ -217,20 +216,18 @@ fun jsonPropertyAnnotation(name: String): AnnotationSpec =
 fun deprecatedAnnotation(reason: String): AnnotationSpec {
     // TODO support for level
     val replace = reason.substringAfter(ParserConstants.REPLACE_WITH_STR, "")
-    val builder: AnnotationSpec.Builder =
-        AnnotationSpec
-            .builder(Deprecated::class)
-            .addMember(
-                "${ParserConstants.MESSAGE}${ParserConstants.ASSIGNMENT_OPERATOR}%S",
-                reason.substringBefore(ParserConstants.REPLACE_WITH_STR),
-            )
+    val builder: AnnotationSpec.Builder = AnnotationSpec.builder(Deprecated::class)
+        .addMember(
+            "${ParserConstants.MESSAGE}${ParserConstants.ASSIGNMENT_OPERATOR}%S",
+            reason.substringBefore(ParserConstants.REPLACE_WITH_STR)
+        )
     if (replace.isNotEmpty()) {
         builder.addMember(
             CodeBlock.of(
                 "${ParserConstants.REPLACE_WITH}${ParserConstants.ASSIGNMENT_OPERATOR}%M(%S)",
                 MemberName("kotlin", ParserConstants.REPLACE_WITH_CLASS),
-                reason.substringAfter(ParserConstants.REPLACE_WITH_STR),
-            ),
+                reason.substringAfter(ParserConstants.REPLACE_WITH_STR)
+            )
         )
     }
     return builder.build()
@@ -335,12 +332,11 @@ fun customAnnotation(
         )
     }
     if (annotationArgumentMap.containsKey(ParserConstants.INPUTS)) {
-        val codeBlocks: List<CodeBlock> =
-            parseInputs(
-                config,
-                annotationArgumentMap[ParserConstants.INPUTS] as ObjectValue,
-                (annotationArgumentMap[ParserConstants.NAME] as StringValue).value,
-            )
+        val codeBlocks: List<CodeBlock> = parseInputs(
+            config,
+            annotationArgumentMap[ParserConstants.INPUTS] as ObjectValue,
+            (annotationArgumentMap[ParserConstants.NAME] as StringValue).value,
+        )
         codeBlocks.forEach { codeBlock ->
             annotation.addMember(codeBlock)
         }
@@ -377,6 +373,7 @@ private fun generateCode(
                 CodeBlock.of("$prefix%S", string)
             }
         }
+
         is FloatValue -> CodeBlock.of("$prefix%L", (value as FloatValue).value)
         // In an enum value the prefix/type (key in the parameters map for the enum) is used to get the package name from the config
         is EnumValue ->
@@ -396,6 +393,7 @@ private fun generateCode(
                     (value as EnumValue).name,
                 ),
             )
+
         is ArrayValue ->
             if ((value as ArrayValue).values.isEmpty()) {
                 CodeBlock.of("[]")
@@ -425,7 +423,14 @@ private fun parseInputs(
 ): List<CodeBlock> {
     val objectFields: List<ObjectField> = inputs.objectFields
     return objectFields.fold(mutableListOf()) { codeBlocks, objectField ->
-        codeBlocks.add(generateCode(config, objectField.value, annotationName, objectField.name + ParserConstants.ASSIGNMENT_OPERATOR))
+        codeBlocks.add(
+            generateCode(
+                config,
+                objectField.value,
+                annotationName,
+                objectField.name + ParserConstants.ASSIGNMENT_OPERATOR
+            )
+        )
         codeBlocks
     }
 }
@@ -449,6 +454,8 @@ fun TypeSpec.Builder.addEnumConstants(enumSpecs: Iterable<TypeSpec>): TypeSpec.B
 fun TypeSpec.Builder.addOptionalGeneratedAnnotation(config: CodeGenConfig): TypeSpec.Builder =
     apply {
         if (config.addGeneratedAnnotation) {
-            generatedAnnotation(config.packageName).forEach { addAnnotation(it) }
+            generatedAnnotation(config.packageName, !config.disableDatesInGeneratedAnnotation).forEach {
+                addAnnotation(it)
+            }
         }
     }

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
@@ -3210,7 +3210,9 @@ class KotlinCodeGenTest {
         assertThat(annotationSpec.members).hasSize(1)
         assertThat(
             annotationSpec.members[0],
-        ).extracting("formatParts", "args").asList().contains(listOf("message = ", "%S"), listOf("Deprecated in the GraphQL schema."))
+        ).extracting("formatParts", "args")
+            .asInstanceOf(InstanceOfAssertFactories.LIST)
+            .contains(listOf("message = ", "%S"), listOf("Deprecated in the GraphQL schema."))
 
         val parameterSpec = (((dataTypes[0].members)[0] as TypeSpec).primaryConstructor as FunSpec).parameters[0]
         assertThat(parameterSpec.name).isEqualTo("name")
@@ -3222,7 +3224,9 @@ class KotlinCodeGenTest {
         assertThat(parameterSpec.annotations[1].members).hasSize(1)
         assertThat(
             parameterSpec.annotations[1].members[0],
-        ).extracting("formatParts", "args").asList().contains(listOf("message = ", "%S"), listOf("Deprecated in the GraphQL schema."))
+        ).extracting("formatParts", "args")
+            .asInstanceOf(InstanceOfAssertFactories.LIST)
+            .contains(listOf("message = ", "%S"), listOf("Deprecated in the GraphQL schema."))
     }
 
     @Test
@@ -4170,7 +4174,8 @@ It takes a title and such.
 
     @Test
     fun generateSourceWithGeneratedAnnotationWithoutDate() {
-        val schema = """
+        val schema =
+            """
             type Query {
                 employees(filter:EmployeeFilterInput) : [Person]
             }
@@ -4194,21 +4199,24 @@ It takes a title and such.
             input EmployeeFilterInput {
                 rank: String
             }
-        """.trimIndent()
+            """.trimIndent()
 
-        val codeGenResult = CodeGen(
-            CodeGenConfig(
-                schemas = setOf(schema),
-                packageName = basePackageName,
-                language = Language.KOTLIN,
-                addGeneratedAnnotation = true,
-                disableDatesInGeneratedAnnotation = true,
-                generateClientApi = true
-            )
-        ).generate()
+        val codeGenResult =
+            CodeGen(
+                CodeGenConfig(
+                    schemas = setOf(schema),
+                    packageName = BASE_PACKAGE_NAME,
+                    language = Language.KOTLIN,
+                    addGeneratedAnnotation = true,
+                    disableDatesInGeneratedAnnotation = true,
+                    generateClientApi = true,
+                ),
+            ).generate()
 
-        val (generatedAnnotationFile, allKotlinSources) = codeGenResult.kotlinSources()
-            .partition { it.name == "Generated" }
+        val (generatedAnnotationFile, allKotlinSources) =
+            codeGenResult
+                .kotlinSources()
+                .partition { it.name == "Generated" }
 
         allKotlinSources.assertKotlinGeneratedAnnotation(shouldHaveDate = false)
         codeGenResult.javaSources().assertJavaGeneratedAnnotation(shouldHaveDate = false)

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/TestUtils.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/TestUtils.kt
@@ -133,11 +133,10 @@ fun <T> invokeMethod(
     return result as T
 }
 
-fun List<FileSpec>.assertKotlinGeneratedAnnotation() =
-    onEach {
+fun List<FileSpec>.assertKotlinGeneratedAnnotation(shouldHaveDate: Boolean) = onEach {
         it.members
             .filterIsInstance(KTypeSpec::class.java)
-            .forEach { typeSpec -> typeSpec.assertKotlinGeneratedAnnotation(it) }
+        .forEach { typeSpec -> typeSpec.assertKotlinGeneratedAnnotation(it, shouldHaveDate) }
     }
 
 fun List<JavaFile>.assertJavaGeneratedAnnotation(shouldHaveDate: Boolean) =
@@ -145,10 +144,9 @@ fun List<JavaFile>.assertJavaGeneratedAnnotation(shouldHaveDate: Boolean) =
         it.typeSpec.assertJavaGeneratedAnnotation(shouldHaveDate)
     }
 
-fun KTypeSpec.assertKotlinGeneratedAnnotation(fileSpec: FileSpec) {
-    val generatedSpec =
-        annotations
-            .firstOrNull { it.canonicalName() == "$BASE_PACKAGE_NAME.Generated" }
+fun KTypeSpec.assertKotlinGeneratedAnnotation(fileSpec: FileSpec, shouldHaveDate: Boolean) {
+    val generatedSpec = annotations
+        .firstOrNull { it.canonicalName() == "$BASE_PACKAGE_NAME.Generated" }
     assertThat(generatedSpec)
         .`as`("@Generated annotation exists in %s at %s", this, fileSpec)
         .isNotNull
@@ -159,7 +157,17 @@ fun KTypeSpec.assertKotlinGeneratedAnnotation(fileSpec: FileSpec) {
         .`as`("$generatedAnnotationClassName annotation exists in %s at %s", this, fileSpec)
         .isNotNull
 
-    typeSpecs.forEach { it.assertKotlinGeneratedAnnotation(fileSpec) }
+    if (shouldHaveDate) {
+        assertThat(javaxGeneratedSpec!!.members)
+            .`as`("generatedAnnotationClassName has a date in %s at %s", this, fileSpec)
+            .anyMatch { it.toString().startsWith("date = ") }
+    } else {
+        assertThat(javaxGeneratedSpec!!.members)
+            .`as`("generatedAnnotationClassName has no date in %s at %s", this, fileSpec)
+            .noneMatch { it.toString().startsWith("date = ") }
+    }
+
+    typeSpecs.forEach { it.assertKotlinGeneratedAnnotation(fileSpec, shouldHaveDate) }
 }
 
 fun TypeSpec.assertJavaGeneratedAnnotation(shouldHaveDate: Boolean) {

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/TestUtils.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/TestUtils.kt
@@ -133,10 +133,11 @@ fun <T> invokeMethod(
     return result as T
 }
 
-fun List<FileSpec>.assertKotlinGeneratedAnnotation(shouldHaveDate: Boolean) = onEach {
+fun List<FileSpec>.assertKotlinGeneratedAnnotation(shouldHaveDate: Boolean) =
+    onEach {
         it.members
             .filterIsInstance(KTypeSpec::class.java)
-        .forEach { typeSpec -> typeSpec.assertKotlinGeneratedAnnotation(it, shouldHaveDate) }
+            .forEach { typeSpec -> typeSpec.assertKotlinGeneratedAnnotation(it, shouldHaveDate) }
     }
 
 fun List<JavaFile>.assertJavaGeneratedAnnotation(shouldHaveDate: Boolean) =
@@ -144,9 +145,13 @@ fun List<JavaFile>.assertJavaGeneratedAnnotation(shouldHaveDate: Boolean) =
         it.typeSpec.assertJavaGeneratedAnnotation(shouldHaveDate)
     }
 
-fun KTypeSpec.assertKotlinGeneratedAnnotation(fileSpec: FileSpec, shouldHaveDate: Boolean) {
-    val generatedSpec = annotations
-        .firstOrNull { it.canonicalName() == "$BASE_PACKAGE_NAME.Generated" }
+fun KTypeSpec.assertKotlinGeneratedAnnotation(
+    fileSpec: FileSpec,
+    shouldHaveDate: Boolean,
+) {
+    val generatedSpec =
+        annotations
+            .firstOrNull { it.canonicalName() == "$BASE_PACKAGE_NAME.Generated" }
     assertThat(generatedSpec)
         .`as`("@Generated annotation exists in %s at %s", this, fileSpec)
         .isNotNull


### PR DESCRIPTION
Makes the Kotlin generator respect `disableDatesInGeneratedAnnotation`. I tried to align the implementation with the Java implementation.

Running the code formatter added some unrelated formatting changes.

fixes #778