### PR TITLE
Follow up on adding *Reference methods to client API queries to also support references on projections

### DIFF
--- a/graphql-dgs-codegen-shared-core/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/BaseProjectionNode.kt
+++ b/graphql-dgs-codegen-shared-core/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/BaseProjectionNode.kt
@@ -38,5 +38,13 @@ abstract class BaseProjectionNode(
     data class InputArgument(
         val name: String,
         val value: Any?,
-    )
+        val isVariableReference: Boolean = false,
+        val type: graphql.language.Type<*>? = null,
+    ) {
+        constructor(
+            name: String,
+            value: Any?,
+        ) :
+            this(name, value, false, null)
+    }
 }

--- a/graphql-dgs-codegen-shared-core/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/GraphQLQueryRequest.kt
+++ b/graphql-dgs-codegen-shared-core/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/GraphQLQueryRequest.kt
@@ -70,7 +70,7 @@ class GraphQLQueryRequest
                 InputValueSerializer(options?.scalars ?: emptyMap(), options?.graphQLContext ?: GraphQLContext.getDefault())
             }
 
-        val projectionSerializer = ProjectionSerializer(inputValueSerializer)
+        val projectionSerializer = ProjectionSerializer(inputValueSerializer, query)
 
         fun serialize(): String = serialize(false)
 
@@ -81,10 +81,6 @@ class GraphQLQueryRequest
 
             query.name?.let { operationDef.name(it) }
             query.getOperationType()?.let { operationDef.operation(OperationDefinition.Operation.valueOf(it.uppercase())) }
-
-            if (query.variableDefinitions.isNotEmpty()) {
-                operationDef.variableDefinitions(query.variableDefinitions)
-            }
 
             val selection = Field.newField(query.getOperationName())
             if (query.input.isNotEmpty()) {
@@ -109,6 +105,10 @@ class GraphQLQueryRequest
                 if (selectionSetFromProjection.selections.isNotEmpty()) {
                     selection.selectionSet(selectionSetFromProjection)
                 }
+            }
+
+            if (query.variableDefinitions.isNotEmpty()) {
+                operationDef.variableDefinitions(query.variableDefinitions)
             }
 
             if (selectionSet != null) {

--- a/graphql-dgs-codegen-shared-core/src/test/kotlin/com/netflix/graphql/dgs/client/codegen/GraphQLQueryRequestTest.kt
+++ b/graphql-dgs-codegen-shared-core/src/test/kotlin/com/netflix/graphql/dgs/client/codegen/GraphQLQueryRequestTest.kt
@@ -185,7 +185,7 @@ class GraphQLQueryRequestTest {
                 input["movie"] = Movie(123, "greatMovie")
             }
         val inputValueSerializer = InputValueSerializer(emptyMap())
-        val projectionSerializer = ProjectionSerializer(inputValueSerializer)
+        val projectionSerializer = ProjectionSerializer(inputValueSerializer, query)
         val selectionSet = projectionSerializer.toSelectionSet(MovieProjection().name().movieId())
         val request = GraphQLQueryRequest(query, selectionSet)
         val result = request.serialize()
@@ -211,7 +211,7 @@ class GraphQLQueryRequestTest {
             }
         val scalars = mapOf(DateRange::class.java to DateRangeScalar(), ZoneId::class.java to ZoneIdScalar())
         val inputValueSerializer = InputValueSerializer(scalars)
-        val projectionSerializer = ProjectionSerializer(inputValueSerializer)
+        val projectionSerializer = ProjectionSerializer(inputValueSerializer, query)
         val selectionSet = projectionSerializer.toSelectionSet(MovieProjection().name().movieId())
         val request =
             GraphQLQueryRequest(query, selectionSet, scalars)

--- a/graphql-dgs-codegen-shared-core/src/test/kotlin/com/netflix/graphql/dgs/client/codegen/ProjectionSerializerTest.kt
+++ b/graphql-dgs-codegen-shared-core/src/test/kotlin/com/netflix/graphql/dgs/client/codegen/ProjectionSerializerTest.kt
@@ -27,11 +27,13 @@ import java.time.ZoneOffset
 import java.util.*
 
 internal class ProjectionSerializerTest {
+    val query = TestGraphQLQuery()
+
     @Test
     fun `Projection with argument that requires a scalar`() {
         val scalars: Map<Class<*>, Coercing<*, *>> =
             mapOf(OffsetDateTime::class.java to ExtendedScalars.DateTime.coercing)
-        val projectionSerializer = ProjectionSerializer(InputValueSerializer(scalars))
+        val projectionSerializer = ProjectionSerializer(InputValueSerializer(scalars), query)
 
         val projection =
             ShowsProjectionRoot()
@@ -63,7 +65,7 @@ internal class ProjectionSerializerTest {
             .username()
             .score()
         // when
-        val serialized = ProjectionSerializer(InputValueSerializer()).serialize(root)
+        val serialized = ProjectionSerializer(InputValueSerializer(), query).serialize(root)
         // then
         assertThat(serialized).isEqualTo(
             """{
@@ -96,7 +98,7 @@ internal class ProjectionSerializerTest {
                 .score()
                 .root()
         // when
-        val serialized = ProjectionSerializer(InputValueSerializer()).serialize(root)
+        val serialized = ProjectionSerializer(InputValueSerializer(), query).serialize(root)
         // then
         assertThat(serialized).isEqualTo(
             """{


### PR DESCRIPTION
Example schema: 

```graphql
type Query {
    fetchByName: [Person]
}

type Person {
    name(showFullName: Boolean): String
    bio(maxLength: Int): String
}
```

This now generates a `awardsWithVariableReferences` method to be used to reference query variables.

```java
var query = new FetchByNameGraphQLQuery.Builder().queryName("MyQuery")
                .build();
@Language("GraphQL") var serialize = new GraphQLQueryRequest(query, new FetchByNameProjectionRoot<>()
                .nameWithVariableReferences("showFullName").parent()
                .bioWithVariableReferences("maxBioLength"))
                .serialize();
```

This produces the following query:

```
query MyQuery($showFullName: Boolean, $maxBioLength: Int) {
  fetchByName {
    name(showFullName: $showFullName)
    bio(maxLength: $maxBioLength)
  }
}
```