### PR TITLE
fix bug with interface fields with @skipcodegen directive not being filtered out #790

### DIFF
--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinInterfaceTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinInterfaceTypeGenerator.kt
@@ -20,6 +20,7 @@ package com.netflix.graphql.dgs.codegen.generators.kotlin
 
 import com.netflix.graphql.dgs.codegen.CodeGenConfig
 import com.netflix.graphql.dgs.codegen.CodeGenResult
+import com.netflix.graphql.dgs.codegen.filterSkipped
 import com.netflix.graphql.dgs.codegen.shouldSkip
 import com.squareup.kotlinpoet.*
 import graphql.language.*
@@ -63,7 +64,7 @@ class KotlinInterfaceTypeGenerator(
 
         val mergedFieldDefinitions = definition.fieldDefinitions + extensions.flatMap { it.fieldDefinitions }
 
-        mergedFieldDefinitions.forEach { field ->
+        mergedFieldDefinitions.filterSkipped().forEach { field ->
             val returnType = typeUtils.findReturnType(field.type)
             val nullableType = if (typeUtils.isNullable(field.type)) returnType.copy(nullable = true) else returnType
             val propertySpec = PropertySpec.builder(field.name, nullableType)

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
@@ -3255,6 +3255,31 @@ class KotlinCodeGenTest {
     }
 
     @Test
+    fun skipCodegenOnInterfaceFields() {
+        val schema =
+            """
+            interface Person {
+                name: String
+                email: String @skipcodegen
+            }
+            """.trimIndent()
+
+        val dataTypes =
+            CodeGen(
+                CodeGenConfig(
+                    schemas = setOf(schema),
+                    packageName = BASE_PACKAGE_NAME,
+                    language = Language.KOTLIN,
+                ),
+            ).generate().kotlinInterfaces
+        assertThat(dataTypes).extracting("name").containsExactly("Person")
+        val type = dataTypes[0].members[0] as TypeSpec
+        assertThat(type.propertySpecs).extracting("name").containsExactly("name")
+
+        assertCompilesKotlin(dataTypes)
+    }
+
+    @Test
     fun generateWithCustomSubPackageName() {
         val schema =
             """


### PR DESCRIPTION
Works fine for Java and Kotlin2, only broken for Kotlin. All three cases now have a unit test for using `@skipcodegen` directive on interfaces.