### PR TITLE
Align the dgs-codegen-core and dgs-codegen-shared-core

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,13 +46,18 @@ allprojects {
     group = 'com.netflix.graphql.dgs.codegen'
 
     dependencies {
-        implementation platform("org.jetbrains.kotlin:kotlin-bom:${Versions.KOTLIN_VERSION}")
-        testImplementation "org.jetbrains.kotlin:kotlin-compiler"
+        // Gradle Platforms applied to all modudles
+        api platform("com.netflix.graphql.dgs:graphql-dgs-platform-dependencies:10.0.4")
 
+        implementation platform("org.jetbrains.kotlin:kotlin-bom:${Versions.KOTLIN_VERSION}")
+
+        // Test dependencies
         testImplementation platform('org.junit:junit-bom:5.10.+')
+        testImplementation 'org.jetbrains.kotlin:kotlin-compiler'
         testImplementation 'org.assertj:assertj-core:3.27.+'
         testImplementation 'org.junit.jupiter:junit-jupiter'
         testImplementation 'org.junit.jupiter:junit-jupiter-params'
+
         testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 
     }

--- a/dependencies.lock
+++ b/dependencies.lock
@@ -1,10 +1,28 @@
 {
     "apiDependenciesMetadata": {
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "locked": "10.0.4",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform-dependencies"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform-dependencies": {
+            "locked": "10.0.4"
+        },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "2.0.21"
         }
     },
     "compileClasspath": {
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "locked": "10.0.4",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform-dependencies"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform-dependencies": {
+            "locked": "10.0.4"
+        },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "2.0.21"
         },
@@ -22,6 +40,15 @@
         }
     },
     "implementationDependenciesMetadata": {
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "locked": "10.0.4",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform-dependencies"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform-dependencies": {
+            "locked": "10.0.4"
+        },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "2.0.21"
         },
@@ -746,6 +773,15 @@
         }
     },
     "runtimeClasspath": {
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "locked": "10.0.4",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform-dependencies"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform-dependencies": {
+            "locked": "10.0.4"
+        },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "2.0.21"
         },
@@ -763,6 +799,15 @@
         }
     },
     "testCompileClasspath": {
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "locked": "10.0.4",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform-dependencies"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform-dependencies": {
+            "locked": "10.0.4"
+        },
         "net.bytebuddy:byte-buddy": {
             "locked": "1.15.11",
             "transitive": [
@@ -907,6 +952,15 @@
         }
     },
     "testImplementationDependenciesMetadata": {
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "locked": "10.0.4",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform-dependencies"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform-dependencies": {
+            "locked": "10.0.4"
+        },
         "net.bytebuddy:byte-buddy": {
             "locked": "1.15.11",
             "transitive": [
@@ -1043,6 +1097,15 @@
         }
     },
     "testRuntimeClasspath": {
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "locked": "10.0.4",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform-dependencies"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform-dependencies": {
+            "locked": "10.0.4"
+        },
         "net.bytebuddy:byte-buddy": {
             "locked": "1.15.11",
             "transitive": [

--- a/graphql-dgs-codegen-core/build.gradle
+++ b/graphql-dgs-codegen-core/build.gradle
@@ -25,9 +25,8 @@ plugins {
 
 dependencies {
     implementation(project(':graphql-dgs-codegen-shared-core'))
-
     implementation('com.netflix.graphql.dgs:graphql-dgs') { transitive = false }
-    implementation 'com.graphql-java:graphql-java'
+
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.18.3'
     implementation 'com.fasterxml.jackson.core:jackson-annotations:2.18.3'
     implementation 'org.slf4j:slf4j-api'
@@ -39,9 +38,9 @@ dependencies {
     implementation 'org.jetbrains.kotlinx:kotlinx-serialization-json:1.8.+'
     implementation 'jakarta.annotation:jakarta.annotation-api:3.0.+'
 
-    testImplementation("com.google.guava:guava:33.4.+")
+    testImplementation 'com.google.guava:guava:33.4.+'
     testImplementation 'com.google.testing.compile:compile-testing:0.+'
-    testImplementation "org.jetbrains.kotlin:kotlin-compiler"
+    testImplementation 'org.jetbrains.kotlin:kotlin-compiler'
 }
 
 application {

--- a/graphql-dgs-codegen-core/dependencies.lock
+++ b/graphql-dgs-codegen-core/dependencies.lock
@@ -1,5 +1,14 @@
 {
     "apiDependenciesMetadata": {
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "locked": "10.0.4",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform-dependencies"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform-dependencies": {
+            "locked": "10.0.4"
+        },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "2.0.21"
         }
@@ -322,6 +331,11 @@
             "transitive": [
                 "com.graphql-java:java-dataloader"
             ]
+        }
+    },
+    "integTestApiDependenciesMetadata": {
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "2.0.21"
         }
     },
     "integTestCompileClasspath": {

--- a/graphql-dgs-codegen-gradle/build.gradle
+++ b/graphql-dgs-codegen-gradle/build.gradle
@@ -23,12 +23,12 @@ plugins {
 apply plugin: 'java-gradle-plugin'
 
 dependencies {
-    api project(":graphql-dgs-codegen-core")
-    compileOnly "com.netflix.nebula:gradle-dependency-lock-plugin:15.2.0"
-    compileOnly "org.jetbrains.kotlin:kotlin-gradle-plugin"
+    api project(':graphql-dgs-codegen-core')
+    compileOnly 'com.netflix.nebula:gradle-dependency-lock-plugin:15.2.0'
+    compileOnly 'org.jetbrains.kotlin:kotlin-gradle-plugin'
 
     testApi gradleTestKit()
-    testImplementation("com.google.guava:guava:33.4.+")
+    testImplementation('com.google.guava:guava:33.4.+')
 }
 
 description = 'Netflix GraphQL DGS Code Generation Plugin'

--- a/graphql-dgs-codegen-gradle/dependencies.lock
+++ b/graphql-dgs-codegen-gradle/dependencies.lock
@@ -3,6 +3,18 @@
         "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core": {
             "project": true
         },
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "locked": "10.0.4",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform-dependencies"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform-dependencies": {
+            "locked": "10.0.4",
+            "transitive": [
+                "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
+            ]
+        },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "2.0.21",
             "transitive": [
@@ -13,6 +25,18 @@
     "compileClasspath": {
         "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core": {
             "project": true
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "locked": "10.0.4",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform-dependencies"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform-dependencies": {
+            "locked": "10.0.4",
+            "transitive": [
+                "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
+            ]
         },
         "com.netflix.nebula:gradle-dependency-lock-plugin": {
             "locked": "15.2.0"
@@ -175,6 +199,18 @@
     "implementationDependenciesMetadata": {
         "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core": {
             "project": true
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "locked": "10.0.4",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform-dependencies"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform-dependencies": {
+            "locked": "10.0.4",
+            "transitive": [
+                "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
+            ]
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "2.0.21"
@@ -972,7 +1008,6 @@
         "com.graphql-java:graphql-java": {
             "locked": "22.3",
             "transitive": [
-                "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core",
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-shared-core",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -1009,6 +1044,7 @@
         "com.netflix.graphql.dgs:graphql-dgs-platform-dependencies": {
             "locked": "10.0.4",
             "transitive": [
+                "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core",
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-shared-core"
             ]
         },
@@ -1176,6 +1212,18 @@
         },
         "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core": {
             "project": true
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "locked": "10.0.4",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform-dependencies"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform-dependencies": {
+            "locked": "10.0.4",
+            "transitive": [
+                "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
+            ]
         },
         "net.bytebuddy:byte-buddy": {
             "locked": "1.15.11",
@@ -1357,6 +1405,18 @@
         },
         "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core": {
             "project": true
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "locked": "10.0.4",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform-dependencies"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform-dependencies": {
+            "locked": "10.0.4",
+            "transitive": [
+                "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core"
+            ]
         },
         "net.bytebuddy:byte-buddy": {
             "locked": "1.15.11",
@@ -1599,7 +1659,6 @@
         "com.graphql-java:graphql-java": {
             "locked": "22.3",
             "transitive": [
-                "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core",
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-shared-core",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -1636,6 +1695,7 @@
         "com.netflix.graphql.dgs:graphql-dgs-platform-dependencies": {
             "locked": "10.0.4",
             "transitive": [
+                "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core",
                 "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-shared-core"
             ]
         },

--- a/graphql-dgs-codegen-shared-core/build.gradle
+++ b/graphql-dgs-codegen-shared-core/build.gradle
@@ -21,9 +21,9 @@ plugins {
 }
 
 dependencies {
-    api platform('com.netflix.graphql.dgs:graphql-dgs-platform-dependencies:10.0.4')
-    implementation 'org.jetbrains.kotlin:kotlin-reflect'
     api 'com.graphql-java:graphql-java'
+
+    implementation 'org.jetbrains.kotlin:kotlin-reflect'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.18.3'
     implementation 'com.fasterxml.jackson.core:jackson-annotations:2.18.3'
 


### PR DESCRIPTION
## Objective


This commit aligns the dgs-codegen-core and dgs-codegen-shared-core such that they share the same graphql-java version. This will prevent deviations that might cause confusion.

## Changes

This commit adds the platform bom as an `api` and `implementation` platform for all sub-modules, simplifying the coordination of the DGS BOM version that is used. In addition, the `graphql-dgs-codegen-core` will now fetch transitively the `graphql-java` dependency from `graphql-dgs-codegen-shared-core` ensuring both use the same version.

## Other

* Updating the Dependency Locks