### PR TITLE
Deduplicate projection methods and superinterfaces, fix Representation type gen

### DIFF
--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ClientApiGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ClientApiGenerator.kt
@@ -681,9 +681,11 @@ class ClientApiGenerator(
     ): CodeGenResult =
         if (type is InterfaceTypeDefinition) {
             val concreteTypes =
-                document.getDefinitionsOfType(ObjectTypeDefinition::class.java).filter {
-                    it.implements.filterIsInstance<NamedNode<*>>().any { iface -> iface.name == type.name }
-                }
+                document
+                    .getDefinitionsOfType(ObjectTypeDefinition::class.java)
+                    .filter {
+                        it.implements.filterIsInstance<NamedNode<*>>().any { iface -> iface.name == type.name }
+                    }.distinctBy { it.name }
             concreteTypes
                 .map {
                     addFragmentProjectionMethod(javaType, root, it, processedEdges, queryDepth)

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/DataTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/DataTypeGenerator.kt
@@ -92,6 +92,7 @@ class DataTypeGenerator(
                         .map { it as TypeName }
                         .any { it.name == name }
                 }.map { it.name }
+                .distinct()
                 .toList()
 
         var implements =

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/EntitiesRepresentationTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/EntitiesRepresentationTypeGenerator.kt
@@ -77,11 +77,7 @@ class EntitiesRepresentationTypeGenerator(
                         )
                     ) {
                         val fieldTypeRepresentationName = toRepresentationName(type)
-                        val fieldRepresentationType =
-                            typeUtils
-                                .findReturnType(it.type)
-                                .toString()
-                                .replace(type.name, fieldTypeRepresentationName)
+                        val fieldRepresentationType = typeUtils.qualifyName(fieldTypeRepresentationName)
 
                         if (generatedRepresentations.containsKey(fieldTypeRepresentationName)) {
                             logger.trace("Representation for {} was already generated.", fieldTypeRepresentationName)

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinDataTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinDataTypeGenerator.kt
@@ -266,12 +266,14 @@ abstract class AbstractKotlinDataTypeGenerator(
         }
 
         val unionTypes =
-            document.getDefinitionsOfType(UnionTypeDefinition::class.java).filter { union ->
-                union.memberTypes
-                    .asSequence()
-                    .map { it as TypeName }
-                    .any { it.name == name }
-            }
+            document
+                .getDefinitionsOfType(UnionTypeDefinition::class.java)
+                .filter { union ->
+                    union.memberTypes
+                        .asSequence()
+                        .map { it as TypeName }
+                        .any { it.name == name }
+                }.distinctBy { it.name }
 
         val interfaceTypes = interfaces + unionTypes
         interfaceTypes.forEach {

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinEntitiesRepresentationTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinEntitiesRepresentationTypeGenerator.kt
@@ -80,11 +80,7 @@ class KotlinEntitiesRepresentationTypeGenerator(
                     ) {
                         val fieldType = typeUtils.findReturnType(it.type)
                         val fieldTypeRepresentationName = toRepresentationName(type)
-                        val fieldRepresentationType =
-                            fieldType
-                                .toString()
-                                .replace(type.name, fieldTypeRepresentationName)
-                                .removeSuffix("?")
+                        val fieldRepresentationType = typeUtils.qualifyName(fieldTypeRepresentationName)
 
                         if (generatedRepresentations.containsKey(fieldTypeRepresentationName)) {
                             logger.trace("Representation for {} was already generated.", fieldTypeRepresentationName)


### PR DESCRIPTION
Follow-up to #877 to dedup method names in generated projections and superinterfaces in generated types.

Also explicitly uses the client package for generated `*Representation` types. It worked correctly before for schema-defined types but external types broke because the representation type generator used String replace with the external package path to import the Representation type which didn't exist.