### PR TITLE
Expose javaGenerateAllConstructor flag in generateJava task

### DIFF
--- a/graphql-dgs-codegen-gradle/src/main/kotlin/com/netflix/graphql/dgs/codegen/gradle/GenerateJavaTask.kt
+++ b/graphql-dgs-codegen-gradle/src/main/kotlin/com/netflix/graphql/dgs/codegen/gradle/GenerateJavaTask.kt
@@ -101,6 +101,9 @@ open class GenerateJavaTask @Inject constructor(
     @Input
     var implementSerializable = false
 
+    @Input
+    var javaGenerateAllConstructor = true
+
     @OutputDirectory
     fun getOutputDir(): File {
         return Paths.get("$generatedSourcesDir/generated/sources/dgs-codegen").toFile()
@@ -216,7 +219,8 @@ open class GenerateJavaTask @Inject constructor(
             includeImports = includeImports,
             includeEnumImports = includeEnumImports,
             includeClassImports = includeClassImports,
-            generateCustomAnnotations = generateCustomAnnotations
+            generateCustomAnnotations = generateCustomAnnotations,
+            javaGenerateAllConstructor = javaGenerateAllConstructor
         )
 
         logger.info("Codegen config: {}", config)


### PR DESCRIPTION
This is already tested with the `generateDataClassWithNoAllConstructor` and `The javaGenerateAllConstructor flag is not applicable for Kotlin` tests

