### PR TITLE
sanitize name enum constant for Kotlin code generation as it clashes with the inherited name property from the Enum class #763

### DIFF
--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ConstantsGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ConstantsGenerator.kt
@@ -37,6 +37,8 @@ class ConstantsGenerator(
     private val config: CodeGenConfig,
     private val document: Document,
 ) {
+    private val javaReservedKeywordSanitizer = JavaReservedKeywordSanitizer()
+
     fun generate(): CodeGenResult {
         val javaType =
             TypeSpec
@@ -217,7 +219,7 @@ class ConstantsGenerator(
         constantsType: TypeSpec.Builder,
         fieldName: String,
     ) {
-        val sanitizedFieldName = ReservedKeywordSanitizer.sanitize(fieldName.capitalized())
+        val sanitizedFieldName = javaReservedKeywordSanitizer.sanitize(fieldName.capitalized())
         if (!constantsType.fieldSpecs.any { it.name == sanitizedFieldName }) {
             constantsType.addField(
                 FieldSpec

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/EnumTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/EnumTypeGenerator.kt
@@ -33,6 +33,8 @@ import javax.lang.model.element.Modifier
 class EnumTypeGenerator(
     private val config: CodeGenConfig,
 ) {
+    private val javaReservedKeywordSanitizer = JavaReservedKeywordSanitizer()
+
     companion object {
         private val logger: Logger = LoggerFactory.getLogger(EnumTypeGenerator::class.java)
     }
@@ -76,7 +78,7 @@ class EnumTypeGenerator(
                     }
                 }
             }
-            javaType.addEnumConstant(ReservedKeywordSanitizer.sanitize(it.name), typeSpec.build())
+            javaType.addEnumConstant(javaReservedKeywordSanitizer.sanitize(it.name), typeSpec.build())
         }
 
         val javaFile = JavaFile.builder(getPackageName(), javaType.build()).build()

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/InterfaceGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/InterfaceGenerator.kt
@@ -40,6 +40,7 @@ class InterfaceGenerator(
         private val logger: Logger = LoggerFactory.getLogger(InterfaceGenerator::class.java)
     }
 
+    private val javaReservedKeywordSanitizer = JavaReservedKeywordSanitizer()
     private val packageName = config.packageNameTypes
     private val typeUtils = TypeUtils(packageName, config, document)
     private val useInterfaceType = config.generateInterfaces
@@ -154,7 +155,7 @@ class InterfaceGenerator(
                     .methodBuilder(
                         typeUtils.transformIfDefaultClassMethodExists("set${fieldName.capitalized()}", TypeUtils.Companion.SET_CLASS),
                     ).addModifiers(Modifier.ABSTRACT, Modifier.PUBLIC)
-                    .addParameter(returnType, ReservedKeywordSanitizer.sanitize(fieldName))
+                    .addParameter(returnType, javaReservedKeywordSanitizer.sanitize(fieldName))
 
             if (fieldDefinition.description != null) {
                 setterBuilder.addJavadoc("\$L", fieldDefinition.description.content)

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/JavaReservedKeywordSanitizer.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/JavaReservedKeywordSanitizer.kt
@@ -18,25 +18,14 @@
 
 package com.netflix.graphql.dgs.codegen.generators.java
 
-import javax.lang.model.SourceVersion
+import com.netflix.graphql.dgs.codegen.generators.shared.ReservedKeywordSanitizer
 
-class ReservedKeywordSanitizer {
-    companion object {
-        private val reservedKeywords =
-            setOf(
-                "_",
-                "parent",
-                "protected",
-                "root",
-            )
-
-        private const val PREFIX = "_"
-
-        fun sanitize(originalName: String): String =
-            if (originalName in reservedKeywords || SourceVersion.isKeyword(originalName)) {
-                "$PREFIX$originalName"
-            } else {
-                originalName
-            }
-    }
+class JavaReservedKeywordSanitizer : ReservedKeywordSanitizer() {
+    override val reservedKeywords =
+        setOf(
+            "_",
+            "parent",
+            "protected",
+            "root",
+        )
 }

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinEnumTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinEnumTypeGenerator.kt
@@ -21,7 +21,6 @@ package com.netflix.graphql.dgs.codegen.generators.kotlin
 import com.netflix.graphql.dgs.codegen.CodeGenConfig
 import com.netflix.graphql.dgs.codegen.CodeGenResult
 import com.netflix.graphql.dgs.codegen.generators.java.EnumTypeGenerator
-import com.netflix.graphql.dgs.codegen.generators.java.ReservedKeywordSanitizer
 import com.netflix.graphql.dgs.codegen.generators.shared.applyDirectivesKotlin
 import com.netflix.graphql.dgs.codegen.shouldSkip
 import com.squareup.kotlinpoet.FileSpec
@@ -34,6 +33,7 @@ import org.slf4j.LoggerFactory
 class KotlinEnumTypeGenerator(
     private val config: CodeGenConfig,
 ) {
+    private val kotlinReservedKeywordSanitizer = KotlinReservedKeywordSanitizer()
     private val logger: Logger = LoggerFactory.getLogger(EnumTypeGenerator::class.java)
 
     fun generate(
@@ -68,7 +68,7 @@ class KotlinEnumTypeGenerator(
                         applyDirectivesKotlin(it.directives, config),
                     )
             }
-            kotlinType.addEnumConstant(ReservedKeywordSanitizer.sanitize(it.name), typeSpec.build())
+            kotlinType.addEnumConstant(kotlinReservedKeywordSanitizer.sanitize(it.name), typeSpec.build())
         }
 
         kotlinType.addType(TypeSpec.companionObjectBuilder().addOptionalGeneratedAnnotation(config).build())

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinReservedKeywordSanitizer.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinReservedKeywordSanitizer.kt
@@ -1,0 +1,32 @@
+/*
+ *
+ *  Copyright 2020 Netflix, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package com.netflix.graphql.dgs.codegen.generators.kotlin
+
+import com.netflix.graphql.dgs.codegen.generators.shared.ReservedKeywordSanitizer
+
+class KotlinReservedKeywordSanitizer : ReservedKeywordSanitizer() {
+    override val reservedKeywords =
+        setOf(
+            "_",
+            "parent",
+            "protected",
+            "root",
+            "name",
+        )
+}

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/shared/ReservedKeywordSanitizer.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/shared/ReservedKeywordSanitizer.kt
@@ -1,0 +1,33 @@
+/*
+ *
+ *  Copyright 2020 Netflix, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package com.netflix.graphql.dgs.codegen.generators.shared
+
+import javax.lang.model.SourceVersion
+
+abstract class ReservedKeywordSanitizer {
+    protected abstract val reservedKeywords: Set<String>
+    private val prefix: String = "_"
+
+    fun sanitize(originalName: String): String =
+        if (originalName in reservedKeywords || SourceVersion.isKeyword(originalName)) {
+            "$prefix$originalName"
+        } else {
+            originalName
+        }
+}

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
@@ -1072,6 +1072,7 @@ class CodeGenTest {
                 default
                 root
                 new
+                name
             }
             """.trimIndent()
 
@@ -1086,11 +1087,7 @@ class CodeGenTest {
         // Check generated enum type
         assertThat(codeGenResult.javaEnumTypes.size).isEqualTo(1)
         assertThat(codeGenResult.javaEnumTypes[0].typeSpec.name).isEqualTo("EmployeeTypes")
-        assertThat(
-            codeGenResult.javaEnumTypes[0]
-                .typeSpec.enumConstants.size,
-        ).isEqualTo(3)
-        assertThat(codeGenResult.javaEnumTypes[0].typeSpec.enumConstants).containsKeys("_default", "_root", "_new")
+        assertThat(codeGenResult.javaEnumTypes[0].typeSpec.enumConstants).containsOnlyKeys("_default", "_root", "_new", "name")
 
         assertCompilesJava(codeGenResult.javaEnumTypes)
     }

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
@@ -1016,6 +1016,7 @@ class KotlinCodeGenTest {
                 default
                 root
                 new
+                name
             }
             """.trimIndent()
 
@@ -1031,8 +1032,7 @@ class KotlinCodeGenTest {
 
         // Check generated enum type
         assertThat(type.name).isEqualTo("EmployeeTypes")
-        assertThat(type.enumConstants.size).isEqualTo(3)
-        assertThat(type.enumConstants).containsKeys("_default", "_root", "_new")
+        assertThat(type.enumConstants).containsOnlyKeys("_default", "_root", "_new", "_name")
         assertThat(type.typeSpecs[0].isCompanion).isTrue
 
         assertCompilesKotlin(result.kotlinDataTypes + result.kotlinEnumTypes)


### PR DESCRIPTION
As reported in https://github.com/Netflix/dgs-codegen/issues/763, when enum has a `name` constant, Kotlin code gen fails with `"constant with name "name" conflicts with a supertype member with the same name`. Java Codegen works just fine. Refactored to have a base reserved keyword sanitizer class so that we can define different reserved keywords for Java and Kotlin.