### PR TITLE
Track input fields been explicitly set vs default to null

### DIFF
--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
@@ -529,7 +529,8 @@ class CodeGenConfig(
     var implementSerializable: Boolean = false,
     var addGeneratedAnnotation: Boolean = false,
     var disableDatesInGeneratedAnnotation: Boolean = false,
-    var addDeprecatedAnnotation: Boolean = false
+    var addDeprecatedAnnotation: Boolean = false,
+    var trackInputFieldSet: Boolean = false
 ) {
     val packageNameClient: String = "$packageName.$subPackageNameClient"
 

--- a/graphql-dgs-codegen-gradle/src/main/kotlin/com/netflix/graphql/dgs/codegen/gradle/GenerateJavaTask.kt
+++ b/graphql-dgs-codegen-gradle/src/main/kotlin/com/netflix/graphql/dgs/codegen/gradle/GenerateJavaTask.kt
@@ -154,6 +154,9 @@ open class GenerateJavaTask @Inject constructor(
     var generateCustomAnnotations = false
 
     @Input
+    var trackInputFieldSet = false
+
+    @Input
     var includeImports = mutableMapOf<String, String>()
 
     @Input
@@ -220,7 +223,8 @@ open class GenerateJavaTask @Inject constructor(
             includeEnumImports = includeEnumImports,
             includeClassImports = includeClassImports,
             generateCustomAnnotations = generateCustomAnnotations,
-            javaGenerateAllConstructor = javaGenerateAllConstructor
+            javaGenerateAllConstructor = javaGenerateAllConstructor,
+            trackInputFieldSet = trackInputFieldSet
         )
 
         logger.info("Codegen config: {}", config)


### PR DESCRIPTION
Introduce a new `trackInputFieldSet` flag to track which fields are set in generated input data types.

When this flag is set to `true`, all fields in input data types will be using `Optional`. Getter/Setters will automatically unwrap the Optional to keep it the same as existing generated code.

All fields will be default to `null`, when explicitly set to `null` via setter, it will be set to `Optional.ofNullable(null)`. 

When `GraphQLQueryRequest` prepares the query, if the value is `null`, it will not include field, if the value is `Optional.ofNullable(null)`, it will include the field with value `null`