### PR TITLE
Build: Adopt Jackson BOM to help manage the Jackson Version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,7 @@ allprojects {
         api platform("com.netflix.graphql.dgs:graphql-dgs-platform-dependencies:10.0.4")
 
         implementation platform("org.jetbrains.kotlin:kotlin-bom:${Versions.KOTLIN_VERSION}")
+        implementation platform("com.fasterxml.jackson:jackson-bom:2.18.3")
 
         // Test dependencies
         testImplementation platform('org.junit:junit-bom:5.10.+')

--- a/dependencies.lock
+++ b/dependencies.lock
@@ -14,6 +14,9 @@
         }
     },
     "compileClasspath": {
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.18.3"
+        },
         "com.netflix.graphql.dgs:graphql-dgs-platform": {
             "locked": "10.0.4",
             "transitive": [
@@ -40,6 +43,9 @@
         }
     },
     "implementationDependenciesMetadata": {
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.18.3"
+        },
         "com.netflix.graphql.dgs:graphql-dgs-platform": {
             "locked": "10.0.4",
             "transitive": [
@@ -773,6 +779,9 @@
         }
     },
     "runtimeClasspath": {
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.18.3"
+        },
         "com.netflix.graphql.dgs:graphql-dgs-platform": {
             "locked": "10.0.4",
             "transitive": [
@@ -799,6 +808,9 @@
         }
     },
     "testCompileClasspath": {
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.18.3"
+        },
         "com.netflix.graphql.dgs:graphql-dgs-platform": {
             "locked": "10.0.4",
             "transitive": [
@@ -952,6 +964,9 @@
         }
     },
     "testImplementationDependenciesMetadata": {
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.18.3"
+        },
         "com.netflix.graphql.dgs:graphql-dgs-platform": {
             "locked": "10.0.4",
             "transitive": [
@@ -1097,6 +1112,9 @@
         }
     },
     "testRuntimeClasspath": {
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.18.3"
+        },
         "com.netflix.graphql.dgs:graphql-dgs-platform": {
             "locked": "10.0.4",
             "transitive": [

--- a/graphql-dgs-codegen-core/build.gradle
+++ b/graphql-dgs-codegen-core/build.gradle
@@ -27,8 +27,8 @@ dependencies {
     implementation(project(':graphql-dgs-codegen-shared-core'))
     implementation('com.netflix.graphql.dgs:graphql-dgs') { transitive = false }
 
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.18.3'
-    implementation 'com.fasterxml.jackson.core:jackson-annotations:2.18.3'
+    implementation 'com.fasterxml.jackson.core:jackson-databind'
+    implementation 'com.fasterxml.jackson.core:jackson-annotations'
     implementation 'org.slf4j:slf4j-api'
 
     implementation 'com.squareup:javapoet:1.13.+'

--- a/graphql-dgs-codegen-core/dependencies.lock
+++ b/graphql-dgs-codegen-core/dependencies.lock
@@ -1122,7 +1122,8 @@
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
-                "com.fasterxml.jackson.core:jackson-databind"
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-shared-core"
             ]
         },
         "com.github.ajalt.clikt:clikt": {
@@ -2332,7 +2333,8 @@
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
-                "com.fasterxml.jackson.core:jackson-databind"
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-shared-core"
             ]
         },
         "com.github.ajalt.clikt:clikt": {
@@ -3308,7 +3310,8 @@
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
-                "com.fasterxml.jackson.core:jackson-databind"
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-shared-core"
             ]
         },
         "com.github.ajalt.clikt:clikt": {

--- a/graphql-dgs-codegen-gradle/dependencies.lock
+++ b/graphql-dgs-codegen-gradle/dependencies.lock
@@ -23,6 +23,9 @@
         }
     },
     "compileClasspath": {
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.18.3"
+        },
         "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core": {
             "project": true
         },
@@ -197,6 +200,9 @@
         }
     },
     "implementationDependenciesMetadata": {
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.18.3"
+        },
         "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core": {
             "project": true
         },
@@ -966,7 +972,9 @@
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
-                "com.fasterxml.jackson.core:jackson-databind"
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core",
+                "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-shared-core"
             ]
         },
         "com.github.ajalt.clikt:clikt": {
@@ -1183,6 +1191,9 @@
         }
     },
     "testCompileClasspath": {
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.18.3"
+        },
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.36.0",
             "transitive": [
@@ -1376,6 +1387,9 @@
         }
     },
     "testImplementationDependenciesMetadata": {
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.18.3"
+        },
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.36.0",
             "transitive": [
@@ -1590,7 +1604,9 @@
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
-                "com.fasterxml.jackson.core:jackson-databind"
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core",
+                "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-shared-core"
             ]
         },
         "com.github.ajalt.clikt:clikt": {

--- a/graphql-dgs-codegen-shared-core/build.gradle
+++ b/graphql-dgs-codegen-shared-core/build.gradle
@@ -24,8 +24,8 @@ dependencies {
     api 'com.graphql-java:graphql-java'
 
     implementation 'org.jetbrains.kotlin:kotlin-reflect'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.18.3'
-    implementation 'com.fasterxml.jackson.core:jackson-annotations:2.18.3'
+    implementation 'com.fasterxml.jackson.core:jackson-databind'
+    implementation 'com.fasterxml.jackson.core:jackson-annotations'
 
     testImplementation 'com.netflix.graphql.dgs:graphql-dgs-extended-scalars'
 }


### PR DESCRIPTION
This commit adopts the jackson-bom so that the version of the jackson dependencies is managed via it and in one single place.

