### PR TITLE
Add support for generating JSpecify annotations

### DIFF
--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
@@ -559,6 +559,7 @@ class CodeGenConfig(
     var disableDatesInGeneratedAnnotation: Boolean = false,
     var addDeprecatedAnnotation: Boolean = false,
     var trackInputFieldSet: Boolean = false,
+    var generateJSpecifyAnnotations: Boolean = false,
 ) {
     val packageNameClient: String = "$packageName.$subPackageNameClient"
 

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/DataTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/DataTypeGenerator.kt
@@ -121,13 +121,19 @@ class DataTypeGenerator(
                     .filterSkipped()
                     .filter { it.name !in fieldsFromSuperTypes }
                     .map {
-                        Field(it.name, typeUtils.findReturnType(it.type, useInterfaceType, true))
+                        Field(it.name, typeUtils.findReturnType(it.type, useInterfaceType, true), it.type !is NonNullType)
                     }.plus(
                         extensions
                             .asSequence()
                             .flatMap { it.fieldDefinitions }
                             .filterSkipped()
-                            .map { Field(it.name, typeUtils.findReturnType(it.type, useInterfaceType, true)) },
+                            .map {
+                                Field(
+                                    it.name,
+                                    typeUtils.findReturnType(it.type, useInterfaceType, true),
+                                    it.type !is NonNullType,
+                                )
+                            },
                     ).toList()
 
             val interfaceName = "I$name"
@@ -145,6 +151,7 @@ class DataTypeGenerator(
                         Field(
                             it.name,
                             typeUtils.findReturnType(it.type, useInterfaceType, true),
+                            it.type !is NonNullType,
                             overrideGetter = overrideGetter,
                             description = it.description,
                             directives = it.directives,
@@ -154,6 +161,7 @@ class DataTypeGenerator(
                             Field(
                                 it.name,
                                 typeUtils.findReturnType(it.type, useInterfaceType, true),
+                                it.type !is NonNullType,
                                 overrideGetter = overrideGetter,
                                 description = it.description,
                                 directives = it.directives,
@@ -204,13 +212,18 @@ class InputTypeGenerator(
                     Field(
                         name = it.name,
                         type = type,
+                        nullable = it.type !is NonNullType,
                         initialValue = defaultValue,
                         description = it.description,
                         directives = it.directives,
                         trackFieldSet = config.trackInputFieldSet && !type.isPrimitive && it.type !is NonNullType,
                     )
                 }.plus(
-                    extensions.asSequence().flatMap { it.inputValueDefinitions }.map { Field(it.name, typeUtils.findReturnType(it.type)) },
+                    extensions
+                        .asSequence()
+                        .flatMap {
+                            it.inputValueDefinitions
+                        }.map { Field(it.name, typeUtils.findReturnType(it.type), it.type !is NonNullType) },
                 ).toList()
         return generate(name, emptyList(), fieldDefinitions, definition.description, definition.directives)
     }
@@ -333,6 +346,7 @@ class InputTypeGenerator(
 internal data class Field(
     val name: String,
     val type: JavaTypeName,
+    val nullable: Boolean,
     val initialValue: CodeBlock? = null,
     val overrideGetter: Boolean = false,
     val interfaceType: com.squareup.javapoet.TypeName? = null,
@@ -346,6 +360,10 @@ abstract class BaseDataTypeGenerator(
     internal val config: CodeGenConfig,
     internal val document: Document,
 ) {
+    companion object {
+        private val logger: Logger = LoggerFactory.getLogger(BaseDataTypeGenerator::class.java)
+    }
+
     internal val typeUtils = TypeUtils(packageName, config, document)
     private val javaReservedKeywordSanitizer = JavaReservedKeywordSanitizer()
 
@@ -356,6 +374,15 @@ abstract class BaseDataTypeGenerator(
         description: Description? = null,
         directives: List<Directive> = emptyList(),
     ): CodeGenResult {
+        // Log warning if JSpecify is enabled and some fields use trackFieldSet
+        if (config.generateJSpecifyAnnotations && fields.any { it.trackFieldSet }) {
+            logger.warn(
+                "Type '{}' has field tracking enabled (trackInputFieldSet=true). " +
+                    "JSpecify annotations are skipped on these fields (which are wrapped in Optional<T>) but are still applied to public API methods.",
+                name,
+            )
+        }
+
         val javaType =
             TypeSpec
                 .classBuilder(name)
@@ -364,6 +391,10 @@ abstract class BaseDataTypeGenerator(
 
         if (config.implementSerializable) {
             javaType.addSuperinterface(Serializable::class.java)
+        }
+
+        if (config.generateJSpecifyAnnotations) {
+            javaType.addAnnotation(jspecifyNullMarkedAnnotation())
         }
 
         if (description != null) {
@@ -389,10 +420,17 @@ abstract class BaseDataTypeGenerator(
         }
 
         fields.forEach {
-            addField(it, javaType)
+            addField(it, javaType, true)
+            addGetterAndSetter(it, javaType)
         }
 
-        addDefaultConstructor(javaType)
+        if (config.generateJSpecifyAnnotations) {
+            // Since JSpecify annotations are enabled, add a private no-arg constructor
+            // only for the Builder to access
+            addDefaultConstructor(javaType, false)
+        } else {
+            addDefaultConstructor(javaType, true)
+        }
 
         if (config.javaGenerateAllConstructor && fields.isNotEmpty() && fields.size < 256) {
             addParameterizedConstructor(fields, javaType)
@@ -402,7 +440,7 @@ abstract class BaseDataTypeGenerator(
 
         addEquals(javaType)
         addHashcode(javaType)
-        addBuilder(javaType)
+        addBuilder(name, fields, javaType)
 
         val javaFile = JavaFile.builder(packageName, javaType.build()).build()
 
@@ -526,6 +564,11 @@ abstract class BaseDataTypeGenerator(
         for (fieldDefinition in fieldDefinitions) {
             val sanitizedName = javaReservedKeywordSanitizer.sanitize(fieldDefinition.name)
             val parameterBuilder = ParameterSpec.builder(fieldDefinition.type, sanitizedName)
+
+            if (config.generateJSpecifyAnnotations && fieldDefinition.nullable) {
+                parameterBuilder.addAnnotation(jspecifyNullableAnnotation())
+            }
+
             if (fieldDefinition.directives.isNotEmpty()) {
                 val (annotations, _) = applyDirectivesJava(fieldDefinition.directives, config)
                 val parameterAnnotations = annotations[SiteTarget.PARAM.name]
@@ -545,8 +588,17 @@ abstract class BaseDataTypeGenerator(
         javaType.addMethod(constructorBuilder.build())
     }
 
-    private fun addDefaultConstructor(javaType: TypeSpec.Builder) {
-        javaType.addMethod(MethodSpec.constructorBuilder().addModifiers(Modifier.PUBLIC).build())
+    private fun addDefaultConstructor(
+        javaType: TypeSpec.Builder,
+        visible: Boolean,
+    ) {
+        val visbilityModifier =
+            if (visible) {
+                Modifier.PUBLIC
+            } else {
+                Modifier.PRIVATE
+            }
+        javaType.addMethod(MethodSpec.constructorBuilder().addModifiers(visbilityModifier).build())
     }
 
     private fun addInterface(
@@ -569,24 +621,27 @@ abstract class BaseDataTypeGenerator(
     private fun addField(
         fieldDefinition: Field,
         javaType: TypeSpec.Builder,
-    ) {
-        addFieldWithGetterAndSetter(fieldDefinition.type, fieldDefinition, javaType)
-    }
-
-    private fun addFieldWithGetterAndSetter(
-        returnType: JavaTypeName,
-        fieldDefinition: Field,
-        javaType: TypeSpec.Builder,
+        annotateField: Boolean,
     ) {
         var fieldType = fieldDefinition.type
         if (fieldDefinition.trackFieldSet) {
             fieldType = ParameterizedTypeName.get(ClassName.get(Optional::class.java), fieldType)
         }
 
+        val sanitizedName = javaReservedKeywordSanitizer.sanitize(fieldDefinition.name)
         val fieldBuilder =
             FieldSpec
-                .builder(fieldType, javaReservedKeywordSanitizer.sanitize(fieldDefinition.name))
+                .builder(fieldType, sanitizedName)
                 .addModifiers(Modifier.PRIVATE)
+
+        // Skip JSpecify annotations on fields when trackFieldSet is true, as the field
+        // is wrapped in Optional<T> which makes nullability annotations semantically unclear.
+        // Public API (getters/setters/constructors) are still properly annotated.
+        // TODO: Consider alternative approaches if combining these features is needed.
+        if (annotateField && config.generateJSpecifyAnnotations && !fieldDefinition.trackFieldSet && fieldDefinition.nullable) {
+            fieldBuilder.addAnnotation(jspecifyNullableAnnotation())
+        }
+
         if (fieldDefinition.initialValue != null) {
             if (fieldDefinition.trackFieldSet) {
                 fieldBuilder.initializer("Optional.of(\$L)", fieldDefinition.initialValue)
@@ -599,6 +654,28 @@ abstract class BaseDataTypeGenerator(
             fieldBuilder.addJavadoc("\$L", fieldDefinition.description.content)
         }
 
+        if (fieldDefinition.directives.isNotEmpty()) {
+            val (annotations, comments) = applyDirectivesJava(fieldDefinition.directives, config)
+            if (!comments.isNullOrBlank()) {
+                fieldBuilder.addJavadoc("\$L", comments)
+            }
+            for ((key, value) in annotations) {
+                when (SiteTarget.valueOf(key)) {
+                    SiteTarget.FIELD -> fieldBuilder.addAnnotations(value)
+                    SiteTarget.GET, SiteTarget.SET, SiteTarget.SETPARAM, SiteTarget.PARAM -> continue
+                    else -> fieldBuilder.addAnnotations(value)
+                }
+            }
+        }
+
+        javaType.addField(fieldBuilder.build())
+    }
+
+    private fun addGetterAndSetter(
+        fieldDefinition: Field,
+        javaType: TypeSpec.Builder,
+    ) {
+        val returnType = fieldDefinition.type
         val getterPrefix =
             if (returnType == com.squareup.javapoet.TypeName.BOOLEAN &&
                 config.generateIsGetterForPrimitiveBooleanFields
@@ -614,6 +691,11 @@ abstract class BaseDataTypeGenerator(
             )
 
         val getterMethodBuilder = MethodSpec.methodBuilder(getterName).addModifiers(Modifier.PUBLIC).returns(returnType)
+
+        if (config.generateJSpecifyAnnotations && fieldDefinition.nullable) {
+            getterMethodBuilder.addAnnotation(jspecifyNullableAnnotation())
+        }
+
         val sanitizedName = javaReservedKeywordSanitizer.sanitize(fieldDefinition.name)
         if (fieldDefinition.trackFieldSet) {
             getterMethodBuilder.addStatement("return \$N == null ? null : \$N.orElse(null)", sanitizedName, sanitizedName)
@@ -634,16 +716,30 @@ abstract class BaseDataTypeGenerator(
                 TypeUtils.SET_CLASS,
             )
         val parameterBuilder = ParameterSpec.builder(returnType, javaReservedKeywordSanitizer.sanitize(fieldDefinition.name))
+
+        if (config.generateJSpecifyAnnotations && fieldDefinition.nullable) {
+            parameterBuilder.addAnnotation(jspecifyNullableAnnotation())
+        }
+
         val setterMethodBuilder =
             MethodSpec
                 .methodBuilder(setterName)
                 .addModifiers(Modifier.PUBLIC)
+
         if (fieldDefinition.trackFieldSet) {
-            setterMethodBuilder.addStatement(
-                "this.\$N = Optional.ofNullable(\$N)",
-                sanitizedName,
-                sanitizedName,
-            )
+            if (fieldDefinition.nullable) {
+                setterMethodBuilder.addStatement(
+                    "this.\$N = Optional.ofNullable(\$N)",
+                    sanitizedName,
+                    sanitizedName,
+                )
+            } else {
+                setterMethodBuilder.addStatement(
+                    "this.\$N = Optional.of(\$N)",
+                    sanitizedName,
+                    sanitizedName,
+                )
+            }
         } else {
             setterMethodBuilder.addStatement(
                 "this.\$N = \$N",
@@ -653,24 +749,18 @@ abstract class BaseDataTypeGenerator(
         }
 
         if (fieldDefinition.directives.isNotEmpty()) {
-            val (annotations, comments) = applyDirectivesJava(fieldDefinition.directives, config)
-            if (!comments.isNullOrBlank()) {
-                fieldBuilder.addJavadoc("\$L", comments)
-            }
+            val (annotations, _) = applyDirectivesJava(fieldDefinition.directives, config)
             for ((key, value) in annotations) {
                 when (SiteTarget.valueOf(key)) {
-                    SiteTarget.FIELD -> fieldBuilder.addAnnotations(value)
                     SiteTarget.GET -> getterMethodBuilder.addAnnotations(value)
                     SiteTarget.SET -> setterMethodBuilder.addAnnotations(value)
                     SiteTarget.SETPARAM -> parameterBuilder.addAnnotations(value)
-                    SiteTarget.PARAM -> continue
-                    else -> fieldBuilder.addAnnotations(value)
+                    else -> continue
                 }
             }
         }
         setterMethodBuilder.addParameter(parameterBuilder.build())
 
-        javaType.addField(fieldBuilder.build())
         javaType.addMethod(getterMethodBuilder.build())
         javaType.addMethod(setterMethodBuilder.build())
         if (fieldDefinition.trackFieldSet) {
@@ -699,18 +789,24 @@ abstract class BaseDataTypeGenerator(
     ) {
         val getterPrefix = if (returnType == JavaTypeName.BOOLEAN && config.generateIsGetterForPrimitiveBooleanFields) "is" else "get"
         val getterName = "${getterPrefix}${fieldDefinition.name[0].uppercase()}${fieldDefinition.name.substring(1)}"
-        javaType.addMethod(
+        val methodBuilder =
             MethodSpec
                 .methodBuilder(getterName)
                 .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
                 .returns(returnType)
-                .build(),
-        )
+
+        if (config.generateJSpecifyAnnotations && fieldDefinition.nullable) {
+            methodBuilder.addAnnotation(jspecifyNullableAnnotation())
+        }
+
+        javaType.addMethod(methodBuilder.build())
     }
 
-    private fun addBuilder(javaType: TypeSpec.Builder) {
-        val builtType = javaType.build()
-        val name = builtType.name
+    private fun addBuilder(
+        name: String,
+        fieldDefinitions: List<Field>,
+        javaType: TypeSpec.Builder,
+    ) {
         val className = ClassName.get(packageName, name)
 
         val buildMethod =
@@ -719,10 +815,6 @@ abstract class BaseDataTypeGenerator(
                 .addModifiers(Modifier.PUBLIC)
                 .returns(className)
                 .addStatement("\$T result = new \$T()", className, className)
-        for (fieldSpec in builtType.fieldSpecs) {
-            buildMethod.addStatement("result.\$N = this.\$N", fieldSpec.name, fieldSpec.name)
-        }
-        buildMethod.addStatement("return result")
 
         val builderClassName = className.nestedClass("Builder")
         val newBuilderMethod =
@@ -740,34 +832,75 @@ abstract class BaseDataTypeGenerator(
                 .classBuilder(builderClassName)
                 .addOptionalGeneratedAnnotation(config)
                 .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
-                .addMethod(buildMethod.build())
 
-        builtType.fieldSpecs.forEach {
-            var originalType = it.type
-            var isOptional = false
-            if (originalType is ParameterizedTypeName && originalType.rawType == ClassName.get(Optional::class.java)) {
-                originalType = originalType.typeArguments.first()
-                isOptional = true
-            }
-            builderType.addField(it)
-            val methodBuilder =
-                MethodSpec
-                    .methodBuilder(it.name)
-                    .addJavadoc(it.javadoc)
-                    .returns(builderClassName)
-            if (isOptional) {
-                methodBuilder.addStatement("this.\$N = Optional.ofNullable(\$N)", it.name, it.name)
+        for (fieldDefinition in fieldDefinitions) {
+            val sanitizedName = javaReservedKeywordSanitizer.sanitize(fieldDefinition.name)
+
+            if (config.generateJSpecifyAnnotations && !fieldDefinition.nullable) {
+                // Wrap non-nullable field assignments in Objects.requireNonNull for runtime validation
+                buildMethod.addStatement(
+                    "result.\$N = \$T.requireNonNull(this.\$N, \$S)",
+                    sanitizedName,
+                    Objects::class.java,
+                    sanitizedName,
+                    "$sanitizedName cannot be null",
+                )
             } else {
-                methodBuilder.addStatement("this.\$N = \$N", it.name, it.name)
+                // Direct assignment for nullable fields or when JSpecify is disabled
+                buildMethod.addStatement("result.\$N = this.\$N", sanitizedName, sanitizedName)
             }
-            methodBuilder
-                .addStatement("return this")
-                .addParameter(ParameterSpec.builder(originalType, it.name).build())
-                .addModifiers(Modifier.PUBLIC)
+        }
 
-            builderType.addMethod(methodBuilder.build())
+        buildMethod.addStatement("return result")
+        builderType.addMethod(buildMethod.build())
+
+        for (fieldDefinition in fieldDefinitions) {
+            addField(fieldDefinition.copy(nullable = true), builderType, true)
+            addBuilderMethod(fieldDefinition, builderType, builderClassName)
         }
 
         javaType.addType(builderType.build())
+    }
+
+    private fun addBuilderMethod(
+        fieldDefinition: Field,
+        builderType: TypeSpec.Builder,
+        builderClassName: ClassName,
+    ) {
+        val sanitizedName = javaReservedKeywordSanitizer.sanitize(fieldDefinition.name)
+        val methodBuilder =
+            MethodSpec
+                .methodBuilder(sanitizedName)
+                .addModifiers(Modifier.PUBLIC)
+                .returns(builderClassName)
+
+        if (fieldDefinition.description != null) {
+            methodBuilder.addJavadoc("\$L", fieldDefinition.description.content)
+        }
+
+        if (fieldDefinition.trackFieldSet) {
+            methodBuilder.addStatement(
+                "this.\$N = Optional.ofNullable(\$N)",
+                sanitizedName,
+                sanitizedName,
+            )
+        } else {
+            methodBuilder.addStatement(
+                "this.\$N = \$N",
+                sanitizedName,
+                sanitizedName,
+            )
+        }
+
+        methodBuilder.addStatement("return this")
+
+        val parameterBuilder = ParameterSpec.builder(fieldDefinition.type, sanitizedName)
+        if (config.generateJSpecifyAnnotations && fieldDefinition.nullable) {
+            parameterBuilder.addAnnotation(jspecifyNullableAnnotation())
+        }
+
+        methodBuilder.addParameter(parameterBuilder.build())
+
+        builderType.addMethod(methodBuilder.build())
     }
 }

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/EntitiesRepresentationTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/EntitiesRepresentationTypeGenerator.kt
@@ -30,6 +30,7 @@ import graphql.language.Document
 import graphql.language.EnumTypeDefinition
 import graphql.language.FieldDefinition
 import graphql.language.InterfaceTypeDefinition
+import graphql.language.NonNullType
 import graphql.language.ObjectTypeDefinition
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -62,7 +63,7 @@ class EntitiesRepresentationTypeGenerator(
         }
         var fieldsCodeGenAccumulator = CodeGenResult.EMPTY
         // generate representations of entity types that have @key, including the __typename field, and the  key fields
-        val typeName = Field("__typename", ClassName.get(String::class.java), CodeBlock.of("\$S", definitionName))
+        val typeName = Field("__typename", ClassName.get(String::class.java), false, CodeBlock.of("\$S", definitionName))
         val fieldDefinitions =
             fields
                 .filter { keyFields.containsKey(it.name) }
@@ -97,9 +98,9 @@ class EntitiesRepresentationTypeGenerator(
                             fieldsCodeGenAccumulator = fieldsCodeGenAccumulator.merge(fieldTypeRepresentation)
                             generatedRepresentations[fieldTypeRepresentationName] = fieldRepresentationType
                         }
-                        Field(it.name, ClassName.get("", fieldRepresentationType))
+                        Field(it.name, ClassName.get("", fieldRepresentationType), it.type !is NonNullType)
                     } else {
-                        Field(it.name, typeUtils.findReturnType(it.type))
+                        Field(it.name, typeUtils.findReturnType(it.type), it.type !is NonNullType)
                     }
                 }
         // Generate base type representation...

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/JavaPoetUtils.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/JavaPoetUtils.kt
@@ -113,6 +113,16 @@ fun jsonSubTypeAnnotation(subTypes: Collection<ClassName>): AnnotationSpec {
     return annotationSpec.build()
 }
 
+/**
+ * Generate a JSpecify `@Nullable` annotation.
+ */
+fun jspecifyNullableAnnotation(): AnnotationSpec = AnnotationSpec.builder(ClassName.get("org.jspecify.annotations", "Nullable")).build()
+
+/**
+ * Generate a JSpecify `@NullMarked` annotation.
+ */
+fun jspecifyNullMarkedAnnotation(): AnnotationSpec = AnnotationSpec.builder(ClassName.get("org.jspecify.annotations", "NullMarked")).build()
+
 fun String.toTypeName(isGenericParam: Boolean = false): TypeName {
     val normalizedClassName = this.trim()
 

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/TypeUtils.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/TypeUtils.kt
@@ -84,6 +84,12 @@ class TypeUtils(
                 ): TraversalControl {
                     val typeName = context.getCurrentAccumulate<JavaTypeName>()
                     val boxed = boxType(typeName)
+                    val possiblyAnnotatedType =
+                        if (config.generateJSpecifyAnnotations && node.type !is NonNullType) {
+                            boxed.annotated(jspecifyNullableAnnotation())
+                        } else {
+                            boxed
+                        }
 
                     var canUseWildcardType = false
                     if (useWildcardType) {
@@ -106,10 +112,10 @@ class TypeUtils(
 
                     val parameterizedTypeName =
                         if (canUseWildcardType) {
-                            val wildcardTypeName: WildcardTypeName = WildcardTypeName.subtypeOf(boxed)
+                            val wildcardTypeName: WildcardTypeName = WildcardTypeName.subtypeOf(possiblyAnnotatedType)
                             ParameterizedTypeName.get(ClassName.get(List::class.java), wildcardTypeName)
                         } else {
-                            ParameterizedTypeName.get(ClassName.get(List::class.java), boxed)
+                            ParameterizedTypeName.get(ClassName.get(List::class.java), possiblyAnnotatedType)
                         }
                     context.setAccumulate(parameterizedTypeName)
                     return TraversalControl.CONTINUE

--- a/graphql-dgs-codegen-gradle/src/main/kotlin/com/netflix/graphql/dgs/codegen/gradle/GenerateJavaTask.kt
+++ b/graphql-dgs-codegen-gradle/src/main/kotlin/com/netflix/graphql/dgs/codegen/gradle/GenerateJavaTask.kt
@@ -150,6 +150,9 @@ open class GenerateJavaTask
         var generateCustomAnnotations = false
 
         @Input
+        var generateJSpecifyAnnotations = false
+
+        @Input
         var trackInputFieldSet = false
 
         @Input
@@ -221,6 +224,7 @@ open class GenerateJavaTask
                     generateCustomAnnotations = generateCustomAnnotations,
                     javaGenerateAllConstructor = javaGenerateAllConstructor,
                     trackInputFieldSet = trackInputFieldSet,
+                    generateJSpecifyAnnotations = generateJSpecifyAnnotations,
                 )
 
             logger.info("Codegen config: {}", config)


### PR DESCRIPTION
  This PR introduces JSpecify annotation support to DGS code generation, which allows nullability information to be preserved in generated Java types to provide null-safety at compile time.

  Note that `graphql-java` brings in the `org.jspecify:jspecify:1.0.0` dependency transitively.

## Key Changes

  **Configuration:**
  - Added `generateJSpecifyAnnotations` boolean flag to `CodeGenConfig` (defaults to `false`)
  - Added corresponding Gradle plugin property `generateJSpecifyAnnotations`

  **JSpecify Integration:**
  - Added utility functions in `JavaPoetUtils`:
    - ~`jspecifyNonNullAnnotation()` - generates `@org.jspecify.annotations.NonNull`~
    - `jspecifyNullableAnnotation()` - generates `@org.jspecify.annotations.Nullable`

  **Annotation Coverage:**
  When `generateJSpecifyAnnotations = true`, annotations are applied based on GraphQL schema nullability to the following locations:
  - Field declarations
  - Constructor parameters for all-args constructors
  - Getter method return types
  - Setter method parameters
  - Builder method parameters
  - Interface abstract getters
  - `List` type elements including nested nullability annotations which are generated on field definitions created by `TypeUtils`

  **Constructor Behavior:**
  - When JSpecify annotations are enabled, the default no-arg constructor becomes `private` instead of `public` to prevent instantiation without proper nullability validation
  - The Builder pattern remains the same for object creation, which would technically allow bypassing nullability checks
     - ~This could be addressed with a future enhancement to generate runtime validation in the `build()` method~ **Done** ✅ 

  **Type System Integration:**
  - Enhanced `TypeUtils.visitListType()` to apply JSpecify annotations to list elements based on nested GraphQL `NonNullType`

  **Testing:**

  - Added unit tests covering primitive types, list types, and nested nullability scenarios
  - Verified annotations on fields, constructors and methods

  Closes #866
