### PR TITLE
fix tests after gradle bump to version 8.14.3

### DIFF
--- a/graphql-dgs-codegen-gradle/src/test/kotlin/com/netflix/graphql/dgs/CodegenGradlePluginTest.kt
+++ b/graphql-dgs-codegen-gradle/src/test/kotlin/com/netflix/graphql/dgs/CodegenGradlePluginTest.kt
@@ -119,6 +119,33 @@ class CodegenGradlePluginTest {
     }
 
     @Test
+    fun sourcesGenerated_GenerateClient() {
+        // build a project
+        val result =
+            GradleRunner
+                .create()
+                .withProjectDir(File("src/test/resources/test-project/"))
+                .withPluginClasspath()
+                .withArguments(
+                    "--stacktrace",
+                    "-c",
+                    "smoke_test_settings_generate_client.gradle",
+                    "-b",
+                    "build_generate_client.gradle",
+                    "clean",
+                    "build",
+                ).forwardOutput()
+                .withDebug(true)
+                .build()
+
+        // Verify the result
+        assertThat(result.task(":build")).extracting { it?.outcome }.isEqualTo(SUCCESS)
+        // Verify that POJOs are generated in the configured directory
+        assertThat(File(EXPECTED_DEFAULT_PATH + "Result.java").exists()).isTrue
+        assertThat(File(EXPECTED_DEFAULT_PATH + "Filter.java").exists()).isTrue
+    }
+
+    @Test
     fun nothingIsGeneratedForNoSchema() {
         // build a project
         val result =

--- a/graphql-dgs-codegen-gradle/src/test/resources/test-project/build_generate_client.gradle
+++ b/graphql-dgs-codegen-gradle/src/test/resources/test-project/build_generate_client.gradle
@@ -1,0 +1,68 @@
+/*
+ *
+ *  Copyright 2020 Netflix, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+plugins {
+    id 'java'
+    id 'com.netflix.dgs.codegen'
+}
+
+configurations {
+    // injected by Gradle Runner through test configuration, see CodegenGradlePluginTest
+    CodeGenConfiguration.exclude group: "com.netflix.graphql.dgs.codegen", module: "graphql-dgs-codegen-core"
+}
+
+repositories {
+    mavenCentral()
+    flatDir {
+        dirs 'build/extra-libs'
+    }
+}
+dependencies {
+    implementation 'com.graphql-java:graphql-java:24.2'
+    implementation(":graphql-dgs-codegen-shared-core")
+}
+
+generateJava {
+    schemaPaths = ["${projectDir}/src/main/resources/schema"]
+    packageName = 'com.netflix.testproject.graphql'
+    typeMapping = [Date: "java.time.LocalDateTime"]
+    omitNullInputFields = true
+    generateDataTypes = true
+    generateDocs = true
+    generateClient = true
+}
+
+codegen.clientCoreConventionsEnabled = false
+
+tasks.named("compileJava") {
+    dependsOn("copySharedCore")
+}
+tasks.register("copySharedCore", Copy) {
+    def libsDir = "../graphql-dgs-codegen-shared-core/build/libs"
+    def jar = new File(libsDir).listFiles().find {
+        it.name.startsWith("graphql-dgs-codegen-shared-core")
+                && it.name.endsWith(".jar")
+                && !it.name.contains("-sources")
+                && !it.name.contains("-javadoc")
+    }
+    from jar.absolutePath
+    into "build/extra-libs"
+    rename { String fileName ->
+        "graphql-dgs-codegen-shared-core.jar"
+    }
+}

--- a/graphql-dgs-codegen-gradle/src/test/resources/test-project/smoke_test_settings_generate_client.gradle
+++ b/graphql-dgs-codegen-gradle/src/test/resources/test-project/smoke_test_settings_generate_client.gradle
@@ -1,0 +1,19 @@
+/*
+ *
+ *  Copyright 2020 Netflix, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+rootProject.buildFileName = 'build_generate_client.gradle'


### PR DESCRIPTION
Hey @iuliiasobolevska 
Looks like in Gradle 8.9 something changed but I couldn't find/identify any relevant information about it. I verified that `graphql-dgs-codegen-shared-core` jar is present after `.withPluginClasspath()` call. Test `sourcesGenerated_OmitNullInputFields` was failing due to missing classes used in generated client.

I removed the `generateClient` parameter for `sourcesGenerated_OmitNullInputFields` test as it doesn't look relevant.
I've added new test exercising `generateClient` flag. 

I'm not well versed in Gradle ecosystem, so there might be better solution out there. This fix feels junky to me but work on my machine 😅 

Closes #867 