### PR TITLE
add data modifier to input type for kotlin2

### DIFF
--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/constantsForInputTypes/expected/types/PersonFilter.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/constantsForInputTypes/expected/types/PersonFilter.kt
@@ -8,7 +8,7 @@ import kotlin.Pair
 import kotlin.String
 import kotlin.collections.List
 
-public class PersonFilter @JsonCreator constructor(
+public data class PersonFilter @JsonCreator constructor(
   @JsonProperty("email")
   public val email: String? = default<PersonFilter, String?>("email", null),
 ) : GraphQLInput() {

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/constantsWithExtendedInputTypes/expected/types/PersonFilter.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/constantsWithExtendedInputTypes/expected/types/PersonFilter.kt
@@ -9,7 +9,7 @@ import kotlin.Pair
 import kotlin.String
 import kotlin.collections.List
 
-public class PersonFilter @JsonCreator constructor(
+public data class PersonFilter @JsonCreator constructor(
   @JsonProperty("email")
   public val email: String? = default<PersonFilter, String?>("email", null),
   @JsonProperty("birthYear")

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassDocs/expected/types/MovieFilter.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassDocs/expected/types/MovieFilter.kt
@@ -13,7 +13,7 @@ import kotlin.collections.List
  *
  * It takes a title and such.
  */
-public class MovieFilter @JsonCreator constructor(
+public data class MovieFilter @JsonCreator constructor(
   @JsonProperty("titleFilter")
   public val titleFilter: String? = default<MovieFilter, String?>("titleFilter", null),
 ) : GraphQLInput() {

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassFieldDocs/expected/types/MovieFilter.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassFieldDocs/expected/types/MovieFilter.kt
@@ -8,7 +8,7 @@ import kotlin.Pair
 import kotlin.String
 import kotlin.collections.List
 
-public class MovieFilter @JsonCreator constructor(
+public data class MovieFilter @JsonCreator constructor(
   @JsonProperty("titleFilter")
   public val titleFilter: String? = default<MovieFilter, String?>("titleFilter", null),
 ) : GraphQLInput() {

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/input/expected/types/MovieFilter.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/input/expected/types/MovieFilter.kt
@@ -8,7 +8,7 @@ import kotlin.Pair
 import kotlin.String
 import kotlin.collections.List
 
-public class MovieFilter @JsonCreator constructor(
+public data class MovieFilter @JsonCreator constructor(
   @JsonProperty("genre")
   public val genre: String? = default<MovieFilter, String?>("genre", null),
 ) : GraphQLInput() {

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/inputWithDefaultBigDecimal/expected/types/OrderFilter.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/inputWithDefaultBigDecimal/expected/types/OrderFilter.kt
@@ -9,7 +9,7 @@ import kotlin.Pair
 import kotlin.String
 import kotlin.collections.List
 
-public class OrderFilter @JsonCreator constructor(
+public data class OrderFilter @JsonCreator constructor(
   @JsonProperty("min")
   public val min: BigDecimal = default<OrderFilter, BigDecimal>("min", java.math.BigDecimal("1.1")),
   @JsonProperty("avg")

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/inputWithDefaultCurrency/expected/types/OrderFilter.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/inputWithDefaultCurrency/expected/types/OrderFilter.kt
@@ -9,7 +9,7 @@ import kotlin.Pair
 import kotlin.String
 import kotlin.collections.List
 
-public class OrderFilter @JsonCreator constructor(
+public data class OrderFilter @JsonCreator constructor(
   @JsonProperty("value")
   public val `value`: Currency = default<OrderFilter, Currency>("value",
       java.util.Currency.getInstance("USD")),

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/inputWithDefaultEnumValueForArray/expected/types/SomeType.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/inputWithDefaultEnumValueForArray/expected/types/SomeType.kt
@@ -8,7 +8,7 @@ import kotlin.Pair
 import kotlin.String
 import kotlin.collections.List
 
-public class SomeType @JsonCreator constructor(
+public data class SomeType @JsonCreator constructor(
   @JsonProperty("colors")
   public val colors: List<Color?>? = default<SomeType, List<Color?>?>("colors",
       listOf(com.netflix.graphql.dgs.codegen.cases.inputWithDefaultEnumValueForArray.expected.types.Color.red)),

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/inputWithDefaultIntValueForArray/expected/types/SomeType.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/inputWithDefaultIntValueForArray/expected/types/SomeType.kt
@@ -9,7 +9,7 @@ import kotlin.Pair
 import kotlin.String
 import kotlin.collections.List
 
-public class SomeType @JsonCreator constructor(
+public data class SomeType @JsonCreator constructor(
   @JsonProperty("numbers")
   public val numbers: List<Int?>? = default<SomeType, List<Int?>?>("numbers", listOf(1, 2, 3)),
 ) : GraphQLInput() {

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/inputWithDefaultStringValueForArray/expected/types/SomeType.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/inputWithDefaultStringValueForArray/expected/types/SomeType.kt
@@ -8,7 +8,7 @@ import kotlin.Pair
 import kotlin.String
 import kotlin.collections.List
 
-public class SomeType @JsonCreator constructor(
+public data class SomeType @JsonCreator constructor(
   @JsonProperty("names")
   public val names: List<String?>? = default<SomeType, List<String?>?>("names", listOf("A", "B")),
 ) : GraphQLInput() {

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/inputWithDefaultValueForArray/expected/types/SomeType.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/inputWithDefaultValueForArray/expected/types/SomeType.kt
@@ -8,7 +8,7 @@ import kotlin.Pair
 import kotlin.String
 import kotlin.collections.List
 
-public class SomeType @JsonCreator constructor(
+public data class SomeType @JsonCreator constructor(
   @JsonProperty("names")
   public val names: List<String?>? = default<SomeType, List<String?>?>("names", emptyList()),
 ) : GraphQLInput() {

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/inputWithDefaultValueForEnum/expected/types/ColorFilter.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/inputWithDefaultValueForEnum/expected/types/ColorFilter.kt
@@ -8,7 +8,7 @@ import kotlin.Pair
 import kotlin.String
 import kotlin.collections.List
 
-public class ColorFilter @JsonCreator constructor(
+public data class ColorFilter @JsonCreator constructor(
   @JsonProperty("color")
   public val color: Color? = default<ColorFilter, Color?>("color",
       com.netflix.graphql.dgs.codegen.cases.inputWithDefaultValueForEnum.expected.types.Color.red),

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/inputWithDefaultValueForNonNullableFields/expected/types/Car.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/inputWithDefaultValueForNonNullableFields/expected/types/Car.kt
@@ -8,7 +8,7 @@ import kotlin.Pair
 import kotlin.String
 import kotlin.collections.List
 
-public class Car @JsonCreator constructor(
+public data class Car @JsonCreator constructor(
   @JsonProperty("brand")
   public val brand: String = default<Car, String>("brand", "BMW"),
 ) : GraphQLInput() {

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/inputWithDefaultValueForNonNullableFields/expected/types/Person.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/inputWithDefaultValueForNonNullableFields/expected/types/Person.kt
@@ -10,7 +10,7 @@ import kotlin.Pair
 import kotlin.String
 import kotlin.collections.List
 
-public class Person @JsonCreator constructor(
+public data class Person @JsonCreator constructor(
   @JsonProperty("name")
   public val name: String = default<Person, String>("name", "Damian"),
   @JsonProperty("age")

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/inputWithDefaultValueForObject/expected/types/Car.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/inputWithDefaultValueForObject/expected/types/Car.kt
@@ -8,7 +8,7 @@ import kotlin.Pair
 import kotlin.String
 import kotlin.collections.List
 
-public class Car @JsonCreator constructor(
+public data class Car @JsonCreator constructor(
   @JsonProperty("brand")
   public val brand: String = default<Car, String>("brand", "BMW"),
 ) : GraphQLInput() {

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/inputWithDefaultValueForObject/expected/types/MovieFilter.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/inputWithDefaultValueForObject/expected/types/MovieFilter.kt
@@ -8,7 +8,7 @@ import kotlin.Pair
 import kotlin.String
 import kotlin.collections.List
 
-public class MovieFilter @JsonCreator constructor(
+public data class MovieFilter @JsonCreator constructor(
   @JsonProperty("director")
   public val director: Person? = default<MovieFilter, Person?>("director",
       com.netflix.graphql.dgs.codegen.cases.inputWithDefaultValueForObject.expected.types.Person(name

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/inputWithDefaultValueForObject/expected/types/Person.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/inputWithDefaultValueForObject/expected/types/Person.kt
@@ -9,7 +9,7 @@ import kotlin.Pair
 import kotlin.String
 import kotlin.collections.List
 
-public class Person @JsonCreator constructor(
+public data class Person @JsonCreator constructor(
   @JsonProperty("name")
   public val name: String? = default<Person, String?>("name", "John"),
   @JsonProperty("age")

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/inputWithExtendedType/expected/types/MovieFilter.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/inputWithExtendedType/expected/types/MovieFilter.kt
@@ -9,7 +9,7 @@ import kotlin.Pair
 import kotlin.String
 import kotlin.collections.List
 
-public class MovieFilter @JsonCreator constructor(
+public data class MovieFilter @JsonCreator constructor(
   @JsonProperty("genre")
   public val genre: String? = default<MovieFilter, String?>("genre", null),
   @JsonProperty("releaseYear")

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/inputWithReservedWord/expected/types/SampleInput.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/inputWithReservedWord/expected/types/SampleInput.kt
@@ -8,7 +8,7 @@ import kotlin.Pair
 import kotlin.String
 import kotlin.collections.List
 
-public class SampleInput @JsonCreator constructor(
+public data class SampleInput @JsonCreator constructor(
   @JsonProperty("return")
   public val `return`: String,
 ) : GraphQLInput() {

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/projectionWithNestedInputs/expected/types/I1.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/projectionWithNestedInputs/expected/types/I1.kt
@@ -8,7 +8,7 @@ import kotlin.Pair
 import kotlin.String
 import kotlin.collections.List
 
-public class I1 @JsonCreator constructor(
+public data class I1 @JsonCreator constructor(
   @JsonProperty("arg1")
   public val arg1: I1? = default<I1, I1?>("arg1", null),
   @JsonProperty("arg2")

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/projectionWithNestedInputs/expected/types/I2.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/projectionWithNestedInputs/expected/types/I2.kt
@@ -8,7 +8,7 @@ import kotlin.Pair
 import kotlin.String
 import kotlin.collections.List
 
-public class I2 @JsonCreator constructor(
+public data class I2 @JsonCreator constructor(
   @JsonProperty("arg1")
   public val arg1: String? = default<I2, String?>("arg1", null),
   @JsonProperty("arg2")

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/projectionWithPrimitiveAndArgs/expected/types/I.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/projectionWithPrimitiveAndArgs/expected/types/I.kt
@@ -8,7 +8,7 @@ import kotlin.Pair
 import kotlin.String
 import kotlin.collections.List
 
-public class I @JsonCreator constructor(
+public data class I @JsonCreator constructor(
   @JsonProperty("arg")
   public val arg: String? = default<I, String?>("arg", null),
 ) : GraphQLInput() {

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/projectionWithTypeAndArgs/expected/types/I.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/projectionWithTypeAndArgs/expected/types/I.kt
@@ -8,7 +8,7 @@ import kotlin.Pair
 import kotlin.String
 import kotlin.collections.List
 
-public class I @JsonCreator constructor(
+public data class I @JsonCreator constructor(
   @JsonProperty("arg")
   public val arg: String? = default<I, String?>("arg", null),
 ) : GraphQLInput() {

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin2/GenerateKotlin2InputTypes.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin2/GenerateKotlin2InputTypes.kt
@@ -82,7 +82,8 @@ fun generateKotlin2InputTypes(
                         if (inputDefinition.description != null) {
                             addKdoc("%L", inputDefinition.description.sanitizeKdoc())
                         }
-                    }.superclass(GraphQLInput::class)
+                    }.addModifiers(KModifier.DATA)
+                    .superclass(GraphQLInput::class)
                     // add a constructor with a parameter for every field
                     .primaryConstructor(
                         FunSpec


### PR DESCRIPTION
When generating Input Types with kotlin2 Generator the resulting kotlin classes are no data classes. This leads to cases where you miss `equals` and `hashcode` Methods which you may need in data fetchers.
@srinivasankavitha what do you think about it? Please let me know if you see some cases where this can be a problem (I don't see any) so I can try to improve my solution.