### PR TITLE
Add support for generating variable references in client api

### DIFF
--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/clientapi/ClientApiGenBuilderTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/clientapi/ClientApiGenBuilderTest.kt
@@ -166,7 +166,7 @@ class ClientApiGenBuilderTest {
             assertThat(codeGenResult.javaQueryTypes.size).isEqualTo(1)
             assertThat(codeGenResult.javaQueryTypes[0].typeSpec.name).isEqualTo("FilterGraphQLQuery")
             assertThat(codeGenResult.javaQueryTypes[0].typeSpec.typeSpecs).hasSize(1)
-            assertThat(codeGenResult.javaQueryTypes[0].typeSpec.typeSpecs[0].methodSpecs).hasSize(4)
+            assertThat(codeGenResult.javaQueryTypes[0].typeSpec.typeSpecs[0].methodSpecs).hasSize(6)
             assertThat(codeGenResult.javaQueryTypes[0].typeSpec.typeSpecs[0].methodSpecs[1].name).isEqualTo("nameFilter")
             assertThat(codeGenResult.javaQueryTypes[0].typeSpec.javadoc.toString()).startsWith(
                 "@deprecated DO NOT USE".trimMargin()
@@ -197,7 +197,7 @@ class ClientApiGenBuilderTest {
             assertThat(codeGenResult.javaQueryTypes.size).isEqualTo(1)
             assertThat(codeGenResult.javaQueryTypes[0].typeSpec.name).isEqualTo("FilterGraphQLQuery")
             assertThat(codeGenResult.javaQueryTypes[0].typeSpec.typeSpecs).hasSize(1)
-            assertThat(codeGenResult.javaQueryTypes[0].typeSpec.typeSpecs[0].methodSpecs).hasSize(4)
+            assertThat(codeGenResult.javaQueryTypes[0].typeSpec.typeSpecs[0].methodSpecs).hasSize(6)
             assertThat(codeGenResult.javaQueryTypes[0].typeSpec.typeSpecs[0].methodSpecs[1].name).isEqualTo("nameFilter")
             assertThat(codeGenResult.javaQueryTypes[0].typeSpec.typeSpecs[0].methodSpecs[1].toString()).startsWith(
                 """
@@ -233,7 +233,7 @@ class ClientApiGenBuilderTest {
             assertThat(codeGenResult.javaQueryTypes.size).isEqualTo(1)
             assertThat(codeGenResult.javaQueryTypes[0].typeSpec.name).isEqualTo("FilterGraphQLQuery")
             assertThat(codeGenResult.javaQueryTypes[0].typeSpec.typeSpecs).hasSize(1)
-            assertThat(codeGenResult.javaQueryTypes[0].typeSpec.typeSpecs[0].methodSpecs).hasSize(4)
+            assertThat(codeGenResult.javaQueryTypes[0].typeSpec.typeSpecs[0].methodSpecs).hasSize(6)
             assertThat(codeGenResult.javaQueryTypes[0].typeSpec.typeSpecs[0].methodSpecs[1].name).isEqualTo("nameFilter")
             assertThat(codeGenResult.javaQueryTypes[0].typeSpec.typeSpecs[0].methodSpecs[1].toString()).startsWith(
                 """
@@ -271,7 +271,7 @@ class ClientApiGenBuilderTest {
             assertThat(codeGenResult.javaQueryTypes.size).isEqualTo(1)
             assertThat(codeGenResult.javaQueryTypes[0].typeSpec.name).isEqualTo("FilterGraphQLQuery")
             assertThat(codeGenResult.javaQueryTypes[0].typeSpec.typeSpecs).hasSize(1)
-            assertThat(codeGenResult.javaQueryTypes[0].typeSpec.typeSpecs[0].methodSpecs).hasSize(4)
+            assertThat(codeGenResult.javaQueryTypes[0].typeSpec.typeSpecs[0].methodSpecs).hasSize(6)
             assertThat(codeGenResult.javaQueryTypes[0].typeSpec.typeSpecs[0].methodSpecs[1].name).isEqualTo("nameFilter")
             assertThat(codeGenResult.javaQueryTypes[0].typeSpec.typeSpecs[0].methodSpecs[1].toString()).startsWith(
                 """
@@ -310,7 +310,7 @@ class ClientApiGenBuilderTest {
             assertThat(codeGenResult.javaQueryTypes.size).isEqualTo(1)
             assertThat(codeGenResult.javaQueryTypes[0].typeSpec.name).isEqualTo("FilterGraphQLQuery")
             assertThat(codeGenResult.javaQueryTypes[0].typeSpec.typeSpecs).hasSize(1)
-            assertThat(codeGenResult.javaQueryTypes[0].typeSpec.typeSpecs[0].methodSpecs).hasSize(4)
+            assertThat(codeGenResult.javaQueryTypes[0].typeSpec.typeSpecs[0].methodSpecs).hasSize(6)
             assertThat(codeGenResult.javaQueryTypes[0].typeSpec.typeSpecs[0].methodSpecs[1].name).isEqualTo("nameFilter")
             assertThat(codeGenResult.javaQueryTypes[0].typeSpec.typeSpecs[0].methodSpecs[1].annotations).isEmpty()
             assertThat(codeGenResult.javaQueryTypes[0].typeSpec.typeSpecs[0].methodSpecs[1].javadoc.isEmpty).isTrue()

--- a/graphql-dgs-codegen-shared-core/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/GraphQLQuery.kt
+++ b/graphql-dgs-codegen-shared-core/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/GraphQLQuery.kt
@@ -21,6 +21,7 @@ import graphql.language.VariableDefinition
 abstract class GraphQLQuery(val operation: String, val name: String?) {
     val input: MutableMap<String, Any> = mutableMapOf()
     val variableDefinitions = mutableListOf<VariableDefinition>()
+    val variableReferences = mutableMapOf<String, String>()
     var queryAlias: String = ""
 
     constructor(operation: String) : this(operation, null)

--- a/graphql-dgs-codegen-shared-core/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/GraphQLQueryRequest.kt
+++ b/graphql-dgs-codegen-shared-core/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/GraphQLQueryRequest.kt
@@ -21,6 +21,7 @@ import graphql.language.AstPrinter
 import graphql.language.Field
 import graphql.language.OperationDefinition
 import graphql.language.SelectionSet
+import graphql.language.VariableReference
 import graphql.schema.Coercing
 
 class GraphQLQueryRequest @JvmOverloads constructor(
@@ -63,7 +64,11 @@ class GraphQLQueryRequest @JvmOverloads constructor(
         if (query.input.isNotEmpty()) {
             selection.arguments(
                 query.input.map { (name, value) ->
-                    Argument(name, inputValueSerializer.toValue(value))
+                    if (query.variableReferences.containsKey(name)) {
+                        Argument(name, VariableReference.of(query.variableReferences[name]))
+                    } else {
+                        Argument(name, inputValueSerializer.toValue(value))
+                    }
                 }
             )
         }


### PR DESCRIPTION
Fix for https://github.com/Netflix/dgs-framework/issues/1998


Allows sending in input arguments as query variables with generated queries.
For each input argument the `Builder` for the query now has an additional `[fieldName]Reference(String reference)` field.

While constructing queries this can be used as follows:

```graphql
type Query {
    fetchByName(name: String, age: Int, aliases: [String!], filter: Filter!): [String]
}

input Filter {
    gender: Gender!
}

enum Gender { MALE, FEMALE}
```

```java
var query = new FetchByNameGraphQLQuery.Builder().queryName("MyQuery")
                .nameReference("myName")
                .ageReference("myAge")
                .aliasesReference("myAliases")
                .filterReference("myFilter")
                .build();

@Language("GraphQL") 
var serialize = new GraphQLQueryRequest(query).serialize();

var result = queryExecutor.execute(serialize, Map.of( "myName", "TestUser", "myAge", 40,"myFilter", Map.of("gender", "MALE"), "myAliases", List.of("MyAlias")));
```