### PR TITLE
load external schemas from any JAR directory

### DIFF
--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
@@ -128,7 +128,7 @@ class CodeGen(private val config: CodeGenConfig) {
         config.schemaJarFilesFromDependencies.forEach { file ->
             val zipFile = ZipFile(file)
             for (entry in zipFile.entries()) {
-                if (!entry.isDirectory && entry.name.startsWith("META-INF") &&
+                if (!entry.isDirectory &&
                     (entry.name.endsWith(".graphqls") || entry.name.endsWith(".graphql"))
                 ) {
                     logger.info("Generating schema from {}: {}", file.name, entry.name)


### PR DESCRIPTION
Make external schema loading more flexible for user to load from any directory.  

Doc change: https://github.com/Netflix/dgs/pull/195