### PR TITLE
Generate javadoc based on comments on individual enum values in the schema

### DIFF
--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/EnumTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/EnumTypeGenerator.kt
@@ -56,7 +56,7 @@ class EnumTypeGenerator(private val config: CodeGenConfig) {
 
         mergedEnumDefinitions.forEach {
             val typeSpec = TypeSpec.anonymousClassBuilder("")
-            if (it.description != null) {
+            if (it.description != null && it.description.content.isNotBlank()) {
                 typeSpec.addJavadoc("\$L", it.description.content)
             }
             if (it.directives.isNotEmpty()) {

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/EnumTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/EnumTypeGenerator.kt
@@ -56,6 +56,9 @@ class EnumTypeGenerator(private val config: CodeGenConfig) {
 
         mergedEnumDefinitions.forEach {
             val typeSpec = TypeSpec.anonymousClassBuilder("")
+            if (it.description != null) {
+                typeSpec.addJavadoc("\$L", it.description.content)
+            }
             if (it.directives.isNotEmpty()) {
                 val (annotations, comments) = applyDirectivesJava(it.directives, config)
                 if (!comments.isNullOrBlank()) {

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
@@ -3579,7 +3579,12 @@ It takes a title and such.
             Some options
             ""${'"'}
             enum Color {
-                red,white,blue
+                ""${'"'}
+                Option one!
+                ""${'"'}
+                red,
+                white,              
+                blue
             }                                 
         """.trimIndent()
 
@@ -3592,6 +3597,10 @@ It takes a title and such.
 
         assertThat(result.javaEnumTypes[0].typeSpec.javadoc.toString()).isEqualTo(
             """Some options
+            """.trimIndent()
+        )
+        assertThat(result.javaEnumTypes[0].typeSpec.enumConstants["red"]?.javadoc.toString()).isEqualTo(
+            """Option one!
             """.trimIndent()
         )
     }

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
@@ -3615,7 +3615,12 @@ It takes a title and such.
             Some options
             ""${'"'}
             enum Color {
-                red,white,blue
+                ""${'"'}
+                Option one!
+                ""${'"'}
+                red,
+                white,
+                blue
             }                                 
         """.trimIndent()
 
@@ -3631,6 +3636,10 @@ It takes a title and such.
 
         assertThat(type.kdoc.toString()).isEqualTo(
             """Some options
+            """.trimIndent()
+        )
+        assertThat(type.enumConstants["red"]?.kdoc.toString()).isEqualTo(
+            """Option one!
             """.trimIndent()
         )
 


### PR DESCRIPTION
Addresses https://github.com/Netflix/dgs-codegen/issues/793.

Functionality already existed on the kotlin side, but was untested AFAICT. 