### PR TITLE
Add integration test suite for Java code generator

### DIFF
--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/fixtures/Node.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/fixtures/Node.java
@@ -1,0 +1,23 @@
+/*
+ *
+ *  Copyright 2020 Netflix, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package com.netflix.graphql.dgs.codegen.java.fixtures;
+
+public interface Node {
+    String getId();
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/constants/constantsForInputTypes/expected/DgsConstants.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/constants/constantsForInputTypes/expected/DgsConstants.java
@@ -1,0 +1,31 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.constants.constantsForInputTypes.expected;
+
+import java.lang.String;
+
+public class DgsConstants {
+  public static final String QUERY_TYPE = "Query";
+
+  public static class QUERY {
+    public static final String TYPE_NAME = "Query";
+
+    public static final String People = "people";
+
+    public static class PEOPLE_INPUT_ARGUMENT {
+      public static final String Filter = "filter";
+    }
+  }
+
+  public static class PERSON {
+    public static final String TYPE_NAME = "Person";
+
+    public static final String Firstname = "firstname";
+
+    public static final String Lastname = "lastname";
+  }
+
+  public static class PERSONFILTER {
+    public static final String TYPE_NAME = "PersonFilter";
+
+    public static final String Email = "email";
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/constants/constantsForInputTypes/expected/client/PeopleGraphQLQuery.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/constants/constantsForInputTypes/expected/client/PeopleGraphQLQuery.java
@@ -1,0 +1,85 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.constants.constantsForInputTypes.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.GraphQLQuery;
+import com.netflix.graphql.dgs.codegen.java.testcases.constants.constantsForInputTypes.expected.types.PersonFilter;
+import graphql.language.VariableDefinition;
+import java.lang.Override;
+import java.lang.String;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class PeopleGraphQLQuery extends GraphQLQuery {
+  public PeopleGraphQLQuery(PersonFilter filter, String queryName, Set<String> fieldsSet) {
+    super("query", queryName);
+    if (filter != null || fieldsSet.contains("filter")) {
+        getInput().put("filter", filter);
+    }
+  }
+
+  public PeopleGraphQLQuery(PersonFilter filter, String queryName, Set<String> fieldsSet,
+      Map<String, String> variableReferences, List<VariableDefinition> variableDefinitions) {
+    super("query", queryName);
+    if (filter != null || fieldsSet.contains("filter")) {
+        getInput().put("filter", filter);
+    }
+    if(variableDefinitions != null) {
+       getVariableDefinitions().addAll(variableDefinitions);
+    }
+
+    if(variableReferences != null) {
+       getVariableReferences().putAll(variableReferences);
+    }                      
+  }
+
+  public PeopleGraphQLQuery() {
+    super("query");
+  }
+
+  @Override
+  public String getOperationName() {
+    return "people";
+  }
+
+  public static Builder newRequest() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private Set<String> fieldsSet = new HashSet<>();
+
+    private final Map<String, String> variableReferences = new HashMap<>();
+
+    private final List<VariableDefinition> variableDefinitions = new ArrayList<>();
+
+    private PersonFilter filter;
+
+    private String queryName;
+
+    public PeopleGraphQLQuery build() {
+      return new PeopleGraphQLQuery(filter, queryName, fieldsSet, variableReferences, variableDefinitions);
+               
+    }
+
+    public Builder filter(PersonFilter filter) {
+      this.filter = filter;
+      this.fieldsSet.add("filter");
+      return this;
+    }
+
+    public Builder filterReference(String variableRef) {
+      this.variableReferences.put("filter", variableRef);
+      this.variableDefinitions.add(graphql.language.VariableDefinition.newVariableDefinition(variableRef, new graphql.language.TypeName("PersonFilter")).build());
+      this.fieldsSet.add("filter");
+      return this;
+    }
+
+    public Builder queryName(String queryName) {
+      this.queryName = queryName;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/constants/constantsForInputTypes/expected/client/PeopleProjectionRoot.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/constants/constantsForInputTypes/expected/client/PeopleProjectionRoot.java
@@ -1,0 +1,24 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.constants.constantsForInputTypes.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.BaseSubProjectionNode;
+
+public class PeopleProjectionRoot<PARENT extends BaseSubProjectionNode<?, ?>, ROOT extends BaseSubProjectionNode<?, ?>> extends BaseSubProjectionNode<PARENT, ROOT> {
+  public PeopleProjectionRoot() {
+    super(null, null, java.util.Optional.of("Person"));
+  }
+
+  public PeopleProjectionRoot<PARENT, ROOT> __typename() {
+    getFields().put("__typename", null);
+    return this;
+  }
+
+  public PeopleProjectionRoot<PARENT, ROOT> firstname() {
+    getFields().put("firstname", null);
+    return this;
+  }
+
+  public PeopleProjectionRoot<PARENT, ROOT> lastname() {
+    getFields().put("lastname", null);
+    return this;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/constants/constantsForInputTypes/expected/datafetchers/PeopleDatafetcher.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/constants/constantsForInputTypes/expected/datafetchers/PeopleDatafetcher.java
@@ -1,0 +1,18 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.constants.constantsForInputTypes.expected.datafetchers;
+
+import com.netflix.graphql.dgs.DgsComponent;
+import com.netflix.graphql.dgs.DgsData;
+import com.netflix.graphql.dgs.codegen.java.testcases.constants.constantsForInputTypes.expected.types.Person;
+import graphql.schema.DataFetchingEnvironment;
+import java.util.List;
+
+@DgsComponent
+public class PeopleDatafetcher {
+  @DgsData(
+      parentType = "Query",
+      field = "people"
+  )
+  public List<Person> getPeople(DataFetchingEnvironment dataFetchingEnvironment) {
+    return null;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/constants/constantsForInputTypes/expected/types/Person.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/constants/constantsForInputTypes/expected/types/Person.java
@@ -1,0 +1,82 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.constants.constantsForInputTypes.expected.types;
+
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.util.Objects;
+
+public class Person {
+  private String firstname;
+
+  private String lastname;
+
+  public Person() {
+  }
+
+  public Person(String firstname, String lastname) {
+    this.firstname = firstname;
+    this.lastname = lastname;
+  }
+
+  public String getFirstname() {
+    return firstname;
+  }
+
+  public void setFirstname(String firstname) {
+    this.firstname = firstname;
+  }
+
+  public String getLastname() {
+    return lastname;
+  }
+
+  public void setLastname(String lastname) {
+    this.lastname = lastname;
+  }
+
+  @Override
+  public String toString() {
+    return "Person{firstname='" + firstname + "', lastname='" + lastname + "'}";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    Person that = (Person) o;
+    return Objects.equals(firstname, that.firstname) &&
+        Objects.equals(lastname, that.lastname);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(firstname, lastname);
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private String firstname;
+
+    private String lastname;
+
+    public Person build() {
+      Person result = new Person();
+      result.firstname = this.firstname;
+      result.lastname = this.lastname;
+      return result;
+    }
+
+    public Builder firstname(String firstname) {
+      this.firstname = firstname;
+      return this;
+    }
+
+    public Builder lastname(String lastname) {
+      this.lastname = lastname;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/constants/constantsForInputTypes/expected/types/PersonFilter.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/constants/constantsForInputTypes/expected/types/PersonFilter.java
@@ -1,0 +1,62 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.constants.constantsForInputTypes.expected.types;
+
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.util.Objects;
+
+public class PersonFilter {
+  private String email;
+
+  public PersonFilter() {
+  }
+
+  public PersonFilter(String email) {
+    this.email = email;
+  }
+
+  public String getEmail() {
+    return email;
+  }
+
+  public void setEmail(String email) {
+    this.email = email;
+  }
+
+  @Override
+  public String toString() {
+    return "PersonFilter{email='" + email + "'}";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    PersonFilter that = (PersonFilter) o;
+    return Objects.equals(email, that.email);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(email);
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private String email;
+
+    public PersonFilter build() {
+      PersonFilter result = new PersonFilter();
+      result.email = this.email;
+      return result;
+    }
+
+    public Builder email(String email) {
+      this.email = email;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/constants/constantsForInputTypes/schema.graphql
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/constants/constantsForInputTypes/schema.graphql
@@ -1,0 +1,12 @@
+type Query {
+  people(filter: PersonFilter): [Person]
+}
+
+type Person {
+  firstname: String
+  lastname: String
+}
+
+input PersonFilter {
+  email: String
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/constants/constantsWithExtendedInputTypes/expected/DgsConstants.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/constants/constantsWithExtendedInputTypes/expected/DgsConstants.java
@@ -1,0 +1,33 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.constants.constantsWithExtendedInputTypes.expected;
+
+import java.lang.String;
+
+public class DgsConstants {
+  public static final String QUERY_TYPE = "Query";
+
+  public static class QUERY {
+    public static final String TYPE_NAME = "Query";
+
+    public static final String People = "people";
+
+    public static class PEOPLE_INPUT_ARGUMENT {
+      public static final String Filter = "filter";
+    }
+  }
+
+  public static class PERSON {
+    public static final String TYPE_NAME = "Person";
+
+    public static final String Firstname = "firstname";
+
+    public static final String Lastname = "lastname";
+  }
+
+  public static class PERSONFILTER {
+    public static final String TYPE_NAME = "PersonFilter";
+
+    public static final String Email = "email";
+
+    public static final String BirthYear = "birthYear";
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/constants/constantsWithExtendedInputTypes/expected/client/PeopleGraphQLQuery.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/constants/constantsWithExtendedInputTypes/expected/client/PeopleGraphQLQuery.java
@@ -1,0 +1,85 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.constants.constantsWithExtendedInputTypes.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.GraphQLQuery;
+import com.netflix.graphql.dgs.codegen.java.testcases.constants.constantsWithExtendedInputTypes.expected.types.PersonFilter;
+import graphql.language.VariableDefinition;
+import java.lang.Override;
+import java.lang.String;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class PeopleGraphQLQuery extends GraphQLQuery {
+  public PeopleGraphQLQuery(PersonFilter filter, String queryName, Set<String> fieldsSet) {
+    super("query", queryName);
+    if (filter != null || fieldsSet.contains("filter")) {
+        getInput().put("filter", filter);
+    }
+  }
+
+  public PeopleGraphQLQuery(PersonFilter filter, String queryName, Set<String> fieldsSet,
+      Map<String, String> variableReferences, List<VariableDefinition> variableDefinitions) {
+    super("query", queryName);
+    if (filter != null || fieldsSet.contains("filter")) {
+        getInput().put("filter", filter);
+    }
+    if(variableDefinitions != null) {
+       getVariableDefinitions().addAll(variableDefinitions);
+    }
+
+    if(variableReferences != null) {
+       getVariableReferences().putAll(variableReferences);
+    }                      
+  }
+
+  public PeopleGraphQLQuery() {
+    super("query");
+  }
+
+  @Override
+  public String getOperationName() {
+    return "people";
+  }
+
+  public static Builder newRequest() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private Set<String> fieldsSet = new HashSet<>();
+
+    private final Map<String, String> variableReferences = new HashMap<>();
+
+    private final List<VariableDefinition> variableDefinitions = new ArrayList<>();
+
+    private PersonFilter filter;
+
+    private String queryName;
+
+    public PeopleGraphQLQuery build() {
+      return new PeopleGraphQLQuery(filter, queryName, fieldsSet, variableReferences, variableDefinitions);
+               
+    }
+
+    public Builder filter(PersonFilter filter) {
+      this.filter = filter;
+      this.fieldsSet.add("filter");
+      return this;
+    }
+
+    public Builder filterReference(String variableRef) {
+      this.variableReferences.put("filter", variableRef);
+      this.variableDefinitions.add(graphql.language.VariableDefinition.newVariableDefinition(variableRef, new graphql.language.TypeName("PersonFilter")).build());
+      this.fieldsSet.add("filter");
+      return this;
+    }
+
+    public Builder queryName(String queryName) {
+      this.queryName = queryName;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/constants/constantsWithExtendedInputTypes/expected/client/PeopleProjectionRoot.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/constants/constantsWithExtendedInputTypes/expected/client/PeopleProjectionRoot.java
@@ -1,0 +1,24 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.constants.constantsWithExtendedInputTypes.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.BaseSubProjectionNode;
+
+public class PeopleProjectionRoot<PARENT extends BaseSubProjectionNode<?, ?>, ROOT extends BaseSubProjectionNode<?, ?>> extends BaseSubProjectionNode<PARENT, ROOT> {
+  public PeopleProjectionRoot() {
+    super(null, null, java.util.Optional.of("Person"));
+  }
+
+  public PeopleProjectionRoot<PARENT, ROOT> __typename() {
+    getFields().put("__typename", null);
+    return this;
+  }
+
+  public PeopleProjectionRoot<PARENT, ROOT> firstname() {
+    getFields().put("firstname", null);
+    return this;
+  }
+
+  public PeopleProjectionRoot<PARENT, ROOT> lastname() {
+    getFields().put("lastname", null);
+    return this;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/constants/constantsWithExtendedInputTypes/expected/datafetchers/PeopleDatafetcher.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/constants/constantsWithExtendedInputTypes/expected/datafetchers/PeopleDatafetcher.java
@@ -1,0 +1,18 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.constants.constantsWithExtendedInputTypes.expected.datafetchers;
+
+import com.netflix.graphql.dgs.DgsComponent;
+import com.netflix.graphql.dgs.DgsData;
+import com.netflix.graphql.dgs.codegen.java.testcases.constants.constantsWithExtendedInputTypes.expected.types.Person;
+import graphql.schema.DataFetchingEnvironment;
+import java.util.List;
+
+@DgsComponent
+public class PeopleDatafetcher {
+  @DgsData(
+      parentType = "Query",
+      field = "people"
+  )
+  public List<Person> getPeople(DataFetchingEnvironment dataFetchingEnvironment) {
+    return null;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/constants/constantsWithExtendedInputTypes/expected/types/Person.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/constants/constantsWithExtendedInputTypes/expected/types/Person.java
@@ -1,0 +1,82 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.constants.constantsWithExtendedInputTypes.expected.types;
+
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.util.Objects;
+
+public class Person {
+  private String firstname;
+
+  private String lastname;
+
+  public Person() {
+  }
+
+  public Person(String firstname, String lastname) {
+    this.firstname = firstname;
+    this.lastname = lastname;
+  }
+
+  public String getFirstname() {
+    return firstname;
+  }
+
+  public void setFirstname(String firstname) {
+    this.firstname = firstname;
+  }
+
+  public String getLastname() {
+    return lastname;
+  }
+
+  public void setLastname(String lastname) {
+    this.lastname = lastname;
+  }
+
+  @Override
+  public String toString() {
+    return "Person{firstname='" + firstname + "', lastname='" + lastname + "'}";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    Person that = (Person) o;
+    return Objects.equals(firstname, that.firstname) &&
+        Objects.equals(lastname, that.lastname);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(firstname, lastname);
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private String firstname;
+
+    private String lastname;
+
+    public Person build() {
+      Person result = new Person();
+      result.firstname = this.firstname;
+      result.lastname = this.lastname;
+      return result;
+    }
+
+    public Builder firstname(String firstname) {
+      this.firstname = firstname;
+      return this;
+    }
+
+    public Builder lastname(String lastname) {
+      this.lastname = lastname;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/constants/constantsWithExtendedInputTypes/expected/types/PersonFilter.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/constants/constantsWithExtendedInputTypes/expected/types/PersonFilter.java
@@ -1,0 +1,83 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.constants.constantsWithExtendedInputTypes.expected.types;
+
+import java.lang.Integer;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.util.Objects;
+
+public class PersonFilter {
+  private String email;
+
+  private Integer birthYear;
+
+  public PersonFilter() {
+  }
+
+  public PersonFilter(String email, Integer birthYear) {
+    this.email = email;
+    this.birthYear = birthYear;
+  }
+
+  public String getEmail() {
+    return email;
+  }
+
+  public void setEmail(String email) {
+    this.email = email;
+  }
+
+  public Integer getBirthYear() {
+    return birthYear;
+  }
+
+  public void setBirthYear(Integer birthYear) {
+    this.birthYear = birthYear;
+  }
+
+  @Override
+  public String toString() {
+    return "PersonFilter{email='" + email + "', birthYear='" + birthYear + "'}";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    PersonFilter that = (PersonFilter) o;
+    return Objects.equals(email, that.email) &&
+        Objects.equals(birthYear, that.birthYear);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(email, birthYear);
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private String email;
+
+    private Integer birthYear;
+
+    public PersonFilter build() {
+      PersonFilter result = new PersonFilter();
+      result.email = this.email;
+      result.birthYear = this.birthYear;
+      return result;
+    }
+
+    public Builder email(String email) {
+      this.email = email;
+      return this;
+    }
+
+    public Builder birthYear(Integer birthYear) {
+      this.birthYear = birthYear;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/constants/constantsWithExtendedInputTypes/schema.graphql
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/constants/constantsWithExtendedInputTypes/schema.graphql
@@ -1,0 +1,16 @@
+type Query {
+  people(filter: PersonFilter): [Person]
+}
+
+type Person {
+  firstname: String
+  lastname: String
+}
+
+input PersonFilter {
+  email: String
+}
+
+extend input PersonFilter {
+  birthYear: Int
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/constants/constantsWithExtendedInterface/expected/DgsConstants.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/constants/constantsWithExtendedInterface/expected/DgsConstants.java
@@ -1,0 +1,23 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.constants.constantsWithExtendedInterface.expected;
+
+import java.lang.String;
+
+public class DgsConstants {
+  public static final String QUERY_TYPE = "Query";
+
+  public static class QUERY {
+    public static final String TYPE_NAME = "Query";
+
+    public static final String People = "people";
+  }
+
+  public static class PERSON {
+    public static final String TYPE_NAME = "Person";
+
+    public static final String Firstname = "firstname";
+
+    public static final String Lastname = "lastname";
+
+    public static final String Age = "age";
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/constants/constantsWithExtendedInterface/expected/client/PeopleGraphQLQuery.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/constants/constantsWithExtendedInterface/expected/client/PeopleGraphQLQuery.java
@@ -1,0 +1,50 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.constants.constantsWithExtendedInterface.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.GraphQLQuery;
+import graphql.language.VariableDefinition;
+import java.lang.Override;
+import java.lang.String;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class PeopleGraphQLQuery extends GraphQLQuery {
+  public PeopleGraphQLQuery(String queryName) {
+    super("query", queryName);
+  }
+
+  public PeopleGraphQLQuery() {
+    super("query");
+  }
+
+  @Override
+  public String getOperationName() {
+    return "people";
+  }
+
+  public static Builder newRequest() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private Set<String> fieldsSet = new HashSet<>();
+
+    private final Map<String, String> variableReferences = new HashMap<>();
+
+    private final List<VariableDefinition> variableDefinitions = new ArrayList<>();
+
+    private String queryName;
+
+    public PeopleGraphQLQuery build() {
+      return new PeopleGraphQLQuery(queryName);                                     
+    }
+
+    public Builder queryName(String queryName) {
+      this.queryName = queryName;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/constants/constantsWithExtendedInterface/expected/client/PeopleProjectionRoot.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/constants/constantsWithExtendedInterface/expected/client/PeopleProjectionRoot.java
@@ -1,0 +1,29 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.constants.constantsWithExtendedInterface.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.BaseSubProjectionNode;
+
+public class PeopleProjectionRoot<PARENT extends BaseSubProjectionNode<?, ?>, ROOT extends BaseSubProjectionNode<?, ?>> extends BaseSubProjectionNode<PARENT, ROOT> {
+  public PeopleProjectionRoot() {
+    super(null, null, java.util.Optional.of("Person"));
+  }
+
+  public PeopleProjectionRoot<PARENT, ROOT> __typename() {
+    getFields().put("__typename", null);
+    return this;
+  }
+
+  public PeopleProjectionRoot<PARENT, ROOT> firstname() {
+    getFields().put("firstname", null);
+    return this;
+  }
+
+  public PeopleProjectionRoot<PARENT, ROOT> lastname() {
+    getFields().put("lastname", null);
+    return this;
+  }
+
+  public PeopleProjectionRoot<PARENT, ROOT> age() {
+    getFields().put("age", null);
+    return this;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/constants/constantsWithExtendedInterface/expected/datafetchers/PeopleDatafetcher.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/constants/constantsWithExtendedInterface/expected/datafetchers/PeopleDatafetcher.java
@@ -1,0 +1,18 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.constants.constantsWithExtendedInterface.expected.datafetchers;
+
+import com.netflix.graphql.dgs.DgsComponent;
+import com.netflix.graphql.dgs.DgsData;
+import com.netflix.graphql.dgs.codegen.java.testcases.constants.constantsWithExtendedInterface.expected.types.Person;
+import graphql.schema.DataFetchingEnvironment;
+import java.util.List;
+
+@DgsComponent
+public class PeopleDatafetcher {
+  @DgsData(
+      parentType = "Query",
+      field = "people"
+  )
+  public List<Person> getPeople(DataFetchingEnvironment dataFetchingEnvironment) {
+    return null;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/constants/constantsWithExtendedInterface/expected/types/Person.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/constants/constantsWithExtendedInterface/expected/types/Person.java
@@ -1,0 +1,18 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.constants.constantsWithExtendedInterface.expected.types;
+
+import java.lang.Integer;
+import java.lang.String;
+
+public interface Person {
+  String getFirstname();
+
+  void setFirstname(String firstname);
+
+  String getLastname();
+
+  void setLastname(String lastname);
+
+  Integer getAge();
+
+  void setAge(Integer age);
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/constants/constantsWithExtendedInterface/schema.graphql
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/constants/constantsWithExtendedInterface/schema.graphql
@@ -1,0 +1,12 @@
+type Query {
+  people: [Person]
+}
+
+interface Person {
+  firstname: String!
+  lastname: String
+}
+
+extend interface Person {
+  age: Int
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/constants/constantsWithExtendedQuery/expected/DgsConstants.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/constants/constantsWithExtendedQuery/expected/DgsConstants.java
@@ -1,0 +1,23 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.constants.constantsWithExtendedQuery.expected;
+
+import java.lang.String;
+
+public class DgsConstants {
+  public static final String QUERY_TYPE = "Query";
+
+  public static class QUERY {
+    public static final String TYPE_NAME = "Query";
+
+    public static final String People = "people";
+
+    public static final String Friends = "friends";
+  }
+
+  public static class PERSON {
+    public static final String TYPE_NAME = "Person";
+
+    public static final String Firstname = "firstname";
+
+    public static final String Lastname = "lastname";
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/constants/constantsWithExtendedQuery/expected/client/FriendsGraphQLQuery.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/constants/constantsWithExtendedQuery/expected/client/FriendsGraphQLQuery.java
@@ -1,0 +1,50 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.constants.constantsWithExtendedQuery.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.GraphQLQuery;
+import graphql.language.VariableDefinition;
+import java.lang.Override;
+import java.lang.String;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class FriendsGraphQLQuery extends GraphQLQuery {
+  public FriendsGraphQLQuery(String queryName) {
+    super("query", queryName);
+  }
+
+  public FriendsGraphQLQuery() {
+    super("query");
+  }
+
+  @Override
+  public String getOperationName() {
+    return "friends";
+  }
+
+  public static Builder newRequest() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private Set<String> fieldsSet = new HashSet<>();
+
+    private final Map<String, String> variableReferences = new HashMap<>();
+
+    private final List<VariableDefinition> variableDefinitions = new ArrayList<>();
+
+    private String queryName;
+
+    public FriendsGraphQLQuery build() {
+      return new FriendsGraphQLQuery(queryName);                                     
+    }
+
+    public Builder queryName(String queryName) {
+      this.queryName = queryName;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/constants/constantsWithExtendedQuery/expected/client/FriendsProjectionRoot.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/constants/constantsWithExtendedQuery/expected/client/FriendsProjectionRoot.java
@@ -1,0 +1,24 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.constants.constantsWithExtendedQuery.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.BaseSubProjectionNode;
+
+public class FriendsProjectionRoot<PARENT extends BaseSubProjectionNode<?, ?>, ROOT extends BaseSubProjectionNode<?, ?>> extends BaseSubProjectionNode<PARENT, ROOT> {
+  public FriendsProjectionRoot() {
+    super(null, null, java.util.Optional.of("Person"));
+  }
+
+  public FriendsProjectionRoot<PARENT, ROOT> __typename() {
+    getFields().put("__typename", null);
+    return this;
+  }
+
+  public FriendsProjectionRoot<PARENT, ROOT> firstname() {
+    getFields().put("firstname", null);
+    return this;
+  }
+
+  public FriendsProjectionRoot<PARENT, ROOT> lastname() {
+    getFields().put("lastname", null);
+    return this;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/constants/constantsWithExtendedQuery/expected/client/PeopleGraphQLQuery.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/constants/constantsWithExtendedQuery/expected/client/PeopleGraphQLQuery.java
@@ -1,0 +1,50 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.constants.constantsWithExtendedQuery.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.GraphQLQuery;
+import graphql.language.VariableDefinition;
+import java.lang.Override;
+import java.lang.String;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class PeopleGraphQLQuery extends GraphQLQuery {
+  public PeopleGraphQLQuery(String queryName) {
+    super("query", queryName);
+  }
+
+  public PeopleGraphQLQuery() {
+    super("query");
+  }
+
+  @Override
+  public String getOperationName() {
+    return "people";
+  }
+
+  public static Builder newRequest() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private Set<String> fieldsSet = new HashSet<>();
+
+    private final Map<String, String> variableReferences = new HashMap<>();
+
+    private final List<VariableDefinition> variableDefinitions = new ArrayList<>();
+
+    private String queryName;
+
+    public PeopleGraphQLQuery build() {
+      return new PeopleGraphQLQuery(queryName);                                     
+    }
+
+    public Builder queryName(String queryName) {
+      this.queryName = queryName;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/constants/constantsWithExtendedQuery/expected/client/PeopleProjectionRoot.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/constants/constantsWithExtendedQuery/expected/client/PeopleProjectionRoot.java
@@ -1,0 +1,24 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.constants.constantsWithExtendedQuery.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.BaseSubProjectionNode;
+
+public class PeopleProjectionRoot<PARENT extends BaseSubProjectionNode<?, ?>, ROOT extends BaseSubProjectionNode<?, ?>> extends BaseSubProjectionNode<PARENT, ROOT> {
+  public PeopleProjectionRoot() {
+    super(null, null, java.util.Optional.of("Person"));
+  }
+
+  public PeopleProjectionRoot<PARENT, ROOT> __typename() {
+    getFields().put("__typename", null);
+    return this;
+  }
+
+  public PeopleProjectionRoot<PARENT, ROOT> firstname() {
+    getFields().put("firstname", null);
+    return this;
+  }
+
+  public PeopleProjectionRoot<PARENT, ROOT> lastname() {
+    getFields().put("lastname", null);
+    return this;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/constants/constantsWithExtendedQuery/expected/datafetchers/FriendsDatafetcher.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/constants/constantsWithExtendedQuery/expected/datafetchers/FriendsDatafetcher.java
@@ -1,0 +1,18 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.constants.constantsWithExtendedQuery.expected.datafetchers;
+
+import com.netflix.graphql.dgs.DgsComponent;
+import com.netflix.graphql.dgs.DgsData;
+import com.netflix.graphql.dgs.codegen.java.testcases.constants.constantsWithExtendedQuery.expected.types.Person;
+import graphql.schema.DataFetchingEnvironment;
+import java.util.List;
+
+@DgsComponent
+public class FriendsDatafetcher {
+  @DgsData(
+      parentType = "Query",
+      field = "friends"
+  )
+  public List<Person> getFriends(DataFetchingEnvironment dataFetchingEnvironment) {
+    return null;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/constants/constantsWithExtendedQuery/expected/datafetchers/PeopleDatafetcher.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/constants/constantsWithExtendedQuery/expected/datafetchers/PeopleDatafetcher.java
@@ -1,0 +1,18 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.constants.constantsWithExtendedQuery.expected.datafetchers;
+
+import com.netflix.graphql.dgs.DgsComponent;
+import com.netflix.graphql.dgs.DgsData;
+import com.netflix.graphql.dgs.codegen.java.testcases.constants.constantsWithExtendedQuery.expected.types.Person;
+import graphql.schema.DataFetchingEnvironment;
+import java.util.List;
+
+@DgsComponent
+public class PeopleDatafetcher {
+  @DgsData(
+      parentType = "Query",
+      field = "people"
+  )
+  public List<Person> getPeople(DataFetchingEnvironment dataFetchingEnvironment) {
+    return null;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/constants/constantsWithExtendedQuery/expected/types/Person.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/constants/constantsWithExtendedQuery/expected/types/Person.java
@@ -1,0 +1,82 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.constants.constantsWithExtendedQuery.expected.types;
+
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.util.Objects;
+
+public class Person {
+  private String firstname;
+
+  private String lastname;
+
+  public Person() {
+  }
+
+  public Person(String firstname, String lastname) {
+    this.firstname = firstname;
+    this.lastname = lastname;
+  }
+
+  public String getFirstname() {
+    return firstname;
+  }
+
+  public void setFirstname(String firstname) {
+    this.firstname = firstname;
+  }
+
+  public String getLastname() {
+    return lastname;
+  }
+
+  public void setLastname(String lastname) {
+    this.lastname = lastname;
+  }
+
+  @Override
+  public String toString() {
+    return "Person{firstname='" + firstname + "', lastname='" + lastname + "'}";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    Person that = (Person) o;
+    return Objects.equals(firstname, that.firstname) &&
+        Objects.equals(lastname, that.lastname);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(firstname, lastname);
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private String firstname;
+
+    private String lastname;
+
+    public Person build() {
+      Person result = new Person();
+      result.firstname = this.firstname;
+      result.lastname = this.lastname;
+      return result;
+    }
+
+    public Builder firstname(String firstname) {
+      this.firstname = firstname;
+      return this;
+    }
+
+    public Builder lastname(String lastname) {
+      this.lastname = lastname;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/constants/constantsWithExtendedQuery/schema.graphql
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/constants/constantsWithExtendedQuery/schema.graphql
@@ -1,0 +1,12 @@
+type Query {
+  people: [Person]
+}
+
+type Person {
+  firstname: String
+  lastname: String
+}
+
+extend type Query {
+  friends: [Person]
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/constants/constantsWithExtendedTypes/expected/DgsConstants.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/constants/constantsWithExtendedTypes/expected/DgsConstants.java
@@ -1,0 +1,23 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.constants.constantsWithExtendedTypes.expected;
+
+import java.lang.String;
+
+public class DgsConstants {
+  public static final String QUERY_TYPE = "Query";
+
+  public static class QUERY {
+    public static final String TYPE_NAME = "Query";
+
+    public static final String People = "people";
+  }
+
+  public static class PERSON {
+    public static final String TYPE_NAME = "Person";
+
+    public static final String Firstname = "firstname";
+
+    public static final String Lastname = "lastname";
+
+    public static final String Email = "email";
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/constants/constantsWithExtendedTypes/expected/client/PeopleGraphQLQuery.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/constants/constantsWithExtendedTypes/expected/client/PeopleGraphQLQuery.java
@@ -1,0 +1,50 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.constants.constantsWithExtendedTypes.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.GraphQLQuery;
+import graphql.language.VariableDefinition;
+import java.lang.Override;
+import java.lang.String;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class PeopleGraphQLQuery extends GraphQLQuery {
+  public PeopleGraphQLQuery(String queryName) {
+    super("query", queryName);
+  }
+
+  public PeopleGraphQLQuery() {
+    super("query");
+  }
+
+  @Override
+  public String getOperationName() {
+    return "people";
+  }
+
+  public static Builder newRequest() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private Set<String> fieldsSet = new HashSet<>();
+
+    private final Map<String, String> variableReferences = new HashMap<>();
+
+    private final List<VariableDefinition> variableDefinitions = new ArrayList<>();
+
+    private String queryName;
+
+    public PeopleGraphQLQuery build() {
+      return new PeopleGraphQLQuery(queryName);                                     
+    }
+
+    public Builder queryName(String queryName) {
+      this.queryName = queryName;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/constants/constantsWithExtendedTypes/expected/client/PeopleProjectionRoot.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/constants/constantsWithExtendedTypes/expected/client/PeopleProjectionRoot.java
@@ -1,0 +1,29 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.constants.constantsWithExtendedTypes.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.BaseSubProjectionNode;
+
+public class PeopleProjectionRoot<PARENT extends BaseSubProjectionNode<?, ?>, ROOT extends BaseSubProjectionNode<?, ?>> extends BaseSubProjectionNode<PARENT, ROOT> {
+  public PeopleProjectionRoot() {
+    super(null, null, java.util.Optional.of("Person"));
+  }
+
+  public PeopleProjectionRoot<PARENT, ROOT> __typename() {
+    getFields().put("__typename", null);
+    return this;
+  }
+
+  public PeopleProjectionRoot<PARENT, ROOT> firstname() {
+    getFields().put("firstname", null);
+    return this;
+  }
+
+  public PeopleProjectionRoot<PARENT, ROOT> lastname() {
+    getFields().put("lastname", null);
+    return this;
+  }
+
+  public PeopleProjectionRoot<PARENT, ROOT> email() {
+    getFields().put("email", null);
+    return this;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/constants/constantsWithExtendedTypes/expected/datafetchers/PeopleDatafetcher.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/constants/constantsWithExtendedTypes/expected/datafetchers/PeopleDatafetcher.java
@@ -1,0 +1,18 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.constants.constantsWithExtendedTypes.expected.datafetchers;
+
+import com.netflix.graphql.dgs.DgsComponent;
+import com.netflix.graphql.dgs.DgsData;
+import com.netflix.graphql.dgs.codegen.java.testcases.constants.constantsWithExtendedTypes.expected.types.Person;
+import graphql.schema.DataFetchingEnvironment;
+import java.util.List;
+
+@DgsComponent
+public class PeopleDatafetcher {
+  @DgsData(
+      parentType = "Query",
+      field = "people"
+  )
+  public List<Person> getPeople(DataFetchingEnvironment dataFetchingEnvironment) {
+    return null;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/constants/constantsWithExtendedTypes/expected/types/Person.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/constants/constantsWithExtendedTypes/expected/types/Person.java
@@ -1,0 +1,102 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.constants.constantsWithExtendedTypes.expected.types;
+
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.util.Objects;
+
+public class Person {
+  private String firstname;
+
+  private String lastname;
+
+  private String email;
+
+  public Person() {
+  }
+
+  public Person(String firstname, String lastname, String email) {
+    this.firstname = firstname;
+    this.lastname = lastname;
+    this.email = email;
+  }
+
+  public String getFirstname() {
+    return firstname;
+  }
+
+  public void setFirstname(String firstname) {
+    this.firstname = firstname;
+  }
+
+  public String getLastname() {
+    return lastname;
+  }
+
+  public void setLastname(String lastname) {
+    this.lastname = lastname;
+  }
+
+  public String getEmail() {
+    return email;
+  }
+
+  public void setEmail(String email) {
+    this.email = email;
+  }
+
+  @Override
+  public String toString() {
+    return "Person{firstname='" + firstname + "', lastname='" + lastname + "', email='" + email + "'}";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    Person that = (Person) o;
+    return Objects.equals(firstname, that.firstname) &&
+        Objects.equals(lastname, that.lastname) &&
+        Objects.equals(email, that.email);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(firstname, lastname, email);
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private String firstname;
+
+    private String lastname;
+
+    private String email;
+
+    public Person build() {
+      Person result = new Person();
+      result.firstname = this.firstname;
+      result.lastname = this.lastname;
+      result.email = this.email;
+      return result;
+    }
+
+    public Builder firstname(String firstname) {
+      this.firstname = firstname;
+      return this;
+    }
+
+    public Builder lastname(String lastname) {
+      this.lastname = lastname;
+      return this;
+    }
+
+    public Builder email(String email) {
+      this.email = email;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/constants/constantsWithExtendedTypes/schema.graphql
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/constants/constantsWithExtendedTypes/schema.graphql
@@ -1,0 +1,12 @@
+type Query {
+  people: [Person]
+}
+
+type Person {
+  firstname: String
+  lastname: String
+}
+
+extend type Person {
+  email: String
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassDocs/expected/DgsConstants.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassDocs/expected/DgsConstants.java
@@ -1,0 +1,29 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassDocs.expected;
+
+import java.lang.String;
+
+public class DgsConstants {
+  public static final String QUERY_TYPE = "Query";
+
+  public static class QUERY {
+    public static final String TYPE_NAME = "Query";
+
+    public static final String Search = "search";
+
+    public static class SEARCH_INPUT_ARGUMENT {
+      public static final String MovieFilter = "movieFilter";
+    }
+  }
+
+  public static class MOVIE {
+    public static final String TYPE_NAME = "Movie";
+
+    public static final String Title = "title";
+  }
+
+  public static class MOVIEFILTER {
+    public static final String TYPE_NAME = "MovieFilter";
+
+    public static final String TitleFilter = "titleFilter";
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassDocs/expected/client/SearchGraphQLQuery.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassDocs/expected/client/SearchGraphQLQuery.java
@@ -1,0 +1,85 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassDocs.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.GraphQLQuery;
+import com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassDocs.expected.types.MovieFilter;
+import graphql.language.VariableDefinition;
+import java.lang.Override;
+import java.lang.String;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class SearchGraphQLQuery extends GraphQLQuery {
+  public SearchGraphQLQuery(MovieFilter movieFilter, String queryName, Set<String> fieldsSet) {
+    super("query", queryName);
+    if (movieFilter != null || fieldsSet.contains("movieFilter")) {
+        getInput().put("movieFilter", movieFilter);
+    }
+  }
+
+  public SearchGraphQLQuery(MovieFilter movieFilter, String queryName, Set<String> fieldsSet,
+      Map<String, String> variableReferences, List<VariableDefinition> variableDefinitions) {
+    super("query", queryName);
+    if (movieFilter != null || fieldsSet.contains("movieFilter")) {
+        getInput().put("movieFilter", movieFilter);
+    }
+    if(variableDefinitions != null) {
+       getVariableDefinitions().addAll(variableDefinitions);
+    }
+
+    if(variableReferences != null) {
+       getVariableReferences().putAll(variableReferences);
+    }                      
+  }
+
+  public SearchGraphQLQuery() {
+    super("query");
+  }
+
+  @Override
+  public String getOperationName() {
+    return "search";
+  }
+
+  public static Builder newRequest() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private Set<String> fieldsSet = new HashSet<>();
+
+    private final Map<String, String> variableReferences = new HashMap<>();
+
+    private final List<VariableDefinition> variableDefinitions = new ArrayList<>();
+
+    private MovieFilter movieFilter;
+
+    private String queryName;
+
+    public SearchGraphQLQuery build() {
+      return new SearchGraphQLQuery(movieFilter, queryName, fieldsSet, variableReferences, variableDefinitions);
+               
+    }
+
+    public Builder movieFilter(MovieFilter movieFilter) {
+      this.movieFilter = movieFilter;
+      this.fieldsSet.add("movieFilter");
+      return this;
+    }
+
+    public Builder movieFilterReference(String variableRef) {
+      this.variableReferences.put("movieFilter", variableRef);
+      this.variableDefinitions.add(graphql.language.VariableDefinition.newVariableDefinition(variableRef, new graphql.language.NonNullType(new graphql.language.TypeName("MovieFilter"))).build());
+      this.fieldsSet.add("movieFilter");
+      return this;
+    }
+
+    public Builder queryName(String queryName) {
+      this.queryName = queryName;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassDocs/expected/client/SearchProjectionRoot.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassDocs/expected/client/SearchProjectionRoot.java
@@ -1,0 +1,19 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassDocs.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.BaseSubProjectionNode;
+
+public class SearchProjectionRoot<PARENT extends BaseSubProjectionNode<?, ?>, ROOT extends BaseSubProjectionNode<?, ?>> extends BaseSubProjectionNode<PARENT, ROOT> {
+  public SearchProjectionRoot() {
+    super(null, null, java.util.Optional.of("Movie"));
+  }
+
+  public SearchProjectionRoot<PARENT, ROOT> __typename() {
+    getFields().put("__typename", null);
+    return this;
+  }
+
+  public SearchProjectionRoot<PARENT, ROOT> title() {
+    getFields().put("title", null);
+    return this;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassDocs/expected/datafetchers/SearchDatafetcher.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassDocs/expected/datafetchers/SearchDatafetcher.java
@@ -1,0 +1,17 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassDocs.expected.datafetchers;
+
+import com.netflix.graphql.dgs.DgsComponent;
+import com.netflix.graphql.dgs.DgsData;
+import com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassDocs.expected.types.Movie;
+import graphql.schema.DataFetchingEnvironment;
+
+@DgsComponent
+public class SearchDatafetcher {
+  @DgsData(
+      parentType = "Query",
+      field = "search"
+  )
+  public Movie getSearch(DataFetchingEnvironment dataFetchingEnvironment) {
+    return null;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassDocs/expected/types/Movie.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassDocs/expected/types/Movie.java
@@ -1,0 +1,66 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassDocs.expected.types;
+
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.util.Objects;
+
+/**
+ * Movies are fun to watch.
+ * They also work well as examples in GraphQL.
+ */
+public class Movie {
+  private String title;
+
+  public Movie() {
+  }
+
+  public Movie(String title) {
+    this.title = title;
+  }
+
+  public String getTitle() {
+    return title;
+  }
+
+  public void setTitle(String title) {
+    this.title = title;
+  }
+
+  @Override
+  public String toString() {
+    return "Movie{title='" + title + "'}";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    Movie that = (Movie) o;
+    return Objects.equals(title, that.title);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(title);
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private String title;
+
+    public Movie build() {
+      Movie result = new Movie();
+      result.title = this.title;
+      return result;
+    }
+
+    public Builder title(String title) {
+      this.title = title;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassDocs/expected/types/MovieFilter.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassDocs/expected/types/MovieFilter.java
@@ -1,0 +1,67 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassDocs.expected.types;
+
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.util.Objects;
+
+/**
+ * Example filter for Movies.
+ *
+ * It takes a title and such.
+ */
+public class MovieFilter {
+  private String titleFilter;
+
+  public MovieFilter() {
+  }
+
+  public MovieFilter(String titleFilter) {
+    this.titleFilter = titleFilter;
+  }
+
+  public String getTitleFilter() {
+    return titleFilter;
+  }
+
+  public void setTitleFilter(String titleFilter) {
+    this.titleFilter = titleFilter;
+  }
+
+  @Override
+  public String toString() {
+    return "MovieFilter{titleFilter='" + titleFilter + "'}";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    MovieFilter that = (MovieFilter) o;
+    return Objects.equals(titleFilter, that.titleFilter);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(titleFilter);
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private String titleFilter;
+
+    public MovieFilter build() {
+      MovieFilter result = new MovieFilter();
+      result.titleFilter = this.titleFilter;
+      return result;
+    }
+
+    public Builder titleFilter(String titleFilter) {
+      this.titleFilter = titleFilter;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassDocs/schema.graphql
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassDocs/schema.graphql
@@ -1,0 +1,20 @@
+type Query {
+  search(movieFilter: MovieFilter!): Movie
+}
+
+"""
+Movies are fun to watch.
+They also work well as examples in GraphQL.
+"""
+type Movie {
+  title: String
+}
+
+"""
+Example filter for Movies.
+
+It takes a title and such.
+"""
+input MovieFilter {
+  titleFilter: String
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassFieldDocs/expected/DgsConstants.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassFieldDocs/expected/DgsConstants.java
@@ -1,0 +1,29 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassFieldDocs.expected;
+
+import java.lang.String;
+
+public class DgsConstants {
+  public static final String QUERY_TYPE = "Query";
+
+  public static class QUERY {
+    public static final String TYPE_NAME = "Query";
+
+    public static final String Search = "search";
+
+    public static class SEARCH_INPUT_ARGUMENT {
+      public static final String MovieFilter = "movieFilter";
+    }
+  }
+
+  public static class MOVIE {
+    public static final String TYPE_NAME = "Movie";
+
+    public static final String Title = "title";
+  }
+
+  public static class MOVIEFILTER {
+    public static final String TYPE_NAME = "MovieFilter";
+
+    public static final String TitleFilter = "titleFilter";
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassFieldDocs/expected/client/SearchGraphQLQuery.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassFieldDocs/expected/client/SearchGraphQLQuery.java
@@ -1,0 +1,85 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassFieldDocs.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.GraphQLQuery;
+import com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassFieldDocs.expected.types.MovieFilter;
+import graphql.language.VariableDefinition;
+import java.lang.Override;
+import java.lang.String;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class SearchGraphQLQuery extends GraphQLQuery {
+  public SearchGraphQLQuery(MovieFilter movieFilter, String queryName, Set<String> fieldsSet) {
+    super("query", queryName);
+    if (movieFilter != null || fieldsSet.contains("movieFilter")) {
+        getInput().put("movieFilter", movieFilter);
+    }
+  }
+
+  public SearchGraphQLQuery(MovieFilter movieFilter, String queryName, Set<String> fieldsSet,
+      Map<String, String> variableReferences, List<VariableDefinition> variableDefinitions) {
+    super("query", queryName);
+    if (movieFilter != null || fieldsSet.contains("movieFilter")) {
+        getInput().put("movieFilter", movieFilter);
+    }
+    if(variableDefinitions != null) {
+       getVariableDefinitions().addAll(variableDefinitions);
+    }
+
+    if(variableReferences != null) {
+       getVariableReferences().putAll(variableReferences);
+    }                      
+  }
+
+  public SearchGraphQLQuery() {
+    super("query");
+  }
+
+  @Override
+  public String getOperationName() {
+    return "search";
+  }
+
+  public static Builder newRequest() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private Set<String> fieldsSet = new HashSet<>();
+
+    private final Map<String, String> variableReferences = new HashMap<>();
+
+    private final List<VariableDefinition> variableDefinitions = new ArrayList<>();
+
+    private MovieFilter movieFilter;
+
+    private String queryName;
+
+    public SearchGraphQLQuery build() {
+      return new SearchGraphQLQuery(movieFilter, queryName, fieldsSet, variableReferences, variableDefinitions);
+               
+    }
+
+    public Builder movieFilter(MovieFilter movieFilter) {
+      this.movieFilter = movieFilter;
+      this.fieldsSet.add("movieFilter");
+      return this;
+    }
+
+    public Builder movieFilterReference(String variableRef) {
+      this.variableReferences.put("movieFilter", variableRef);
+      this.variableDefinitions.add(graphql.language.VariableDefinition.newVariableDefinition(variableRef, new graphql.language.NonNullType(new graphql.language.TypeName("MovieFilter"))).build());
+      this.fieldsSet.add("movieFilter");
+      return this;
+    }
+
+    public Builder queryName(String queryName) {
+      this.queryName = queryName;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassFieldDocs/expected/client/SearchProjectionRoot.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassFieldDocs/expected/client/SearchProjectionRoot.java
@@ -1,0 +1,19 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassFieldDocs.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.BaseSubProjectionNode;
+
+public class SearchProjectionRoot<PARENT extends BaseSubProjectionNode<?, ?>, ROOT extends BaseSubProjectionNode<?, ?>> extends BaseSubProjectionNode<PARENT, ROOT> {
+  public SearchProjectionRoot() {
+    super(null, null, java.util.Optional.of("Movie"));
+  }
+
+  public SearchProjectionRoot<PARENT, ROOT> __typename() {
+    getFields().put("__typename", null);
+    return this;
+  }
+
+  public SearchProjectionRoot<PARENT, ROOT> title() {
+    getFields().put("title", null);
+    return this;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassFieldDocs/expected/datafetchers/SearchDatafetcher.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassFieldDocs/expected/datafetchers/SearchDatafetcher.java
@@ -1,0 +1,17 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassFieldDocs.expected.datafetchers;
+
+import com.netflix.graphql.dgs.DgsComponent;
+import com.netflix.graphql.dgs.DgsData;
+import com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassFieldDocs.expected.types.Movie;
+import graphql.schema.DataFetchingEnvironment;
+
+@DgsComponent
+public class SearchDatafetcher {
+  @DgsData(
+      parentType = "Query",
+      field = "search"
+  )
+  public Movie getSearch(DataFetchingEnvironment dataFetchingEnvironment) {
+    return null;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassFieldDocs/expected/types/Movie.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassFieldDocs/expected/types/Movie.java
@@ -1,0 +1,74 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassFieldDocs.expected.types;
+
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.util.Objects;
+
+public class Movie {
+  /**
+   * The original, non localized title with some specials characters : %!({[*$,.:;.
+   */
+  private String title;
+
+  public Movie() {
+  }
+
+  public Movie(String title) {
+    this.title = title;
+  }
+
+  /**
+   * The original, non localized title with some specials characters : %!({[*$,.:;.
+   */
+  public String getTitle() {
+    return title;
+  }
+
+  public void setTitle(String title) {
+    this.title = title;
+  }
+
+  @Override
+  public String toString() {
+    return "Movie{title='" + title + "'}";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    Movie that = (Movie) o;
+    return Objects.equals(title, that.title);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(title);
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    /**
+     * The original, non localized title with some specials characters : %!({[*$,.:;.
+     */
+    private String title;
+
+    public Movie build() {
+      Movie result = new Movie();
+      result.title = this.title;
+      return result;
+    }
+
+    /**
+     * The original, non localized title with some specials characters : %!({[*$,.:;.
+     */
+    public Builder title(String title) {
+      this.title = title;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassFieldDocs/expected/types/MovieFilter.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassFieldDocs/expected/types/MovieFilter.java
@@ -1,0 +1,74 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassFieldDocs.expected.types;
+
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.util.Objects;
+
+public class MovieFilter {
+  /**
+   * Starts-with filter
+   */
+  private String titleFilter;
+
+  public MovieFilter() {
+  }
+
+  public MovieFilter(String titleFilter) {
+    this.titleFilter = titleFilter;
+  }
+
+  /**
+   * Starts-with filter
+   */
+  public String getTitleFilter() {
+    return titleFilter;
+  }
+
+  public void setTitleFilter(String titleFilter) {
+    this.titleFilter = titleFilter;
+  }
+
+  @Override
+  public String toString() {
+    return "MovieFilter{titleFilter='" + titleFilter + "'}";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    MovieFilter that = (MovieFilter) o;
+    return Objects.equals(titleFilter, that.titleFilter);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(titleFilter);
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    /**
+     * Starts-with filter
+     */
+    private String titleFilter;
+
+    public MovieFilter build() {
+      MovieFilter result = new MovieFilter();
+      result.titleFilter = this.titleFilter;
+      return result;
+    }
+
+    /**
+     * Starts-with filter
+     */
+    public Builder titleFilter(String titleFilter) {
+      this.titleFilter = titleFilter;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassFieldDocs/schema.graphql
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassFieldDocs/schema.graphql
@@ -1,0 +1,17 @@
+type Query {
+  search(movieFilter: MovieFilter!): Movie
+}
+
+type Movie {
+  """
+  The original, non localized title with some specials characters : %!({[*$,.:;.
+  """
+  title: String
+}
+
+input MovieFilter {
+  """
+  Starts-with filter
+  """
+  titleFilter: String
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWIthNoFields/expected/DgsConstants.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWIthNoFields/expected/DgsConstants.java
@@ -1,0 +1,17 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWIthNoFields.expected;
+
+import java.lang.String;
+
+public class DgsConstants {
+  public static final String QUERY_TYPE = "Query";
+
+  public static class QUERY {
+    public static final String TYPE_NAME = "Query";
+
+    public static final String Me = "me";
+  }
+
+  public static class PERSON {
+    public static final String TYPE_NAME = "Person";
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWIthNoFields/expected/client/MeGraphQLQuery.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWIthNoFields/expected/client/MeGraphQLQuery.java
@@ -1,0 +1,50 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWIthNoFields.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.GraphQLQuery;
+import graphql.language.VariableDefinition;
+import java.lang.Override;
+import java.lang.String;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class MeGraphQLQuery extends GraphQLQuery {
+  public MeGraphQLQuery(String queryName) {
+    super("query", queryName);
+  }
+
+  public MeGraphQLQuery() {
+    super("query");
+  }
+
+  @Override
+  public String getOperationName() {
+    return "me";
+  }
+
+  public static Builder newRequest() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private Set<String> fieldsSet = new HashSet<>();
+
+    private final Map<String, String> variableReferences = new HashMap<>();
+
+    private final List<VariableDefinition> variableDefinitions = new ArrayList<>();
+
+    private String queryName;
+
+    public MeGraphQLQuery build() {
+      return new MeGraphQLQuery(queryName);                                     
+    }
+
+    public Builder queryName(String queryName) {
+      this.queryName = queryName;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWIthNoFields/expected/client/MeProjectionRoot.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWIthNoFields/expected/client/MeProjectionRoot.java
@@ -1,0 +1,14 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWIthNoFields.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.BaseSubProjectionNode;
+
+public class MeProjectionRoot<PARENT extends BaseSubProjectionNode<?, ?>, ROOT extends BaseSubProjectionNode<?, ?>> extends BaseSubProjectionNode<PARENT, ROOT> {
+  public MeProjectionRoot() {
+    super(null, null, java.util.Optional.of("Person"));
+  }
+
+  public MeProjectionRoot<PARENT, ROOT> __typename() {
+    getFields().put("__typename", null);
+    return this;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWIthNoFields/expected/datafetchers/MeDatafetcher.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWIthNoFields/expected/datafetchers/MeDatafetcher.java
@@ -1,0 +1,17 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWIthNoFields.expected.datafetchers;
+
+import com.netflix.graphql.dgs.DgsComponent;
+import com.netflix.graphql.dgs.DgsData;
+import com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWIthNoFields.expected.types.Person;
+import graphql.schema.DataFetchingEnvironment;
+
+@DgsComponent
+public class MeDatafetcher {
+  @DgsData(
+      parentType = "Query",
+      field = "me"
+  )
+  public Person getMe(DataFetchingEnvironment dataFetchingEnvironment) {
+    return null;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWIthNoFields/expected/types/Person.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWIthNoFields/expected/types/Person.java
@@ -1,0 +1,25 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWIthNoFields.expected.types;
+
+import java.lang.Override;
+import java.lang.String;
+
+public class Person {
+  public Person() {
+  }
+
+  @Override
+  public String toString() {
+    return "Person{}";
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    public Person build() {
+      Person result = new Person();
+      return result;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWIthNoFields/schema.graphql
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWIthNoFields/schema.graphql
@@ -1,0 +1,6 @@
+type Query {
+  me: Person
+}
+
+type Person {
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithBooleanField/expected/DgsConstants.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithBooleanField/expected/DgsConstants.java
@@ -1,0 +1,19 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithBooleanField.expected;
+
+import java.lang.String;
+
+public class DgsConstants {
+  public static final String QUERY_TYPE = "Query";
+
+  public static class QUERY {
+    public static final String TYPE_NAME = "Query";
+
+    public static final String Test = "test";
+  }
+
+  public static class REQUIREDTESTTYPE {
+    public static final String TYPE_NAME = "RequiredTestType";
+
+    public static final String IsRequired = "isRequired";
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithBooleanField/expected/client/TestGraphQLQuery.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithBooleanField/expected/client/TestGraphQLQuery.java
@@ -1,0 +1,50 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithBooleanField.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.GraphQLQuery;
+import graphql.language.VariableDefinition;
+import java.lang.Override;
+import java.lang.String;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class TestGraphQLQuery extends GraphQLQuery {
+  public TestGraphQLQuery(String queryName) {
+    super("query", queryName);
+  }
+
+  public TestGraphQLQuery() {
+    super("query");
+  }
+
+  @Override
+  public String getOperationName() {
+    return "test";
+  }
+
+  public static Builder newRequest() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private Set<String> fieldsSet = new HashSet<>();
+
+    private final Map<String, String> variableReferences = new HashMap<>();
+
+    private final List<VariableDefinition> variableDefinitions = new ArrayList<>();
+
+    private String queryName;
+
+    public TestGraphQLQuery build() {
+      return new TestGraphQLQuery(queryName);                                     
+    }
+
+    public Builder queryName(String queryName) {
+      this.queryName = queryName;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithBooleanField/expected/client/TestProjectionRoot.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithBooleanField/expected/client/TestProjectionRoot.java
@@ -1,0 +1,19 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithBooleanField.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.BaseSubProjectionNode;
+
+public class TestProjectionRoot<PARENT extends BaseSubProjectionNode<?, ?>, ROOT extends BaseSubProjectionNode<?, ?>> extends BaseSubProjectionNode<PARENT, ROOT> {
+  public TestProjectionRoot() {
+    super(null, null, java.util.Optional.of("RequiredTestType"));
+  }
+
+  public TestProjectionRoot<PARENT, ROOT> __typename() {
+    getFields().put("__typename", null);
+    return this;
+  }
+
+  public TestProjectionRoot<PARENT, ROOT> isRequired() {
+    getFields().put("isRequired", null);
+    return this;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithBooleanField/expected/datafetchers/TestDatafetcher.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithBooleanField/expected/datafetchers/TestDatafetcher.java
@@ -1,0 +1,17 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithBooleanField.expected.datafetchers;
+
+import com.netflix.graphql.dgs.DgsComponent;
+import com.netflix.graphql.dgs.DgsData;
+import com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithBooleanField.expected.types.RequiredTestType;
+import graphql.schema.DataFetchingEnvironment;
+
+@DgsComponent
+public class TestDatafetcher {
+  @DgsData(
+      parentType = "Query",
+      field = "test"
+  )
+  public RequiredTestType getTest(DataFetchingEnvironment dataFetchingEnvironment) {
+    return null;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithBooleanField/expected/types/RequiredTestType.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithBooleanField/expected/types/RequiredTestType.java
@@ -1,0 +1,62 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithBooleanField.expected.types;
+
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.util.Objects;
+
+public class RequiredTestType {
+  private boolean isRequired;
+
+  public RequiredTestType() {
+  }
+
+  public RequiredTestType(boolean isRequired) {
+    this.isRequired = isRequired;
+  }
+
+  public boolean getIsRequired() {
+    return isRequired;
+  }
+
+  public void setIsRequired(boolean isRequired) {
+    this.isRequired = isRequired;
+  }
+
+  @Override
+  public String toString() {
+    return "RequiredTestType{isRequired='" + isRequired + "'}";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    RequiredTestType that = (RequiredTestType) o;
+    return isRequired == that.isRequired;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(isRequired);
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private boolean isRequired;
+
+    public RequiredTestType build() {
+      RequiredTestType result = new RequiredTestType();
+      result.isRequired = this.isRequired;
+      return result;
+    }
+
+    public Builder isRequired(boolean isRequired) {
+      this.isRequired = isRequired;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithBooleanField/schema.graphql
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithBooleanField/schema.graphql
@@ -1,0 +1,7 @@
+type Query {
+  test: RequiredTestType
+}
+
+type RequiredTestType {
+  isRequired: Boolean!
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithDeclaredScalars/expected/DgsConstants.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithDeclaredScalars/expected/DgsConstants.java
@@ -1,0 +1,51 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithDeclaredScalars.expected;
+
+import java.lang.String;
+
+public class DgsConstants {
+  public static final String QUERY_TYPE = "Query";
+
+  public static class QUERY {
+    public static final String TYPE_NAME = "Query";
+
+    public static final String Entity = "entity";
+
+    public static final String EntityConnection = "entityConnection";
+  }
+
+  public static class ENTITY {
+    public static final String TYPE_NAME = "Entity";
+
+    public static final String Long = "long";
+
+    public static final String DateTime = "dateTime";
+  }
+
+  public static class ENTITYCONNECTION {
+    public static final String TYPE_NAME = "EntityConnection";
+
+    public static final String PageInfo = "pageInfo";
+
+    public static final String Edges = "edges";
+  }
+
+  public static class ENTITYEDGE {
+    public static final String TYPE_NAME = "EntityEdge";
+
+    public static final String Cursor = "cursor";
+
+    public static final String Node = "node";
+  }
+
+  public static class PAGEINFO {
+    public static final String TYPE_NAME = "PageInfo";
+
+    public static final String StartCursor = "startCursor";
+
+    public static final String EndCursor = "endCursor";
+
+    public static final String HasNextPage = "hasNextPage";
+
+    public static final String HasPreviousPage = "hasPreviousPage";
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithDeclaredScalars/expected/client/EntityConnectionGraphQLQuery.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithDeclaredScalars/expected/client/EntityConnectionGraphQLQuery.java
@@ -1,0 +1,50 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithDeclaredScalars.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.GraphQLQuery;
+import graphql.language.VariableDefinition;
+import java.lang.Override;
+import java.lang.String;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class EntityConnectionGraphQLQuery extends GraphQLQuery {
+  public EntityConnectionGraphQLQuery(String queryName) {
+    super("query", queryName);
+  }
+
+  public EntityConnectionGraphQLQuery() {
+    super("query");
+  }
+
+  @Override
+  public String getOperationName() {
+    return "entityConnection";
+  }
+
+  public static Builder newRequest() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private Set<String> fieldsSet = new HashSet<>();
+
+    private final Map<String, String> variableReferences = new HashMap<>();
+
+    private final List<VariableDefinition> variableDefinitions = new ArrayList<>();
+
+    private String queryName;
+
+    public EntityConnectionGraphQLQuery build() {
+      return new EntityConnectionGraphQLQuery(queryName);                                     
+    }
+
+    public Builder queryName(String queryName) {
+      this.queryName = queryName;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithDeclaredScalars/expected/client/EntityConnectionProjectionRoot.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithDeclaredScalars/expected/client/EntityConnectionProjectionRoot.java
@@ -1,0 +1,28 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithDeclaredScalars.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.BaseSubProjectionNode;
+
+public class EntityConnectionProjectionRoot<PARENT extends BaseSubProjectionNode<?, ?>, ROOT extends BaseSubProjectionNode<?, ?>> extends BaseSubProjectionNode<PARENT, ROOT> {
+  public EntityConnectionProjectionRoot() {
+    super(null, null, java.util.Optional.of("EntityConnection"));
+  }
+
+  public EntityConnectionProjectionRoot<PARENT, ROOT> __typename() {
+    getFields().put("__typename", null);
+    return this;
+  }
+
+  public PageInfoProjection<EntityConnectionProjectionRoot<PARENT, ROOT>, EntityConnectionProjectionRoot<PARENT, ROOT>> pageInfo(
+      ) {
+    PageInfoProjection<EntityConnectionProjectionRoot<PARENT, ROOT>, EntityConnectionProjectionRoot<PARENT, ROOT>> projection = new PageInfoProjection<>(this, this);    
+    getFields().put("pageInfo", projection);
+    return projection;
+  }
+
+  public EntityEdgeProjection<EntityConnectionProjectionRoot<PARENT, ROOT>, EntityConnectionProjectionRoot<PARENT, ROOT>> edges(
+      ) {
+    EntityEdgeProjection<EntityConnectionProjectionRoot<PARENT, ROOT>, EntityConnectionProjectionRoot<PARENT, ROOT>> projection = new EntityEdgeProjection<>(this, this);    
+    getFields().put("edges", projection);
+    return projection;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithDeclaredScalars/expected/client/EntityEdgeProjection.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithDeclaredScalars/expected/client/EntityEdgeProjection.java
@@ -1,0 +1,25 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithDeclaredScalars.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.BaseSubProjectionNode;
+
+public class EntityEdgeProjection<PARENT extends BaseSubProjectionNode<?, ?>, ROOT extends BaseSubProjectionNode<?, ?>> extends BaseSubProjectionNode<PARENT, ROOT> {
+  public EntityEdgeProjection(PARENT parent, ROOT root) {
+    super(parent, root, java.util.Optional.of("EntityEdge"));
+  }
+
+  public EntityEdgeProjection<PARENT, ROOT> __typename() {
+    getFields().put("__typename", null);
+    return this;
+  }
+
+  public EntityProjection<EntityEdgeProjection<PARENT, ROOT>, ROOT> node() {
+     EntityProjection<EntityEdgeProjection<PARENT, ROOT>, ROOT> projection = new EntityProjection<>(this, getRoot());
+     getFields().put("node", projection);
+     return projection;
+  }
+
+  public EntityEdgeProjection<PARENT, ROOT> cursor() {
+    getFields().put("cursor", null);
+    return this;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithDeclaredScalars/expected/client/EntityGraphQLQuery.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithDeclaredScalars/expected/client/EntityGraphQLQuery.java
@@ -1,0 +1,50 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithDeclaredScalars.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.GraphQLQuery;
+import graphql.language.VariableDefinition;
+import java.lang.Override;
+import java.lang.String;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class EntityGraphQLQuery extends GraphQLQuery {
+  public EntityGraphQLQuery(String queryName) {
+    super("query", queryName);
+  }
+
+  public EntityGraphQLQuery() {
+    super("query");
+  }
+
+  @Override
+  public String getOperationName() {
+    return "entity";
+  }
+
+  public static Builder newRequest() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private Set<String> fieldsSet = new HashSet<>();
+
+    private final Map<String, String> variableReferences = new HashMap<>();
+
+    private final List<VariableDefinition> variableDefinitions = new ArrayList<>();
+
+    private String queryName;
+
+    public EntityGraphQLQuery build() {
+      return new EntityGraphQLQuery(queryName);                                     
+    }
+
+    public Builder queryName(String queryName) {
+      this.queryName = queryName;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithDeclaredScalars/expected/client/EntityProjection.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithDeclaredScalars/expected/client/EntityProjection.java
@@ -1,0 +1,24 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithDeclaredScalars.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.BaseSubProjectionNode;
+
+public class EntityProjection<PARENT extends BaseSubProjectionNode<?, ?>, ROOT extends BaseSubProjectionNode<?, ?>> extends BaseSubProjectionNode<PARENT, ROOT> {
+  public EntityProjection(PARENT parent, ROOT root) {
+    super(parent, root, java.util.Optional.of("Entity"));
+  }
+
+  public EntityProjection<PARENT, ROOT> __typename() {
+    getFields().put("__typename", null);
+    return this;
+  }
+
+  public EntityProjection<PARENT, ROOT> _long() {
+    getFields().put("long", null);
+    return this;
+  }
+
+  public EntityProjection<PARENT, ROOT> dateTime() {
+    getFields().put("dateTime", null);
+    return this;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithDeclaredScalars/expected/client/EntityProjectionRoot.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithDeclaredScalars/expected/client/EntityProjectionRoot.java
@@ -1,0 +1,24 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithDeclaredScalars.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.BaseSubProjectionNode;
+
+public class EntityProjectionRoot<PARENT extends BaseSubProjectionNode<?, ?>, ROOT extends BaseSubProjectionNode<?, ?>> extends BaseSubProjectionNode<PARENT, ROOT> {
+  public EntityProjectionRoot() {
+    super(null, null, java.util.Optional.of("Entity"));
+  }
+
+  public EntityProjectionRoot<PARENT, ROOT> __typename() {
+    getFields().put("__typename", null);
+    return this;
+  }
+
+  public EntityProjectionRoot<PARENT, ROOT> _long() {
+    getFields().put("long", null);
+    return this;
+  }
+
+  public EntityProjectionRoot<PARENT, ROOT> dateTime() {
+    getFields().put("dateTime", null);
+    return this;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithDeclaredScalars/expected/client/PageInfoProjection.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithDeclaredScalars/expected/client/PageInfoProjection.java
@@ -1,0 +1,34 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithDeclaredScalars.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.BaseSubProjectionNode;
+
+public class PageInfoProjection<PARENT extends BaseSubProjectionNode<?, ?>, ROOT extends BaseSubProjectionNode<?, ?>> extends BaseSubProjectionNode<PARENT, ROOT> {
+  public PageInfoProjection(PARENT parent, ROOT root) {
+    super(parent, root, java.util.Optional.of("PageInfo"));
+  }
+
+  public PageInfoProjection<PARENT, ROOT> __typename() {
+    getFields().put("__typename", null);
+    return this;
+  }
+
+  public PageInfoProjection<PARENT, ROOT> startCursor() {
+    getFields().put("startCursor", null);
+    return this;
+  }
+
+  public PageInfoProjection<PARENT, ROOT> endCursor() {
+    getFields().put("endCursor", null);
+    return this;
+  }
+
+  public PageInfoProjection<PARENT, ROOT> hasNextPage() {
+    getFields().put("hasNextPage", null);
+    return this;
+  }
+
+  public PageInfoProjection<PARENT, ROOT> hasPreviousPage() {
+    getFields().put("hasPreviousPage", null);
+    return this;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithDeclaredScalars/expected/datafetchers/EntityConnectionDatafetcher.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithDeclaredScalars/expected/datafetchers/EntityConnectionDatafetcher.java
@@ -1,0 +1,17 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithDeclaredScalars.expected.datafetchers;
+
+import com.netflix.graphql.dgs.DgsComponent;
+import com.netflix.graphql.dgs.DgsData;
+import com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithDeclaredScalars.expected.types.EntityConnection;
+import graphql.schema.DataFetchingEnvironment;
+
+@DgsComponent
+public class EntityConnectionDatafetcher {
+  @DgsData(
+      parentType = "Query",
+      field = "entityConnection"
+  )
+  public EntityConnection getEntityConnection(DataFetchingEnvironment dataFetchingEnvironment) {
+    return null;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithDeclaredScalars/expected/datafetchers/EntityDatafetcher.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithDeclaredScalars/expected/datafetchers/EntityDatafetcher.java
@@ -1,0 +1,18 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithDeclaredScalars.expected.datafetchers;
+
+import com.netflix.graphql.dgs.DgsComponent;
+import com.netflix.graphql.dgs.DgsData;
+import com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithDeclaredScalars.expected.types.Entity;
+import graphql.schema.DataFetchingEnvironment;
+import java.util.List;
+
+@DgsComponent
+public class EntityDatafetcher {
+  @DgsData(
+      parentType = "Query",
+      field = "entity"
+  )
+  public List<Entity> getEntity(DataFetchingEnvironment dataFetchingEnvironment) {
+    return null;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithDeclaredScalars/expected/types/Entity.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithDeclaredScalars/expected/types/Entity.java
@@ -1,0 +1,84 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithDeclaredScalars.expected.types;
+
+import java.lang.Long;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.time.OffsetDateTime;
+import java.util.Objects;
+
+public class Entity {
+  private Long _long;
+
+  private OffsetDateTime dateTime;
+
+  public Entity() {
+  }
+
+  public Entity(Long _long, OffsetDateTime dateTime) {
+    this._long = _long;
+    this.dateTime = dateTime;
+  }
+
+  public Long getLong() {
+    return _long;
+  }
+
+  public void setLong(Long _long) {
+    this._long = _long;
+  }
+
+  public OffsetDateTime getDateTime() {
+    return dateTime;
+  }
+
+  public void setDateTime(OffsetDateTime dateTime) {
+    this.dateTime = dateTime;
+  }
+
+  @Override
+  public String toString() {
+    return "Entity{long='" + _long + "', dateTime='" + dateTime + "'}";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    Entity that = (Entity) o;
+    return Objects.equals(_long, that._long) &&
+        Objects.equals(dateTime, that.dateTime);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_long, dateTime);
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private Long _long;
+
+    private OffsetDateTime dateTime;
+
+    public Entity build() {
+      Entity result = new Entity();
+      result._long = this._long;
+      result.dateTime = this.dateTime;
+      return result;
+    }
+
+    public Builder _long(Long _long) {
+      this._long = _long;
+      return this;
+    }
+
+    public Builder dateTime(OffsetDateTime dateTime) {
+      this.dateTime = dateTime;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithDeclaredScalars/expected/types/EntityConnection.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithDeclaredScalars/expected/types/EntityConnection.java
@@ -1,0 +1,83 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithDeclaredScalars.expected.types;
+
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.util.List;
+import java.util.Objects;
+
+public class EntityConnection {
+  private PageInfo pageInfo;
+
+  private List<EntityEdge> edges;
+
+  public EntityConnection() {
+  }
+
+  public EntityConnection(PageInfo pageInfo, List<EntityEdge> edges) {
+    this.pageInfo = pageInfo;
+    this.edges = edges;
+  }
+
+  public PageInfo getPageInfo() {
+    return pageInfo;
+  }
+
+  public void setPageInfo(PageInfo pageInfo) {
+    this.pageInfo = pageInfo;
+  }
+
+  public List<EntityEdge> getEdges() {
+    return edges;
+  }
+
+  public void setEdges(List<EntityEdge> edges) {
+    this.edges = edges;
+  }
+
+  @Override
+  public String toString() {
+    return "EntityConnection{pageInfo='" + pageInfo + "', edges='" + edges + "'}";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    EntityConnection that = (EntityConnection) o;
+    return Objects.equals(pageInfo, that.pageInfo) &&
+        Objects.equals(edges, that.edges);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(pageInfo, edges);
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private PageInfo pageInfo;
+
+    private List<EntityEdge> edges;
+
+    public EntityConnection build() {
+      EntityConnection result = new EntityConnection();
+      result.pageInfo = this.pageInfo;
+      result.edges = this.edges;
+      return result;
+    }
+
+    public Builder pageInfo(PageInfo pageInfo) {
+      this.pageInfo = pageInfo;
+      return this;
+    }
+
+    public Builder edges(List<EntityEdge> edges) {
+      this.edges = edges;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithDeclaredScalars/expected/types/EntityEdge.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithDeclaredScalars/expected/types/EntityEdge.java
@@ -1,0 +1,82 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithDeclaredScalars.expected.types;
+
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.util.Objects;
+
+public class EntityEdge {
+  private String cursor;
+
+  private Entity node;
+
+  public EntityEdge() {
+  }
+
+  public EntityEdge(String cursor, Entity node) {
+    this.cursor = cursor;
+    this.node = node;
+  }
+
+  public String getCursor() {
+    return cursor;
+  }
+
+  public void setCursor(String cursor) {
+    this.cursor = cursor;
+  }
+
+  public Entity getNode() {
+    return node;
+  }
+
+  public void setNode(Entity node) {
+    this.node = node;
+  }
+
+  @Override
+  public String toString() {
+    return "EntityEdge{cursor='" + cursor + "', node='" + node + "'}";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    EntityEdge that = (EntityEdge) o;
+    return Objects.equals(cursor, that.cursor) &&
+        Objects.equals(node, that.node);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(cursor, node);
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private String cursor;
+
+    private Entity node;
+
+    public EntityEdge build() {
+      EntityEdge result = new EntityEdge();
+      result.cursor = this.cursor;
+      result.node = this.node;
+      return result;
+    }
+
+    public Builder cursor(String cursor) {
+      this.cursor = cursor;
+      return this;
+    }
+
+    public Builder node(Entity node) {
+      this.node = node;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithDeclaredScalars/expected/types/PageInfo.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithDeclaredScalars/expected/types/PageInfo.java
@@ -1,0 +1,123 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithDeclaredScalars.expected.types;
+
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.util.Objects;
+
+public class PageInfo {
+  private String startCursor;
+
+  private String endCursor;
+
+  private boolean hasNextPage;
+
+  private boolean hasPreviousPage;
+
+  public PageInfo() {
+  }
+
+  public PageInfo(String startCursor, String endCursor, boolean hasNextPage,
+      boolean hasPreviousPage) {
+    this.startCursor = startCursor;
+    this.endCursor = endCursor;
+    this.hasNextPage = hasNextPage;
+    this.hasPreviousPage = hasPreviousPage;
+  }
+
+  public String getStartCursor() {
+    return startCursor;
+  }
+
+  public void setStartCursor(String startCursor) {
+    this.startCursor = startCursor;
+  }
+
+  public String getEndCursor() {
+    return endCursor;
+  }
+
+  public void setEndCursor(String endCursor) {
+    this.endCursor = endCursor;
+  }
+
+  public boolean getHasNextPage() {
+    return hasNextPage;
+  }
+
+  public void setHasNextPage(boolean hasNextPage) {
+    this.hasNextPage = hasNextPage;
+  }
+
+  public boolean getHasPreviousPage() {
+    return hasPreviousPage;
+  }
+
+  public void setHasPreviousPage(boolean hasPreviousPage) {
+    this.hasPreviousPage = hasPreviousPage;
+  }
+
+  @Override
+  public String toString() {
+    return "PageInfo{startCursor='" + startCursor + "', endCursor='" + endCursor + "', hasNextPage='" + hasNextPage + "', hasPreviousPage='" + hasPreviousPage + "'}";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    PageInfo that = (PageInfo) o;
+    return Objects.equals(startCursor, that.startCursor) &&
+        Objects.equals(endCursor, that.endCursor) &&
+        hasNextPage == that.hasNextPage &&
+        hasPreviousPage == that.hasPreviousPage;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(startCursor, endCursor, hasNextPage, hasPreviousPage);
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private String startCursor;
+
+    private String endCursor;
+
+    private boolean hasNextPage;
+
+    private boolean hasPreviousPage;
+
+    public PageInfo build() {
+      PageInfo result = new PageInfo();
+      result.startCursor = this.startCursor;
+      result.endCursor = this.endCursor;
+      result.hasNextPage = this.hasNextPage;
+      result.hasPreviousPage = this.hasPreviousPage;
+      return result;
+    }
+
+    public Builder startCursor(String startCursor) {
+      this.startCursor = startCursor;
+      return this;
+    }
+
+    public Builder endCursor(String endCursor) {
+      this.endCursor = endCursor;
+      return this;
+    }
+
+    public Builder hasNextPage(boolean hasNextPage) {
+      this.hasNextPage = hasNextPage;
+      return this;
+    }
+
+    public Builder hasPreviousPage(boolean hasPreviousPage) {
+      this.hasPreviousPage = hasPreviousPage;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithDeclaredScalars/schema.graphql
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithDeclaredScalars/schema.graphql
@@ -1,0 +1,29 @@
+type Query {
+  entity: [Entity]
+  entityConnection: EntityConnection
+}
+
+type Entity {
+  long: Long
+  dateTime: DateTime
+}
+
+type EntityConnection {
+  pageInfo: PageInfo!
+  edges: [EntityEdge]
+}
+
+type EntityEdge {
+  cursor: String!
+  node: Entity
+}
+
+type PageInfo {
+  startCursor: String
+  endCursor: String
+  hasNextPage: Boolean!
+  hasPreviousPage: Boolean!
+}
+
+scalar Long @javaType(name : "java.lang.Long")
+scalar DateTime @javaType(name : "java.time.OffsetDateTime")

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithDeeplyNestedComplexField/expected/DgsConstants.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithDeeplyNestedComplexField/expected/DgsConstants.java
@@ -1,0 +1,43 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithDeeplyNestedComplexField.expected;
+
+import java.lang.String;
+
+public class DgsConstants {
+  public static final String QUERY_TYPE = "Query";
+
+  public static class QUERY {
+    public static final String TYPE_NAME = "Query";
+
+    public static final String Cars = "cars";
+  }
+
+  public static class CAR {
+    public static final String TYPE_NAME = "Car";
+
+    public static final String Make = "make";
+
+    public static final String Model = "model";
+
+    public static final String Engine = "engine";
+  }
+
+  public static class ENGINE {
+    public static final String TYPE_NAME = "Engine";
+
+    public static final String Type = "type";
+
+    public static final String Bhp = "bhp";
+
+    public static final String Size = "size";
+
+    public static final String Performance = "performance";
+  }
+
+  public static class PERFORMANCE {
+    public static final String TYPE_NAME = "Performance";
+
+    public static final String ZeroToSixty = "zeroToSixty";
+
+    public static final String QuarterMile = "quarterMile";
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithDeeplyNestedComplexField/expected/client/CarsGraphQLQuery.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithDeeplyNestedComplexField/expected/client/CarsGraphQLQuery.java
@@ -1,0 +1,50 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithDeeplyNestedComplexField.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.GraphQLQuery;
+import graphql.language.VariableDefinition;
+import java.lang.Override;
+import java.lang.String;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class CarsGraphQLQuery extends GraphQLQuery {
+  public CarsGraphQLQuery(String queryName) {
+    super("query", queryName);
+  }
+
+  public CarsGraphQLQuery() {
+    super("query");
+  }
+
+  @Override
+  public String getOperationName() {
+    return "cars";
+  }
+
+  public static Builder newRequest() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private Set<String> fieldsSet = new HashSet<>();
+
+    private final Map<String, String> variableReferences = new HashMap<>();
+
+    private final List<VariableDefinition> variableDefinitions = new ArrayList<>();
+
+    private String queryName;
+
+    public CarsGraphQLQuery build() {
+      return new CarsGraphQLQuery(queryName);                                     
+    }
+
+    public Builder queryName(String queryName) {
+      this.queryName = queryName;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithDeeplyNestedComplexField/expected/client/CarsProjectionRoot.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithDeeplyNestedComplexField/expected/client/CarsProjectionRoot.java
@@ -1,0 +1,31 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithDeeplyNestedComplexField.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.BaseSubProjectionNode;
+
+public class CarsProjectionRoot<PARENT extends BaseSubProjectionNode<?, ?>, ROOT extends BaseSubProjectionNode<?, ?>> extends BaseSubProjectionNode<PARENT, ROOT> {
+  public CarsProjectionRoot() {
+    super(null, null, java.util.Optional.of("Car"));
+  }
+
+  public CarsProjectionRoot<PARENT, ROOT> __typename() {
+    getFields().put("__typename", null);
+    return this;
+  }
+
+  public EngineProjection<CarsProjectionRoot<PARENT, ROOT>, CarsProjectionRoot<PARENT, ROOT>> engine(
+      ) {
+    EngineProjection<CarsProjectionRoot<PARENT, ROOT>, CarsProjectionRoot<PARENT, ROOT>> projection = new EngineProjection<>(this, this);    
+    getFields().put("engine", projection);
+    return projection;
+  }
+
+  public CarsProjectionRoot<PARENT, ROOT> make() {
+    getFields().put("make", null);
+    return this;
+  }
+
+  public CarsProjectionRoot<PARENT, ROOT> model() {
+    getFields().put("model", null);
+    return this;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithDeeplyNestedComplexField/expected/client/EngineProjection.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithDeeplyNestedComplexField/expected/client/EngineProjection.java
@@ -1,0 +1,35 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithDeeplyNestedComplexField.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.BaseSubProjectionNode;
+
+public class EngineProjection<PARENT extends BaseSubProjectionNode<?, ?>, ROOT extends BaseSubProjectionNode<?, ?>> extends BaseSubProjectionNode<PARENT, ROOT> {
+  public EngineProjection(PARENT parent, ROOT root) {
+    super(parent, root, java.util.Optional.of("Engine"));
+  }
+
+  public EngineProjection<PARENT, ROOT> __typename() {
+    getFields().put("__typename", null);
+    return this;
+  }
+
+  public PerformanceProjection<EngineProjection<PARENT, ROOT>, ROOT> performance() {
+     PerformanceProjection<EngineProjection<PARENT, ROOT>, ROOT> projection = new PerformanceProjection<>(this, getRoot());
+     getFields().put("performance", projection);
+     return projection;
+  }
+
+  public EngineProjection<PARENT, ROOT> type() {
+    getFields().put("type", null);
+    return this;
+  }
+
+  public EngineProjection<PARENT, ROOT> bhp() {
+    getFields().put("bhp", null);
+    return this;
+  }
+
+  public EngineProjection<PARENT, ROOT> size() {
+    getFields().put("size", null);
+    return this;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithDeeplyNestedComplexField/expected/client/PerformanceProjection.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithDeeplyNestedComplexField/expected/client/PerformanceProjection.java
@@ -1,0 +1,24 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithDeeplyNestedComplexField.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.BaseSubProjectionNode;
+
+public class PerformanceProjection<PARENT extends BaseSubProjectionNode<?, ?>, ROOT extends BaseSubProjectionNode<?, ?>> extends BaseSubProjectionNode<PARENT, ROOT> {
+  public PerformanceProjection(PARENT parent, ROOT root) {
+    super(parent, root, java.util.Optional.of("Performance"));
+  }
+
+  public PerformanceProjection<PARENT, ROOT> __typename() {
+    getFields().put("__typename", null);
+    return this;
+  }
+
+  public PerformanceProjection<PARENT, ROOT> zeroToSixty() {
+    getFields().put("zeroToSixty", null);
+    return this;
+  }
+
+  public PerformanceProjection<PARENT, ROOT> quarterMile() {
+    getFields().put("quarterMile", null);
+    return this;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithDeeplyNestedComplexField/expected/datafetchers/CarsDatafetcher.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithDeeplyNestedComplexField/expected/datafetchers/CarsDatafetcher.java
@@ -1,0 +1,18 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithDeeplyNestedComplexField.expected.datafetchers;
+
+import com.netflix.graphql.dgs.DgsComponent;
+import com.netflix.graphql.dgs.DgsData;
+import com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithDeeplyNestedComplexField.expected.types.Car;
+import graphql.schema.DataFetchingEnvironment;
+import java.util.List;
+
+@DgsComponent
+public class CarsDatafetcher {
+  @DgsData(
+      parentType = "Query",
+      field = "cars"
+  )
+  public List<Car> getCars(DataFetchingEnvironment dataFetchingEnvironment) {
+    return null;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithDeeplyNestedComplexField/expected/types/Car.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithDeeplyNestedComplexField/expected/types/Car.java
@@ -1,0 +1,102 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithDeeplyNestedComplexField.expected.types;
+
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.util.Objects;
+
+public class Car {
+  private String make;
+
+  private String model;
+
+  private Engine engine;
+
+  public Car() {
+  }
+
+  public Car(String make, String model, Engine engine) {
+    this.make = make;
+    this.model = model;
+    this.engine = engine;
+  }
+
+  public String getMake() {
+    return make;
+  }
+
+  public void setMake(String make) {
+    this.make = make;
+  }
+
+  public String getModel() {
+    return model;
+  }
+
+  public void setModel(String model) {
+    this.model = model;
+  }
+
+  public Engine getEngine() {
+    return engine;
+  }
+
+  public void setEngine(Engine engine) {
+    this.engine = engine;
+  }
+
+  @Override
+  public String toString() {
+    return "Car{make='" + make + "', model='" + model + "', engine='" + engine + "'}";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    Car that = (Car) o;
+    return Objects.equals(make, that.make) &&
+        Objects.equals(model, that.model) &&
+        Objects.equals(engine, that.engine);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(make, model, engine);
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private String make;
+
+    private String model;
+
+    private Engine engine;
+
+    public Car build() {
+      Car result = new Car();
+      result.make = this.make;
+      result.model = this.model;
+      result.engine = this.engine;
+      return result;
+    }
+
+    public Builder make(String make) {
+      this.make = make;
+      return this;
+    }
+
+    public Builder model(String model) {
+      this.model = model;
+      return this;
+    }
+
+    public Builder engine(Engine engine) {
+      this.engine = engine;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithDeeplyNestedComplexField/expected/types/Engine.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithDeeplyNestedComplexField/expected/types/Engine.java
@@ -1,0 +1,124 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithDeeplyNestedComplexField.expected.types;
+
+import java.lang.Double;
+import java.lang.Integer;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.util.Objects;
+
+public class Engine {
+  private String type;
+
+  private Integer bhp;
+
+  private Double size;
+
+  private Performance performance;
+
+  public Engine() {
+  }
+
+  public Engine(String type, Integer bhp, Double size, Performance performance) {
+    this.type = type;
+    this.bhp = bhp;
+    this.size = size;
+    this.performance = performance;
+  }
+
+  public String getType() {
+    return type;
+  }
+
+  public void setType(String type) {
+    this.type = type;
+  }
+
+  public Integer getBhp() {
+    return bhp;
+  }
+
+  public void setBhp(Integer bhp) {
+    this.bhp = bhp;
+  }
+
+  public Double getSize() {
+    return size;
+  }
+
+  public void setSize(Double size) {
+    this.size = size;
+  }
+
+  public Performance getPerformance() {
+    return performance;
+  }
+
+  public void setPerformance(Performance performance) {
+    this.performance = performance;
+  }
+
+  @Override
+  public String toString() {
+    return "Engine{type='" + type + "', bhp='" + bhp + "', size='" + size + "', performance='" + performance + "'}";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    Engine that = (Engine) o;
+    return Objects.equals(type, that.type) &&
+        Objects.equals(bhp, that.bhp) &&
+        Objects.equals(size, that.size) &&
+        Objects.equals(performance, that.performance);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(type, bhp, size, performance);
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private String type;
+
+    private Integer bhp;
+
+    private Double size;
+
+    private Performance performance;
+
+    public Engine build() {
+      Engine result = new Engine();
+      result.type = this.type;
+      result.bhp = this.bhp;
+      result.size = this.size;
+      result.performance = this.performance;
+      return result;
+    }
+
+    public Builder type(String type) {
+      this.type = type;
+      return this;
+    }
+
+    public Builder bhp(Integer bhp) {
+      this.bhp = bhp;
+      return this;
+    }
+
+    public Builder size(Double size) {
+      this.size = size;
+      return this;
+    }
+
+    public Builder performance(Performance performance) {
+      this.performance = performance;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithDeeplyNestedComplexField/expected/types/Performance.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithDeeplyNestedComplexField/expected/types/Performance.java
@@ -1,0 +1,83 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithDeeplyNestedComplexField.expected.types;
+
+import java.lang.Double;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.util.Objects;
+
+public class Performance {
+  private Double zeroToSixty;
+
+  private Double quarterMile;
+
+  public Performance() {
+  }
+
+  public Performance(Double zeroToSixty, Double quarterMile) {
+    this.zeroToSixty = zeroToSixty;
+    this.quarterMile = quarterMile;
+  }
+
+  public Double getZeroToSixty() {
+    return zeroToSixty;
+  }
+
+  public void setZeroToSixty(Double zeroToSixty) {
+    this.zeroToSixty = zeroToSixty;
+  }
+
+  public Double getQuarterMile() {
+    return quarterMile;
+  }
+
+  public void setQuarterMile(Double quarterMile) {
+    this.quarterMile = quarterMile;
+  }
+
+  @Override
+  public String toString() {
+    return "Performance{zeroToSixty='" + zeroToSixty + "', quarterMile='" + quarterMile + "'}";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    Performance that = (Performance) o;
+    return Objects.equals(zeroToSixty, that.zeroToSixty) &&
+        Objects.equals(quarterMile, that.quarterMile);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(zeroToSixty, quarterMile);
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private Double zeroToSixty;
+
+    private Double quarterMile;
+
+    public Performance build() {
+      Performance result = new Performance();
+      result.zeroToSixty = this.zeroToSixty;
+      result.quarterMile = this.quarterMile;
+      return result;
+    }
+
+    public Builder zeroToSixty(Double zeroToSixty) {
+      this.zeroToSixty = zeroToSixty;
+      return this;
+    }
+
+    public Builder quarterMile(Double quarterMile) {
+      this.quarterMile = quarterMile;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithDeeplyNestedComplexField/schema.graphql
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithDeeplyNestedComplexField/schema.graphql
@@ -1,0 +1,21 @@
+type Query {
+  cars: [Car]
+}
+
+type Car {
+  make: String
+  model: String
+  engine: Engine
+}
+
+type Engine {
+  type: String
+  bhp: Int
+  size: Float
+  performance: Performance
+}
+
+type Performance {
+  zeroToSixty: Float
+  quarterMile: Float
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithExtendedInterface/expected/DgsConstants.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithExtendedInterface/expected/DgsConstants.java
@@ -1,0 +1,23 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithExtendedInterface.expected;
+
+import java.lang.String;
+
+public class DgsConstants {
+  public static final String QUERY_TYPE = "Query";
+
+  public static class QUERY {
+    public static final String TYPE_NAME = "Query";
+
+    public static final String People = "people";
+  }
+
+  public static class PERSON {
+    public static final String TYPE_NAME = "Person";
+
+    public static final String Firstname = "firstname";
+
+    public static final String Lastname = "lastname";
+
+    public static final String Age = "age";
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithExtendedInterface/expected/client/PeopleGraphQLQuery.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithExtendedInterface/expected/client/PeopleGraphQLQuery.java
@@ -1,0 +1,50 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithExtendedInterface.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.GraphQLQuery;
+import graphql.language.VariableDefinition;
+import java.lang.Override;
+import java.lang.String;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class PeopleGraphQLQuery extends GraphQLQuery {
+  public PeopleGraphQLQuery(String queryName) {
+    super("query", queryName);
+  }
+
+  public PeopleGraphQLQuery() {
+    super("query");
+  }
+
+  @Override
+  public String getOperationName() {
+    return "people";
+  }
+
+  public static Builder newRequest() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private Set<String> fieldsSet = new HashSet<>();
+
+    private final Map<String, String> variableReferences = new HashMap<>();
+
+    private final List<VariableDefinition> variableDefinitions = new ArrayList<>();
+
+    private String queryName;
+
+    public PeopleGraphQLQuery build() {
+      return new PeopleGraphQLQuery(queryName);                                     
+    }
+
+    public Builder queryName(String queryName) {
+      this.queryName = queryName;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithExtendedInterface/expected/client/PeopleProjectionRoot.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithExtendedInterface/expected/client/PeopleProjectionRoot.java
@@ -1,0 +1,29 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithExtendedInterface.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.BaseSubProjectionNode;
+
+public class PeopleProjectionRoot<PARENT extends BaseSubProjectionNode<?, ?>, ROOT extends BaseSubProjectionNode<?, ?>> extends BaseSubProjectionNode<PARENT, ROOT> {
+  public PeopleProjectionRoot() {
+    super(null, null, java.util.Optional.of("Person"));
+  }
+
+  public PeopleProjectionRoot<PARENT, ROOT> __typename() {
+    getFields().put("__typename", null);
+    return this;
+  }
+
+  public PeopleProjectionRoot<PARENT, ROOT> firstname() {
+    getFields().put("firstname", null);
+    return this;
+  }
+
+  public PeopleProjectionRoot<PARENT, ROOT> lastname() {
+    getFields().put("lastname", null);
+    return this;
+  }
+
+  public PeopleProjectionRoot<PARENT, ROOT> age() {
+    getFields().put("age", null);
+    return this;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithExtendedInterface/expected/datafetchers/PeopleDatafetcher.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithExtendedInterface/expected/datafetchers/PeopleDatafetcher.java
@@ -1,0 +1,18 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithExtendedInterface.expected.datafetchers;
+
+import com.netflix.graphql.dgs.DgsComponent;
+import com.netflix.graphql.dgs.DgsData;
+import com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithExtendedInterface.expected.types.Person;
+import graphql.schema.DataFetchingEnvironment;
+import java.util.List;
+
+@DgsComponent
+public class PeopleDatafetcher {
+  @DgsData(
+      parentType = "Query",
+      field = "people"
+  )
+  public List<Person> getPeople(DataFetchingEnvironment dataFetchingEnvironment) {
+    return null;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithExtendedInterface/expected/types/Person.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithExtendedInterface/expected/types/Person.java
@@ -1,0 +1,18 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithExtendedInterface.expected.types;
+
+import java.lang.Integer;
+import java.lang.String;
+
+public interface Person {
+  String getFirstname();
+
+  void setFirstname(String firstname);
+
+  String getLastname();
+
+  void setLastname(String lastname);
+
+  Integer getAge();
+
+  void setAge(Integer age);
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithExtendedInterface/schema.graphql
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithExtendedInterface/schema.graphql
@@ -1,0 +1,12 @@
+type Query {
+  people: [Person]
+}
+
+interface Person {
+  firstname: String!
+  lastname: String
+}
+
+extend interface Person {
+  age: Int
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithExtendedInterfaceInheritance/expected/DgsConstants.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithExtendedInterfaceInheritance/expected/DgsConstants.java
@@ -1,0 +1,35 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithExtendedInterfaceInheritance.expected;
+
+import java.lang.String;
+
+public class DgsConstants {
+  public static final String QUERY_TYPE = "Query";
+
+  public static class QUERY {
+    public static final String TYPE_NAME = "Query";
+
+    public static final String People = "people";
+  }
+
+  public static class EMPLOYEE {
+    public static final String TYPE_NAME = "Employee";
+
+    public static final String Firstname = "firstname";
+
+    public static final String Lastname = "lastname";
+
+    public static final String Company = "company";
+
+    public static final String Age = "age";
+  }
+
+  public static class PERSON {
+    public static final String TYPE_NAME = "Person";
+
+    public static final String Firstname = "firstname";
+
+    public static final String Lastname = "lastname";
+
+    public static final String Age = "age";
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithExtendedInterfaceInheritance/expected/client/EmployeeFragmentProjection.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithExtendedInterfaceInheritance/expected/client/EmployeeFragmentProjection.java
@@ -1,0 +1,55 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithExtendedInterfaceInheritance.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.BaseSubProjectionNode;
+import java.lang.Override;
+import java.lang.String;
+
+public class EmployeeFragmentProjection<PARENT extends BaseSubProjectionNode<?, ?>, ROOT extends BaseSubProjectionNode<?, ?>> extends BaseSubProjectionNode<PARENT, ROOT> {
+  {
+    getFields().put("__typename", null);
+  }
+
+  public EmployeeFragmentProjection(PARENT parent, ROOT root) {
+    super(parent, root, java.util.Optional.of("Employee"));
+  }
+
+  public EmployeeFragmentProjection<PARENT, ROOT> __typename() {
+    getFields().put("__typename", null);
+    return this;
+  }
+
+  public EmployeeFragmentProjection<PARENT, ROOT> firstname() {
+    getFields().put("firstname", null);
+    return this;
+  }
+
+  public EmployeeFragmentProjection<PARENT, ROOT> lastname() {
+    getFields().put("lastname", null);
+    return this;
+  }
+
+  public EmployeeFragmentProjection<PARENT, ROOT> company() {
+    getFields().put("company", null);
+    return this;
+  }
+
+  public EmployeeFragmentProjection<PARENT, ROOT> age() {
+    getFields().put("age", null);
+    return this;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder builder = new StringBuilder();
+    builder.append("... on Employee {");
+    getFields().forEach((k, v) -> {
+        builder.append(" ").append(k);
+        if(v != null) {
+            builder.append(" ").append(v.toString());
+        }
+    });
+    builder.append("}");
+     
+    return builder.toString();
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithExtendedInterfaceInheritance/expected/client/PeopleGraphQLQuery.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithExtendedInterfaceInheritance/expected/client/PeopleGraphQLQuery.java
@@ -1,0 +1,50 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithExtendedInterfaceInheritance.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.GraphQLQuery;
+import graphql.language.VariableDefinition;
+import java.lang.Override;
+import java.lang.String;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class PeopleGraphQLQuery extends GraphQLQuery {
+  public PeopleGraphQLQuery(String queryName) {
+    super("query", queryName);
+  }
+
+  public PeopleGraphQLQuery() {
+    super("query");
+  }
+
+  @Override
+  public String getOperationName() {
+    return "people";
+  }
+
+  public static Builder newRequest() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private Set<String> fieldsSet = new HashSet<>();
+
+    private final Map<String, String> variableReferences = new HashMap<>();
+
+    private final List<VariableDefinition> variableDefinitions = new ArrayList<>();
+
+    private String queryName;
+
+    public PeopleGraphQLQuery build() {
+      return new PeopleGraphQLQuery(queryName);                                     
+    }
+
+    public Builder queryName(String queryName) {
+      this.queryName = queryName;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithExtendedInterfaceInheritance/expected/client/PeopleProjectionRoot.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithExtendedInterfaceInheritance/expected/client/PeopleProjectionRoot.java
@@ -1,0 +1,36 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithExtendedInterfaceInheritance.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.BaseSubProjectionNode;
+
+public class PeopleProjectionRoot<PARENT extends BaseSubProjectionNode<?, ?>, ROOT extends BaseSubProjectionNode<?, ?>> extends BaseSubProjectionNode<PARENT, ROOT> {
+  public PeopleProjectionRoot() {
+    super(null, null, java.util.Optional.of("Person"));
+  }
+
+  public PeopleProjectionRoot<PARENT, ROOT> __typename() {
+    getFields().put("__typename", null);
+    return this;
+  }
+
+  public PeopleProjectionRoot<PARENT, ROOT> firstname() {
+    getFields().put("firstname", null);
+    return this;
+  }
+
+  public PeopleProjectionRoot<PARENT, ROOT> lastname() {
+    getFields().put("lastname", null);
+    return this;
+  }
+
+  public PeopleProjectionRoot<PARENT, ROOT> age() {
+    getFields().put("age", null);
+    return this;
+  }
+
+  public EmployeeFragmentProjection<PeopleProjectionRoot<PARENT, ROOT>, PeopleProjectionRoot<PARENT, ROOT>> onEmployee(
+      ) {
+    EmployeeFragmentProjection<PeopleProjectionRoot<PARENT, ROOT>, PeopleProjectionRoot<PARENT, ROOT>> fragment = new EmployeeFragmentProjection<>(this, this);
+    getFragments().add(fragment);
+    return fragment;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithExtendedInterfaceInheritance/expected/datafetchers/PeopleDatafetcher.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithExtendedInterfaceInheritance/expected/datafetchers/PeopleDatafetcher.java
@@ -1,0 +1,18 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithExtendedInterfaceInheritance.expected.datafetchers;
+
+import com.netflix.graphql.dgs.DgsComponent;
+import com.netflix.graphql.dgs.DgsData;
+import com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithExtendedInterfaceInheritance.expected.types.Person;
+import graphql.schema.DataFetchingEnvironment;
+import java.util.List;
+
+@DgsComponent
+public class PeopleDatafetcher {
+  @DgsData(
+      parentType = "Query",
+      field = "people"
+  )
+  public List<Person> getPeople(DataFetchingEnvironment dataFetchingEnvironment) {
+    return null;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithExtendedInterfaceInheritance/expected/types/Employee.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithExtendedInterfaceInheritance/expected/types/Employee.java
@@ -1,0 +1,126 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithExtendedInterfaceInheritance.expected.types;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.util.Objects;
+
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NONE
+)
+public class Employee implements com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithExtendedInterfaceInheritance.expected.types.Person {
+  private String firstname;
+
+  private String lastname;
+
+  private String company;
+
+  private int age;
+
+  public Employee() {
+  }
+
+  public Employee(String firstname, String lastname, String company, int age) {
+    this.firstname = firstname;
+    this.lastname = lastname;
+    this.company = company;
+    this.age = age;
+  }
+
+  public String getFirstname() {
+    return firstname;
+  }
+
+  public void setFirstname(String firstname) {
+    this.firstname = firstname;
+  }
+
+  public String getLastname() {
+    return lastname;
+  }
+
+  public void setLastname(String lastname) {
+    this.lastname = lastname;
+  }
+
+  public String getCompany() {
+    return company;
+  }
+
+  public void setCompany(String company) {
+    this.company = company;
+  }
+
+  public int getAge() {
+    return age;
+  }
+
+  public void setAge(int age) {
+    this.age = age;
+  }
+
+  @Override
+  public String toString() {
+    return "Employee{firstname='" + firstname + "', lastname='" + lastname + "', company='" + company + "', age='" + age + "'}";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    Employee that = (Employee) o;
+    return Objects.equals(firstname, that.firstname) &&
+        Objects.equals(lastname, that.lastname) &&
+        Objects.equals(company, that.company) &&
+        age == that.age;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(firstname, lastname, company, age);
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private String firstname;
+
+    private String lastname;
+
+    private String company;
+
+    private int age;
+
+    public Employee build() {
+      Employee result = new Employee();
+      result.firstname = this.firstname;
+      result.lastname = this.lastname;
+      result.company = this.company;
+      result.age = this.age;
+      return result;
+    }
+
+    public Builder firstname(String firstname) {
+      this.firstname = firstname;
+      return this;
+    }
+
+    public Builder lastname(String lastname) {
+      this.lastname = lastname;
+      return this;
+    }
+
+    public Builder company(String company) {
+      this.company = company;
+      return this;
+    }
+
+    public Builder age(int age) {
+      this.age = age;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithExtendedInterfaceInheritance/expected/types/Person.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithExtendedInterfaceInheritance/expected/types/Person.java
@@ -1,0 +1,25 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithExtendedInterfaceInheritance.expected.types;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import java.lang.String;
+
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NAME,
+    include = JsonTypeInfo.As.PROPERTY,
+    property = "__typename"
+)
+@JsonSubTypes(@JsonSubTypes.Type(value = Employee.class, name = "Employee"))
+public interface Person {
+  String getFirstname();
+
+  void setFirstname(String firstname);
+
+  String getLastname();
+
+  void setLastname(String lastname);
+
+  int getAge();
+
+  void setAge(int age);
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithExtendedInterfaceInheritance/schema.graphql
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithExtendedInterfaceInheritance/schema.graphql
@@ -1,0 +1,22 @@
+type Query {
+  people: [Person]
+}
+
+interface Person {
+  firstname: String!
+  lastname: String
+}
+
+type Employee implements Person {
+  firstname: String!
+  lastname: String
+  company: String
+}
+
+extend interface Person {
+  age: Int!
+}
+
+extend type Employee {
+  age: Int!
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithInterface/expected/DgsConstants.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithInterface/expected/DgsConstants.java
@@ -1,0 +1,31 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithInterface.expected;
+
+import java.lang.String;
+
+public class DgsConstants {
+  public static final String QUERY_TYPE = "Query";
+
+  public static class QUERY {
+    public static final String TYPE_NAME = "Query";
+
+    public static final String People = "people";
+  }
+
+  public static class EMPLOYEE {
+    public static final String TYPE_NAME = "Employee";
+
+    public static final String Firstname = "firstname";
+
+    public static final String Lastname = "lastname";
+
+    public static final String Company = "company";
+  }
+
+  public static class PERSON {
+    public static final String TYPE_NAME = "Person";
+
+    public static final String Firstname = "firstname";
+
+    public static final String Lastname = "lastname";
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithInterface/expected/client/EmployeeFragmentProjection.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithInterface/expected/client/EmployeeFragmentProjection.java
@@ -1,0 +1,50 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithInterface.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.BaseSubProjectionNode;
+import java.lang.Override;
+import java.lang.String;
+
+public class EmployeeFragmentProjection<PARENT extends BaseSubProjectionNode<?, ?>, ROOT extends BaseSubProjectionNode<?, ?>> extends BaseSubProjectionNode<PARENT, ROOT> {
+  {
+    getFields().put("__typename", null);
+  }
+
+  public EmployeeFragmentProjection(PARENT parent, ROOT root) {
+    super(parent, root, java.util.Optional.of("Employee"));
+  }
+
+  public EmployeeFragmentProjection<PARENT, ROOT> __typename() {
+    getFields().put("__typename", null);
+    return this;
+  }
+
+  public EmployeeFragmentProjection<PARENT, ROOT> firstname() {
+    getFields().put("firstname", null);
+    return this;
+  }
+
+  public EmployeeFragmentProjection<PARENT, ROOT> lastname() {
+    getFields().put("lastname", null);
+    return this;
+  }
+
+  public EmployeeFragmentProjection<PARENT, ROOT> company() {
+    getFields().put("company", null);
+    return this;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder builder = new StringBuilder();
+    builder.append("... on Employee {");
+    getFields().forEach((k, v) -> {
+        builder.append(" ").append(k);
+        if(v != null) {
+            builder.append(" ").append(v.toString());
+        }
+    });
+    builder.append("}");
+     
+    return builder.toString();
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithInterface/expected/client/PeopleGraphQLQuery.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithInterface/expected/client/PeopleGraphQLQuery.java
@@ -1,0 +1,50 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithInterface.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.GraphQLQuery;
+import graphql.language.VariableDefinition;
+import java.lang.Override;
+import java.lang.String;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class PeopleGraphQLQuery extends GraphQLQuery {
+  public PeopleGraphQLQuery(String queryName) {
+    super("query", queryName);
+  }
+
+  public PeopleGraphQLQuery() {
+    super("query");
+  }
+
+  @Override
+  public String getOperationName() {
+    return "people";
+  }
+
+  public static Builder newRequest() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private Set<String> fieldsSet = new HashSet<>();
+
+    private final Map<String, String> variableReferences = new HashMap<>();
+
+    private final List<VariableDefinition> variableDefinitions = new ArrayList<>();
+
+    private String queryName;
+
+    public PeopleGraphQLQuery build() {
+      return new PeopleGraphQLQuery(queryName);                                     
+    }
+
+    public Builder queryName(String queryName) {
+      this.queryName = queryName;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithInterface/expected/client/PeopleProjectionRoot.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithInterface/expected/client/PeopleProjectionRoot.java
@@ -1,0 +1,31 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithInterface.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.BaseSubProjectionNode;
+
+public class PeopleProjectionRoot<PARENT extends BaseSubProjectionNode<?, ?>, ROOT extends BaseSubProjectionNode<?, ?>> extends BaseSubProjectionNode<PARENT, ROOT> {
+  public PeopleProjectionRoot() {
+    super(null, null, java.util.Optional.of("Person"));
+  }
+
+  public PeopleProjectionRoot<PARENT, ROOT> __typename() {
+    getFields().put("__typename", null);
+    return this;
+  }
+
+  public PeopleProjectionRoot<PARENT, ROOT> firstname() {
+    getFields().put("firstname", null);
+    return this;
+  }
+
+  public PeopleProjectionRoot<PARENT, ROOT> lastname() {
+    getFields().put("lastname", null);
+    return this;
+  }
+
+  public EmployeeFragmentProjection<PeopleProjectionRoot<PARENT, ROOT>, PeopleProjectionRoot<PARENT, ROOT>> onEmployee(
+      ) {
+    EmployeeFragmentProjection<PeopleProjectionRoot<PARENT, ROOT>, PeopleProjectionRoot<PARENT, ROOT>> fragment = new EmployeeFragmentProjection<>(this, this);
+    getFragments().add(fragment);
+    return fragment;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithInterface/expected/datafetchers/PeopleDatafetcher.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithInterface/expected/datafetchers/PeopleDatafetcher.java
@@ -1,0 +1,18 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithInterface.expected.datafetchers;
+
+import com.netflix.graphql.dgs.DgsComponent;
+import com.netflix.graphql.dgs.DgsData;
+import com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithInterface.expected.types.Person;
+import graphql.schema.DataFetchingEnvironment;
+import java.util.List;
+
+@DgsComponent
+public class PeopleDatafetcher {
+  @DgsData(
+      parentType = "Query",
+      field = "people"
+  )
+  public List<Person> getPeople(DataFetchingEnvironment dataFetchingEnvironment) {
+    return null;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithInterface/expected/types/Employee.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithInterface/expected/types/Employee.java
@@ -1,0 +1,106 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithInterface.expected.types;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.util.Objects;
+
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NONE
+)
+public class Employee implements com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithInterface.expected.types.Person {
+  private String firstname;
+
+  private String lastname;
+
+  private String company;
+
+  public Employee() {
+  }
+
+  public Employee(String firstname, String lastname, String company) {
+    this.firstname = firstname;
+    this.lastname = lastname;
+    this.company = company;
+  }
+
+  public String getFirstname() {
+    return firstname;
+  }
+
+  public void setFirstname(String firstname) {
+    this.firstname = firstname;
+  }
+
+  public String getLastname() {
+    return lastname;
+  }
+
+  public void setLastname(String lastname) {
+    this.lastname = lastname;
+  }
+
+  public String getCompany() {
+    return company;
+  }
+
+  public void setCompany(String company) {
+    this.company = company;
+  }
+
+  @Override
+  public String toString() {
+    return "Employee{firstname='" + firstname + "', lastname='" + lastname + "', company='" + company + "'}";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    Employee that = (Employee) o;
+    return Objects.equals(firstname, that.firstname) &&
+        Objects.equals(lastname, that.lastname) &&
+        Objects.equals(company, that.company);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(firstname, lastname, company);
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private String firstname;
+
+    private String lastname;
+
+    private String company;
+
+    public Employee build() {
+      Employee result = new Employee();
+      result.firstname = this.firstname;
+      result.lastname = this.lastname;
+      result.company = this.company;
+      return result;
+    }
+
+    public Builder firstname(String firstname) {
+      this.firstname = firstname;
+      return this;
+    }
+
+    public Builder lastname(String lastname) {
+      this.lastname = lastname;
+      return this;
+    }
+
+    public Builder company(String company) {
+      this.company = company;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithInterface/expected/types/Person.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithInterface/expected/types/Person.java
@@ -1,0 +1,21 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithInterface.expected.types;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import java.lang.String;
+
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NAME,
+    include = JsonTypeInfo.As.PROPERTY,
+    property = "__typename"
+)
+@JsonSubTypes(@JsonSubTypes.Type(value = Employee.class, name = "Employee"))
+public interface Person {
+  String getFirstname();
+
+  void setFirstname(String firstname);
+
+  String getLastname();
+
+  void setLastname(String lastname);
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithInterface/schema.graphql
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithInterface/schema.graphql
@@ -1,0 +1,14 @@
+type Query {
+  people: [Person]
+}
+
+interface Person {
+  firstname: String
+  lastname: String
+}
+
+type Employee implements Person {
+  firstname: String
+  lastname: String
+  company: String
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithInterfaceInheritance/expected/DgsConstants.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithInterfaceInheritance/expected/DgsConstants.java
@@ -1,0 +1,43 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithInterfaceInheritance.expected;
+
+import java.lang.String;
+
+public class DgsConstants {
+  public static final String QUERY_TYPE = "Query";
+
+  public static class QUERY {
+    public static final String TYPE_NAME = "Query";
+
+    public static final String People = "people";
+  }
+
+  public static class TALENT {
+    public static final String TYPE_NAME = "Talent";
+
+    public static final String Firstname = "firstname";
+
+    public static final String Lastname = "lastname";
+
+    public static final String Company = "company";
+
+    public static final String ImdbProfile = "imdbProfile";
+  }
+
+  public static class PERSON {
+    public static final String TYPE_NAME = "Person";
+
+    public static final String Firstname = "firstname";
+
+    public static final String Lastname = "lastname";
+  }
+
+  public static class EMPLOYEE {
+    public static final String TYPE_NAME = "Employee";
+
+    public static final String Firstname = "firstname";
+
+    public static final String Lastname = "lastname";
+
+    public static final String Company = "company";
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithInterfaceInheritance/expected/client/PeopleGraphQLQuery.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithInterfaceInheritance/expected/client/PeopleGraphQLQuery.java
@@ -1,0 +1,50 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithInterfaceInheritance.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.GraphQLQuery;
+import graphql.language.VariableDefinition;
+import java.lang.Override;
+import java.lang.String;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class PeopleGraphQLQuery extends GraphQLQuery {
+  public PeopleGraphQLQuery(String queryName) {
+    super("query", queryName);
+  }
+
+  public PeopleGraphQLQuery() {
+    super("query");
+  }
+
+  @Override
+  public String getOperationName() {
+    return "people";
+  }
+
+  public static Builder newRequest() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private Set<String> fieldsSet = new HashSet<>();
+
+    private final Map<String, String> variableReferences = new HashMap<>();
+
+    private final List<VariableDefinition> variableDefinitions = new ArrayList<>();
+
+    private String queryName;
+
+    public PeopleGraphQLQuery build() {
+      return new PeopleGraphQLQuery(queryName);                                     
+    }
+
+    public Builder queryName(String queryName) {
+      this.queryName = queryName;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithInterfaceInheritance/expected/client/PeopleProjectionRoot.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithInterfaceInheritance/expected/client/PeopleProjectionRoot.java
@@ -1,0 +1,24 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithInterfaceInheritance.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.BaseSubProjectionNode;
+
+public class PeopleProjectionRoot<PARENT extends BaseSubProjectionNode<?, ?>, ROOT extends BaseSubProjectionNode<?, ?>> extends BaseSubProjectionNode<PARENT, ROOT> {
+  public PeopleProjectionRoot() {
+    super(null, null, java.util.Optional.of("Person"));
+  }
+
+  public PeopleProjectionRoot<PARENT, ROOT> __typename() {
+    getFields().put("__typename", null);
+    return this;
+  }
+
+  public PeopleProjectionRoot<PARENT, ROOT> firstname() {
+    getFields().put("firstname", null);
+    return this;
+  }
+
+  public PeopleProjectionRoot<PARENT, ROOT> lastname() {
+    getFields().put("lastname", null);
+    return this;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithInterfaceInheritance/expected/datafetchers/PeopleDatafetcher.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithInterfaceInheritance/expected/datafetchers/PeopleDatafetcher.java
@@ -1,0 +1,18 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithInterfaceInheritance.expected.datafetchers;
+
+import com.netflix.graphql.dgs.DgsComponent;
+import com.netflix.graphql.dgs.DgsData;
+import com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithInterfaceInheritance.expected.types.Person;
+import graphql.schema.DataFetchingEnvironment;
+import java.util.List;
+
+@DgsComponent
+public class PeopleDatafetcher {
+  @DgsData(
+      parentType = "Query",
+      field = "people"
+  )
+  public List<Person> getPeople(DataFetchingEnvironment dataFetchingEnvironment) {
+    return null;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithInterfaceInheritance/expected/types/Employee.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithInterfaceInheritance/expected/types/Employee.java
@@ -1,0 +1,25 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithInterfaceInheritance.expected.types;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import java.lang.String;
+
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NAME,
+    include = JsonTypeInfo.As.PROPERTY,
+    property = "__typename"
+)
+@JsonSubTypes(@JsonSubTypes.Type(value = Talent.class, name = "Talent"))
+public interface Employee extends Person {
+  String getFirstname();
+
+  void setFirstname(String firstname);
+
+  String getLastname();
+
+  void setLastname(String lastname);
+
+  String getCompany();
+
+  void setCompany(String company);
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithInterfaceInheritance/expected/types/Person.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithInterfaceInheritance/expected/types/Person.java
@@ -1,0 +1,13 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithInterfaceInheritance.expected.types;
+
+import java.lang.String;
+
+public interface Person {
+  String getFirstname();
+
+  void setFirstname(String firstname);
+
+  String getLastname();
+
+  void setLastname(String lastname);
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithInterfaceInheritance/expected/types/Talent.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithInterfaceInheritance/expected/types/Talent.java
@@ -1,0 +1,126 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithInterfaceInheritance.expected.types;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.util.Objects;
+
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NONE
+)
+public class Talent implements com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithInterfaceInheritance.expected.types.Employee {
+  private String firstname;
+
+  private String lastname;
+
+  private String company;
+
+  private String imdbProfile;
+
+  public Talent() {
+  }
+
+  public Talent(String firstname, String lastname, String company, String imdbProfile) {
+    this.firstname = firstname;
+    this.lastname = lastname;
+    this.company = company;
+    this.imdbProfile = imdbProfile;
+  }
+
+  public String getFirstname() {
+    return firstname;
+  }
+
+  public void setFirstname(String firstname) {
+    this.firstname = firstname;
+  }
+
+  public String getLastname() {
+    return lastname;
+  }
+
+  public void setLastname(String lastname) {
+    this.lastname = lastname;
+  }
+
+  public String getCompany() {
+    return company;
+  }
+
+  public void setCompany(String company) {
+    this.company = company;
+  }
+
+  public String getImdbProfile() {
+    return imdbProfile;
+  }
+
+  public void setImdbProfile(String imdbProfile) {
+    this.imdbProfile = imdbProfile;
+  }
+
+  @Override
+  public String toString() {
+    return "Talent{firstname='" + firstname + "', lastname='" + lastname + "', company='" + company + "', imdbProfile='" + imdbProfile + "'}";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    Talent that = (Talent) o;
+    return Objects.equals(firstname, that.firstname) &&
+        Objects.equals(lastname, that.lastname) &&
+        Objects.equals(company, that.company) &&
+        Objects.equals(imdbProfile, that.imdbProfile);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(firstname, lastname, company, imdbProfile);
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private String firstname;
+
+    private String lastname;
+
+    private String company;
+
+    private String imdbProfile;
+
+    public Talent build() {
+      Talent result = new Talent();
+      result.firstname = this.firstname;
+      result.lastname = this.lastname;
+      result.company = this.company;
+      result.imdbProfile = this.imdbProfile;
+      return result;
+    }
+
+    public Builder firstname(String firstname) {
+      this.firstname = firstname;
+      return this;
+    }
+
+    public Builder lastname(String lastname) {
+      this.lastname = lastname;
+      return this;
+    }
+
+    public Builder company(String company) {
+      this.company = company;
+      return this;
+    }
+
+    public Builder imdbProfile(String imdbProfile) {
+      this.imdbProfile = imdbProfile;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithInterfaceInheritance/schema.graphql
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithInterfaceInheritance/schema.graphql
@@ -1,0 +1,21 @@
+type Query {
+  people: [Person]
+}
+
+interface Person {
+  firstname: String!
+  lastname: String
+}
+
+interface Employee implements Person {
+  firstname: String!
+  lastname: String
+  company: String
+}
+
+type Talent implements Employee {
+  firstname: String!
+  lastname: String
+  company: String
+  imdbProfile: String
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithListProperties/expected/DgsConstants.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithListProperties/expected/DgsConstants.java
@@ -1,0 +1,21 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithListProperties.expected;
+
+import java.lang.String;
+
+public class DgsConstants {
+  public static final String QUERY_TYPE = "Query";
+
+  public static class QUERY {
+    public static final String TYPE_NAME = "Query";
+
+    public static final String People = "people";
+  }
+
+  public static class PERSON {
+    public static final String TYPE_NAME = "Person";
+
+    public static final String Name = "name";
+
+    public static final String Email = "email";
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithListProperties/expected/client/PeopleGraphQLQuery.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithListProperties/expected/client/PeopleGraphQLQuery.java
@@ -1,0 +1,50 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithListProperties.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.GraphQLQuery;
+import graphql.language.VariableDefinition;
+import java.lang.Override;
+import java.lang.String;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class PeopleGraphQLQuery extends GraphQLQuery {
+  public PeopleGraphQLQuery(String queryName) {
+    super("query", queryName);
+  }
+
+  public PeopleGraphQLQuery() {
+    super("query");
+  }
+
+  @Override
+  public String getOperationName() {
+    return "people";
+  }
+
+  public static Builder newRequest() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private Set<String> fieldsSet = new HashSet<>();
+
+    private final Map<String, String> variableReferences = new HashMap<>();
+
+    private final List<VariableDefinition> variableDefinitions = new ArrayList<>();
+
+    private String queryName;
+
+    public PeopleGraphQLQuery build() {
+      return new PeopleGraphQLQuery(queryName);                                     
+    }
+
+    public Builder queryName(String queryName) {
+      this.queryName = queryName;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithListProperties/expected/client/PeopleProjectionRoot.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithListProperties/expected/client/PeopleProjectionRoot.java
@@ -1,0 +1,24 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithListProperties.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.BaseSubProjectionNode;
+
+public class PeopleProjectionRoot<PARENT extends BaseSubProjectionNode<?, ?>, ROOT extends BaseSubProjectionNode<?, ?>> extends BaseSubProjectionNode<PARENT, ROOT> {
+  public PeopleProjectionRoot() {
+    super(null, null, java.util.Optional.of("Person"));
+  }
+
+  public PeopleProjectionRoot<PARENT, ROOT> __typename() {
+    getFields().put("__typename", null);
+    return this;
+  }
+
+  public PeopleProjectionRoot<PARENT, ROOT> name() {
+    getFields().put("name", null);
+    return this;
+  }
+
+  public PeopleProjectionRoot<PARENT, ROOT> email() {
+    getFields().put("email", null);
+    return this;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithListProperties/expected/datafetchers/PeopleDatafetcher.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithListProperties/expected/datafetchers/PeopleDatafetcher.java
@@ -1,0 +1,18 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithListProperties.expected.datafetchers;
+
+import com.netflix.graphql.dgs.DgsComponent;
+import com.netflix.graphql.dgs.DgsData;
+import com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithListProperties.expected.types.Person;
+import graphql.schema.DataFetchingEnvironment;
+import java.util.List;
+
+@DgsComponent
+public class PeopleDatafetcher {
+  @DgsData(
+      parentType = "Query",
+      field = "people"
+  )
+  public List<Person> getPeople(DataFetchingEnvironment dataFetchingEnvironment) {
+    return null;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithListProperties/expected/types/Person.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithListProperties/expected/types/Person.java
@@ -1,0 +1,83 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithListProperties.expected.types;
+
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.util.List;
+import java.util.Objects;
+
+public class Person {
+  private String name;
+
+  private List<String> email;
+
+  public Person() {
+  }
+
+  public Person(String name, List<String> email) {
+    this.name = name;
+    this.email = email;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public List<String> getEmail() {
+    return email;
+  }
+
+  public void setEmail(List<String> email) {
+    this.email = email;
+  }
+
+  @Override
+  public String toString() {
+    return "Person{name='" + name + "', email='" + email + "'}";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    Person that = (Person) o;
+    return Objects.equals(name, that.name) &&
+        Objects.equals(email, that.email);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, email);
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private String name;
+
+    private List<String> email;
+
+    public Person build() {
+      Person result = new Person();
+      result.name = this.name;
+      result.email = this.email;
+      return result;
+    }
+
+    public Builder name(String name) {
+      this.name = name;
+      return this;
+    }
+
+    public Builder email(List<String> email) {
+      this.email = email;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithListProperties/schema.graphql
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithListProperties/schema.graphql
@@ -1,0 +1,8 @@
+type Query {
+  people: [Person]
+}
+
+type Person {
+  name: String
+  email: [String]
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithMappedInterfaces/expected/DgsConstants.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithMappedInterfaces/expected/DgsConstants.java
@@ -1,0 +1,31 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithMappedInterfaces.expected;
+
+import java.lang.String;
+
+public class DgsConstants {
+  public static final String QUERY_TYPE = "Query";
+
+  public static class QUERY {
+    public static final String TYPE_NAME = "Query";
+
+    public static final String Products = "products";
+  }
+
+  public static class PRODUCT {
+    public static final String TYPE_NAME = "Product";
+
+    public static final String Id = "id";
+  }
+
+  public static class NODE {
+    public static final String TYPE_NAME = "Node";
+
+    public static final String Id = "id";
+  }
+
+  public static class ENTITY {
+    public static final String TYPE_NAME = "Entity";
+
+    public static final String Id = "id";
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithMappedInterfaces/expected/client/ProductsGraphQLQuery.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithMappedInterfaces/expected/client/ProductsGraphQLQuery.java
@@ -1,0 +1,50 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithMappedInterfaces.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.GraphQLQuery;
+import graphql.language.VariableDefinition;
+import java.lang.Override;
+import java.lang.String;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class ProductsGraphQLQuery extends GraphQLQuery {
+  public ProductsGraphQLQuery(String queryName) {
+    super("query", queryName);
+  }
+
+  public ProductsGraphQLQuery() {
+    super("query");
+  }
+
+  @Override
+  public String getOperationName() {
+    return "products";
+  }
+
+  public static Builder newRequest() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private Set<String> fieldsSet = new HashSet<>();
+
+    private final Map<String, String> variableReferences = new HashMap<>();
+
+    private final List<VariableDefinition> variableDefinitions = new ArrayList<>();
+
+    private String queryName;
+
+    public ProductsGraphQLQuery build() {
+      return new ProductsGraphQLQuery(queryName);                                     
+    }
+
+    public Builder queryName(String queryName) {
+      this.queryName = queryName;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithMappedInterfaces/expected/client/ProductsProjectionRoot.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithMappedInterfaces/expected/client/ProductsProjectionRoot.java
@@ -1,0 +1,19 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithMappedInterfaces.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.BaseSubProjectionNode;
+
+public class ProductsProjectionRoot<PARENT extends BaseSubProjectionNode<?, ?>, ROOT extends BaseSubProjectionNode<?, ?>> extends BaseSubProjectionNode<PARENT, ROOT> {
+  public ProductsProjectionRoot() {
+    super(null, null, java.util.Optional.of("Product"));
+  }
+
+  public ProductsProjectionRoot<PARENT, ROOT> __typename() {
+    getFields().put("__typename", null);
+    return this;
+  }
+
+  public ProductsProjectionRoot<PARENT, ROOT> id() {
+    getFields().put("id", null);
+    return this;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithMappedInterfaces/expected/datafetchers/ProductsDatafetcher.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithMappedInterfaces/expected/datafetchers/ProductsDatafetcher.java
@@ -1,0 +1,18 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithMappedInterfaces.expected.datafetchers;
+
+import com.netflix.graphql.dgs.DgsComponent;
+import com.netflix.graphql.dgs.DgsData;
+import com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithMappedInterfaces.expected.types.Product;
+import graphql.schema.DataFetchingEnvironment;
+import java.util.List;
+
+@DgsComponent
+public class ProductsDatafetcher {
+  @DgsData(
+      parentType = "Query",
+      field = "products"
+  )
+  public List<Product> getProducts(DataFetchingEnvironment dataFetchingEnvironment) {
+    return null;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithMappedInterfaces/expected/types/Entity.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithMappedInterfaces/expected/types/Entity.java
@@ -1,0 +1,18 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithMappedInterfaces.expected.types;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.netflix.graphql.dgs.codegen.java.fixtures.Node;
+import java.lang.String;
+
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NAME,
+    include = JsonTypeInfo.As.PROPERTY,
+    property = "__typename"
+)
+@JsonSubTypes(@JsonSubTypes.Type(value = Product.class, name = "Product"))
+public interface Entity extends Node {
+  String getId();
+
+  void setId(String id);
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithMappedInterfaces/expected/types/Product.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithMappedInterfaces/expected/types/Product.java
@@ -1,0 +1,66 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithMappedInterfaces.expected.types;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.util.Objects;
+
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NONE
+)
+public class Product implements com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithMappedInterfaces.expected.types.Entity, com.netflix.graphql.dgs.codegen.java.fixtures.Node {
+  private String id;
+
+  public Product() {
+  }
+
+  public Product(String id) {
+    this.id = id;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(String id) {
+    this.id = id;
+  }
+
+  @Override
+  public String toString() {
+    return "Product{id='" + id + "'}";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    Product that = (Product) o;
+    return Objects.equals(id, that.id);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id);
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private String id;
+
+    public Product build() {
+      Product result = new Product();
+      result.id = this.id;
+      return result;
+    }
+
+    public Builder id(String id) {
+      this.id = id;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithMappedInterfaces/schema.graphql
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithMappedInterfaces/schema.graphql
@@ -1,0 +1,15 @@
+type Query {
+    products: [Product]
+}
+
+interface Node {
+    id: ID!
+}
+
+interface Entity implements Node {
+    id: ID!
+}
+
+type Product implements Entity & Node {
+    id: ID!
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithMappedTypes/expected/DgsConstants.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithMappedTypes/expected/DgsConstants.java
@@ -1,0 +1,51 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithMappedTypes.expected;
+
+import java.lang.String;
+
+public class DgsConstants {
+  public static final String QUERY_TYPE = "Query";
+
+  public static class QUERY {
+    public static final String TYPE_NAME = "Query";
+
+    public static final String Entity = "entity";
+
+    public static final String EntityConnection = "entityConnection";
+  }
+
+  public static class ENTITY {
+    public static final String TYPE_NAME = "Entity";
+
+    public static final String Long = "long";
+
+    public static final String DateTime = "dateTime";
+  }
+
+  public static class ENTITYCONNECTION {
+    public static final String TYPE_NAME = "EntityConnection";
+
+    public static final String PageInfo = "pageInfo";
+
+    public static final String Edges = "edges";
+  }
+
+  public static class ENTITYEDGE {
+    public static final String TYPE_NAME = "EntityEdge";
+
+    public static final String Cursor = "cursor";
+
+    public static final String Node = "node";
+  }
+
+  public static class PAGEINFO {
+    public static final String TYPE_NAME = "PageInfo";
+
+    public static final String StartCursor = "startCursor";
+
+    public static final String EndCursor = "endCursor";
+
+    public static final String HasNextPage = "hasNextPage";
+
+    public static final String HasPreviousPage = "hasPreviousPage";
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithMappedTypes/expected/client/EntityConnectionGraphQLQuery.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithMappedTypes/expected/client/EntityConnectionGraphQLQuery.java
@@ -1,0 +1,50 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithMappedTypes.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.GraphQLQuery;
+import graphql.language.VariableDefinition;
+import java.lang.Override;
+import java.lang.String;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class EntityConnectionGraphQLQuery extends GraphQLQuery {
+  public EntityConnectionGraphQLQuery(String queryName) {
+    super("query", queryName);
+  }
+
+  public EntityConnectionGraphQLQuery() {
+    super("query");
+  }
+
+  @Override
+  public String getOperationName() {
+    return "entityConnection";
+  }
+
+  public static Builder newRequest() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private Set<String> fieldsSet = new HashSet<>();
+
+    private final Map<String, String> variableReferences = new HashMap<>();
+
+    private final List<VariableDefinition> variableDefinitions = new ArrayList<>();
+
+    private String queryName;
+
+    public EntityConnectionGraphQLQuery build() {
+      return new EntityConnectionGraphQLQuery(queryName);                                     
+    }
+
+    public Builder queryName(String queryName) {
+      this.queryName = queryName;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithMappedTypes/expected/client/EntityConnectionProjectionRoot.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithMappedTypes/expected/client/EntityConnectionProjectionRoot.java
@@ -1,0 +1,28 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithMappedTypes.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.BaseSubProjectionNode;
+
+public class EntityConnectionProjectionRoot<PARENT extends BaseSubProjectionNode<?, ?>, ROOT extends BaseSubProjectionNode<?, ?>> extends BaseSubProjectionNode<PARENT, ROOT> {
+  public EntityConnectionProjectionRoot() {
+    super(null, null, java.util.Optional.of("EntityConnection"));
+  }
+
+  public EntityConnectionProjectionRoot<PARENT, ROOT> __typename() {
+    getFields().put("__typename", null);
+    return this;
+  }
+
+  public PageInfoProjection<EntityConnectionProjectionRoot<PARENT, ROOT>, EntityConnectionProjectionRoot<PARENT, ROOT>> pageInfo(
+      ) {
+    PageInfoProjection<EntityConnectionProjectionRoot<PARENT, ROOT>, EntityConnectionProjectionRoot<PARENT, ROOT>> projection = new PageInfoProjection<>(this, this);    
+    getFields().put("pageInfo", projection);
+    return projection;
+  }
+
+  public EntityEdgeProjection<EntityConnectionProjectionRoot<PARENT, ROOT>, EntityConnectionProjectionRoot<PARENT, ROOT>> edges(
+      ) {
+    EntityEdgeProjection<EntityConnectionProjectionRoot<PARENT, ROOT>, EntityConnectionProjectionRoot<PARENT, ROOT>> projection = new EntityEdgeProjection<>(this, this);    
+    getFields().put("edges", projection);
+    return projection;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithMappedTypes/expected/client/EntityEdgeProjection.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithMappedTypes/expected/client/EntityEdgeProjection.java
@@ -1,0 +1,25 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithMappedTypes.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.BaseSubProjectionNode;
+
+public class EntityEdgeProjection<PARENT extends BaseSubProjectionNode<?, ?>, ROOT extends BaseSubProjectionNode<?, ?>> extends BaseSubProjectionNode<PARENT, ROOT> {
+  public EntityEdgeProjection(PARENT parent, ROOT root) {
+    super(parent, root, java.util.Optional.of("EntityEdge"));
+  }
+
+  public EntityEdgeProjection<PARENT, ROOT> __typename() {
+    getFields().put("__typename", null);
+    return this;
+  }
+
+  public EntityProjection<EntityEdgeProjection<PARENT, ROOT>, ROOT> node() {
+     EntityProjection<EntityEdgeProjection<PARENT, ROOT>, ROOT> projection = new EntityProjection<>(this, getRoot());
+     getFields().put("node", projection);
+     return projection;
+  }
+
+  public EntityEdgeProjection<PARENT, ROOT> cursor() {
+    getFields().put("cursor", null);
+    return this;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithMappedTypes/expected/client/EntityGraphQLQuery.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithMappedTypes/expected/client/EntityGraphQLQuery.java
@@ -1,0 +1,50 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithMappedTypes.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.GraphQLQuery;
+import graphql.language.VariableDefinition;
+import java.lang.Override;
+import java.lang.String;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class EntityGraphQLQuery extends GraphQLQuery {
+  public EntityGraphQLQuery(String queryName) {
+    super("query", queryName);
+  }
+
+  public EntityGraphQLQuery() {
+    super("query");
+  }
+
+  @Override
+  public String getOperationName() {
+    return "entity";
+  }
+
+  public static Builder newRequest() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private Set<String> fieldsSet = new HashSet<>();
+
+    private final Map<String, String> variableReferences = new HashMap<>();
+
+    private final List<VariableDefinition> variableDefinitions = new ArrayList<>();
+
+    private String queryName;
+
+    public EntityGraphQLQuery build() {
+      return new EntityGraphQLQuery(queryName);                                     
+    }
+
+    public Builder queryName(String queryName) {
+      this.queryName = queryName;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithMappedTypes/expected/client/EntityProjection.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithMappedTypes/expected/client/EntityProjection.java
@@ -1,0 +1,24 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithMappedTypes.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.BaseSubProjectionNode;
+
+public class EntityProjection<PARENT extends BaseSubProjectionNode<?, ?>, ROOT extends BaseSubProjectionNode<?, ?>> extends BaseSubProjectionNode<PARENT, ROOT> {
+  public EntityProjection(PARENT parent, ROOT root) {
+    super(parent, root, java.util.Optional.of("Entity"));
+  }
+
+  public EntityProjection<PARENT, ROOT> __typename() {
+    getFields().put("__typename", null);
+    return this;
+  }
+
+  public EntityProjection<PARENT, ROOT> _long() {
+    getFields().put("long", null);
+    return this;
+  }
+
+  public EntityProjection<PARENT, ROOT> dateTime() {
+    getFields().put("dateTime", null);
+    return this;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithMappedTypes/expected/client/EntityProjectionRoot.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithMappedTypes/expected/client/EntityProjectionRoot.java
@@ -1,0 +1,24 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithMappedTypes.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.BaseSubProjectionNode;
+
+public class EntityProjectionRoot<PARENT extends BaseSubProjectionNode<?, ?>, ROOT extends BaseSubProjectionNode<?, ?>> extends BaseSubProjectionNode<PARENT, ROOT> {
+  public EntityProjectionRoot() {
+    super(null, null, java.util.Optional.of("Entity"));
+  }
+
+  public EntityProjectionRoot<PARENT, ROOT> __typename() {
+    getFields().put("__typename", null);
+    return this;
+  }
+
+  public EntityProjectionRoot<PARENT, ROOT> _long() {
+    getFields().put("long", null);
+    return this;
+  }
+
+  public EntityProjectionRoot<PARENT, ROOT> dateTime() {
+    getFields().put("dateTime", null);
+    return this;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithMappedTypes/expected/client/PageInfoProjection.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithMappedTypes/expected/client/PageInfoProjection.java
@@ -1,0 +1,34 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithMappedTypes.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.BaseSubProjectionNode;
+
+public class PageInfoProjection<PARENT extends BaseSubProjectionNode<?, ?>, ROOT extends BaseSubProjectionNode<?, ?>> extends BaseSubProjectionNode<PARENT, ROOT> {
+  public PageInfoProjection(PARENT parent, ROOT root) {
+    super(parent, root, java.util.Optional.of("PageInfo"));
+  }
+
+  public PageInfoProjection<PARENT, ROOT> __typename() {
+    getFields().put("__typename", null);
+    return this;
+  }
+
+  public PageInfoProjection<PARENT, ROOT> startCursor() {
+    getFields().put("startCursor", null);
+    return this;
+  }
+
+  public PageInfoProjection<PARENT, ROOT> endCursor() {
+    getFields().put("endCursor", null);
+    return this;
+  }
+
+  public PageInfoProjection<PARENT, ROOT> hasNextPage() {
+    getFields().put("hasNextPage", null);
+    return this;
+  }
+
+  public PageInfoProjection<PARENT, ROOT> hasPreviousPage() {
+    getFields().put("hasPreviousPage", null);
+    return this;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithMappedTypes/expected/datafetchers/EntityConnectionDatafetcher.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithMappedTypes/expected/datafetchers/EntityConnectionDatafetcher.java
@@ -1,0 +1,19 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithMappedTypes.expected.datafetchers;
+
+import com.netflix.graphql.dgs.DgsComponent;
+import com.netflix.graphql.dgs.DgsData;
+import com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithMappedTypes.expected.types.EntityEdge;
+import graphql.relay.SimpleListConnection;
+import graphql.schema.DataFetchingEnvironment;
+
+@DgsComponent
+public class EntityConnectionDatafetcher {
+  @DgsData(
+      parentType = "Query",
+      field = "entityConnection"
+  )
+  public SimpleListConnection<EntityEdge> getEntityConnection(
+      DataFetchingEnvironment dataFetchingEnvironment) {
+    return null;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithMappedTypes/expected/datafetchers/EntityDatafetcher.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithMappedTypes/expected/datafetchers/EntityDatafetcher.java
@@ -1,0 +1,18 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithMappedTypes.expected.datafetchers;
+
+import com.netflix.graphql.dgs.DgsComponent;
+import com.netflix.graphql.dgs.DgsData;
+import com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithMappedTypes.expected.types.Entity;
+import graphql.schema.DataFetchingEnvironment;
+import java.util.List;
+
+@DgsComponent
+public class EntityDatafetcher {
+  @DgsData(
+      parentType = "Query",
+      field = "entity"
+  )
+  public List<Entity> getEntity(DataFetchingEnvironment dataFetchingEnvironment) {
+    return null;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithMappedTypes/expected/types/Entity.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithMappedTypes/expected/types/Entity.java
@@ -1,0 +1,84 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithMappedTypes.expected.types;
+
+import java.lang.Long;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.time.OffsetDateTime;
+import java.util.Objects;
+
+public class Entity {
+  private Long _long;
+
+  private OffsetDateTime dateTime;
+
+  public Entity() {
+  }
+
+  public Entity(Long _long, OffsetDateTime dateTime) {
+    this._long = _long;
+    this.dateTime = dateTime;
+  }
+
+  public Long getLong() {
+    return _long;
+  }
+
+  public void setLong(Long _long) {
+    this._long = _long;
+  }
+
+  public OffsetDateTime getDateTime() {
+    return dateTime;
+  }
+
+  public void setDateTime(OffsetDateTime dateTime) {
+    this.dateTime = dateTime;
+  }
+
+  @Override
+  public String toString() {
+    return "Entity{long='" + _long + "', dateTime='" + dateTime + "'}";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    Entity that = (Entity) o;
+    return Objects.equals(_long, that._long) &&
+        Objects.equals(dateTime, that.dateTime);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_long, dateTime);
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private Long _long;
+
+    private OffsetDateTime dateTime;
+
+    public Entity build() {
+      Entity result = new Entity();
+      result._long = this._long;
+      result.dateTime = this.dateTime;
+      return result;
+    }
+
+    public Builder _long(Long _long) {
+      this._long = _long;
+      return this;
+    }
+
+    public Builder dateTime(OffsetDateTime dateTime) {
+      this.dateTime = dateTime;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithMappedTypes/expected/types/EntityEdge.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithMappedTypes/expected/types/EntityEdge.java
@@ -1,0 +1,82 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithMappedTypes.expected.types;
+
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.util.Objects;
+
+public class EntityEdge {
+  private String cursor;
+
+  private Entity node;
+
+  public EntityEdge() {
+  }
+
+  public EntityEdge(String cursor, Entity node) {
+    this.cursor = cursor;
+    this.node = node;
+  }
+
+  public String getCursor() {
+    return cursor;
+  }
+
+  public void setCursor(String cursor) {
+    this.cursor = cursor;
+  }
+
+  public Entity getNode() {
+    return node;
+  }
+
+  public void setNode(Entity node) {
+    this.node = node;
+  }
+
+  @Override
+  public String toString() {
+    return "EntityEdge{cursor='" + cursor + "', node='" + node + "'}";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    EntityEdge that = (EntityEdge) o;
+    return Objects.equals(cursor, that.cursor) &&
+        Objects.equals(node, that.node);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(cursor, node);
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private String cursor;
+
+    private Entity node;
+
+    public EntityEdge build() {
+      EntityEdge result = new EntityEdge();
+      result.cursor = this.cursor;
+      result.node = this.node;
+      return result;
+    }
+
+    public Builder cursor(String cursor) {
+      this.cursor = cursor;
+      return this;
+    }
+
+    public Builder node(Entity node) {
+      this.node = node;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithMappedTypes/schema.graphql
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithMappedTypes/schema.graphql
@@ -1,0 +1,29 @@
+type Query {
+  entity: [Entity]
+  entityConnection: EntityConnection
+}
+
+type Entity {
+  long: Long
+  dateTime: DateTime
+}
+
+type EntityConnection {
+  pageInfo: PageInfo!
+  edges: [EntityEdge]
+}
+
+type EntityEdge {
+  cursor: String!
+  node: Entity
+}
+
+type PageInfo {
+  startCursor: String
+  endCursor: String
+  hasNextPage: Boolean!
+  hasPreviousPage: Boolean!
+}
+
+scalar Long
+scalar DateTime

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithNonNullableAndInterface/expected/DgsConstants.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithNonNullableAndInterface/expected/DgsConstants.java
@@ -1,0 +1,33 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithNonNullableAndInterface.expected;
+
+import java.lang.String;
+
+public class DgsConstants {
+  public static final String QUERY_TYPE = "Query";
+
+  public static class QUERY {
+    public static final String TYPE_NAME = "Query";
+
+    public static final String People = "people";
+  }
+
+  public static class EMPLOYEE {
+    public static final String TYPE_NAME = "Employee";
+
+    public static final String Firstname = "firstname";
+
+    public static final String Lastname = "lastname";
+
+    public static final String Company = "company";
+  }
+
+  public static class PERSON {
+    public static final String TYPE_NAME = "Person";
+
+    public static final String Firstname = "firstname";
+
+    public static final String Lastname = "lastname";
+
+    public static final String Company = "company";
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithNonNullableAndInterface/expected/client/EmployeeFragmentProjection.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithNonNullableAndInterface/expected/client/EmployeeFragmentProjection.java
@@ -1,0 +1,50 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithNonNullableAndInterface.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.BaseSubProjectionNode;
+import java.lang.Override;
+import java.lang.String;
+
+public class EmployeeFragmentProjection<PARENT extends BaseSubProjectionNode<?, ?>, ROOT extends BaseSubProjectionNode<?, ?>> extends BaseSubProjectionNode<PARENT, ROOT> {
+  {
+    getFields().put("__typename", null);
+  }
+
+  public EmployeeFragmentProjection(PARENT parent, ROOT root) {
+    super(parent, root, java.util.Optional.of("Employee"));
+  }
+
+  public EmployeeFragmentProjection<PARENT, ROOT> __typename() {
+    getFields().put("__typename", null);
+    return this;
+  }
+
+  public EmployeeFragmentProjection<PARENT, ROOT> firstname() {
+    getFields().put("firstname", null);
+    return this;
+  }
+
+  public EmployeeFragmentProjection<PARENT, ROOT> lastname() {
+    getFields().put("lastname", null);
+    return this;
+  }
+
+  public EmployeeFragmentProjection<PARENT, ROOT> company() {
+    getFields().put("company", null);
+    return this;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder builder = new StringBuilder();
+    builder.append("... on Employee {");
+    getFields().forEach((k, v) -> {
+        builder.append(" ").append(k);
+        if(v != null) {
+            builder.append(" ").append(v.toString());
+        }
+    });
+    builder.append("}");
+     
+    return builder.toString();
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithNonNullableAndInterface/expected/client/PeopleGraphQLQuery.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithNonNullableAndInterface/expected/client/PeopleGraphQLQuery.java
@@ -1,0 +1,50 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithNonNullableAndInterface.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.GraphQLQuery;
+import graphql.language.VariableDefinition;
+import java.lang.Override;
+import java.lang.String;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class PeopleGraphQLQuery extends GraphQLQuery {
+  public PeopleGraphQLQuery(String queryName) {
+    super("query", queryName);
+  }
+
+  public PeopleGraphQLQuery() {
+    super("query");
+  }
+
+  @Override
+  public String getOperationName() {
+    return "people";
+  }
+
+  public static Builder newRequest() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private Set<String> fieldsSet = new HashSet<>();
+
+    private final Map<String, String> variableReferences = new HashMap<>();
+
+    private final List<VariableDefinition> variableDefinitions = new ArrayList<>();
+
+    private String queryName;
+
+    public PeopleGraphQLQuery build() {
+      return new PeopleGraphQLQuery(queryName);                                     
+    }
+
+    public Builder queryName(String queryName) {
+      this.queryName = queryName;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithNonNullableAndInterface/expected/client/PeopleProjectionRoot.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithNonNullableAndInterface/expected/client/PeopleProjectionRoot.java
@@ -1,0 +1,36 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithNonNullableAndInterface.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.BaseSubProjectionNode;
+
+public class PeopleProjectionRoot<PARENT extends BaseSubProjectionNode<?, ?>, ROOT extends BaseSubProjectionNode<?, ?>> extends BaseSubProjectionNode<PARENT, ROOT> {
+  public PeopleProjectionRoot() {
+    super(null, null, java.util.Optional.of("Person"));
+  }
+
+  public PeopleProjectionRoot<PARENT, ROOT> __typename() {
+    getFields().put("__typename", null);
+    return this;
+  }
+
+  public PeopleProjectionRoot<PARENT, ROOT> firstname() {
+    getFields().put("firstname", null);
+    return this;
+  }
+
+  public PeopleProjectionRoot<PARENT, ROOT> lastname() {
+    getFields().put("lastname", null);
+    return this;
+  }
+
+  public PeopleProjectionRoot<PARENT, ROOT> company() {
+    getFields().put("company", null);
+    return this;
+  }
+
+  public EmployeeFragmentProjection<PeopleProjectionRoot<PARENT, ROOT>, PeopleProjectionRoot<PARENT, ROOT>> onEmployee(
+      ) {
+    EmployeeFragmentProjection<PeopleProjectionRoot<PARENT, ROOT>, PeopleProjectionRoot<PARENT, ROOT>> fragment = new EmployeeFragmentProjection<>(this, this);
+    getFragments().add(fragment);
+    return fragment;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithNonNullableAndInterface/expected/datafetchers/PeopleDatafetcher.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithNonNullableAndInterface/expected/datafetchers/PeopleDatafetcher.java
@@ -1,0 +1,18 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithNonNullableAndInterface.expected.datafetchers;
+
+import com.netflix.graphql.dgs.DgsComponent;
+import com.netflix.graphql.dgs.DgsData;
+import com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithNonNullableAndInterface.expected.types.Person;
+import graphql.schema.DataFetchingEnvironment;
+import java.util.List;
+
+@DgsComponent
+public class PeopleDatafetcher {
+  @DgsData(
+      parentType = "Query",
+      field = "people"
+  )
+  public List<Person> getPeople(DataFetchingEnvironment dataFetchingEnvironment) {
+    return null;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithNonNullableAndInterface/expected/types/Employee.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithNonNullableAndInterface/expected/types/Employee.java
@@ -1,0 +1,106 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithNonNullableAndInterface.expected.types;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.util.Objects;
+
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NONE
+)
+public class Employee implements com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithNonNullableAndInterface.expected.types.Person {
+  private String firstname;
+
+  private String lastname;
+
+  private String company;
+
+  public Employee() {
+  }
+
+  public Employee(String firstname, String lastname, String company) {
+    this.firstname = firstname;
+    this.lastname = lastname;
+    this.company = company;
+  }
+
+  public String getFirstname() {
+    return firstname;
+  }
+
+  public void setFirstname(String firstname) {
+    this.firstname = firstname;
+  }
+
+  public String getLastname() {
+    return lastname;
+  }
+
+  public void setLastname(String lastname) {
+    this.lastname = lastname;
+  }
+
+  public String getCompany() {
+    return company;
+  }
+
+  public void setCompany(String company) {
+    this.company = company;
+  }
+
+  @Override
+  public String toString() {
+    return "Employee{firstname='" + firstname + "', lastname='" + lastname + "', company='" + company + "'}";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    Employee that = (Employee) o;
+    return Objects.equals(firstname, that.firstname) &&
+        Objects.equals(lastname, that.lastname) &&
+        Objects.equals(company, that.company);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(firstname, lastname, company);
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private String firstname;
+
+    private String lastname;
+
+    private String company;
+
+    public Employee build() {
+      Employee result = new Employee();
+      result.firstname = this.firstname;
+      result.lastname = this.lastname;
+      result.company = this.company;
+      return result;
+    }
+
+    public Builder firstname(String firstname) {
+      this.firstname = firstname;
+      return this;
+    }
+
+    public Builder lastname(String lastname) {
+      this.lastname = lastname;
+      return this;
+    }
+
+    public Builder company(String company) {
+      this.company = company;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithNonNullableAndInterface/expected/types/Person.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithNonNullableAndInterface/expected/types/Person.java
@@ -1,0 +1,25 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithNonNullableAndInterface.expected.types;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import java.lang.String;
+
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NAME,
+    include = JsonTypeInfo.As.PROPERTY,
+    property = "__typename"
+)
+@JsonSubTypes(@JsonSubTypes.Type(value = Employee.class, name = "Employee"))
+public interface Person {
+  String getFirstname();
+
+  void setFirstname(String firstname);
+
+  String getLastname();
+
+  void setLastname(String lastname);
+
+  String getCompany();
+
+  void setCompany(String company);
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithNonNullableAndInterface/schema.graphql
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithNonNullableAndInterface/schema.graphql
@@ -1,0 +1,15 @@
+type Query {
+  people: [Person]
+}
+
+interface Person {
+  firstname: String!
+  lastname: String!
+  company: String
+}
+
+type Employee implements Person {
+  firstname: String!
+  lastname: String!
+  company: String
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithNonNullableComplexType/expected/DgsConstants.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithNonNullableComplexType/expected/DgsConstants.java
@@ -1,0 +1,17 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithNonNullableComplexType.expected;
+
+import java.lang.String;
+
+public class DgsConstants {
+  public static class MYTYPE {
+    public static final String TYPE_NAME = "MyType";
+
+    public static final String Other = "other";
+  }
+
+  public static class OTHERTYPE {
+    public static final String TYPE_NAME = "OtherType";
+
+    public static final String Name = "name";
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithNonNullableComplexType/expected/types/MyType.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithNonNullableComplexType/expected/types/MyType.java
@@ -1,0 +1,62 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithNonNullableComplexType.expected.types;
+
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.util.Objects;
+
+public class MyType {
+  private OtherType other;
+
+  public MyType() {
+  }
+
+  public MyType(OtherType other) {
+    this.other = other;
+  }
+
+  public OtherType getOther() {
+    return other;
+  }
+
+  public void setOther(OtherType other) {
+    this.other = other;
+  }
+
+  @Override
+  public String toString() {
+    return "MyType{other='" + other + "'}";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    MyType that = (MyType) o;
+    return Objects.equals(other, that.other);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(other);
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private OtherType other;
+
+    public MyType build() {
+      MyType result = new MyType();
+      result.other = this.other;
+      return result;
+    }
+
+    public Builder other(OtherType other) {
+      this.other = other;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithNonNullableComplexType/expected/types/OtherType.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithNonNullableComplexType/expected/types/OtherType.java
@@ -1,0 +1,62 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithNonNullableComplexType.expected.types;
+
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.util.Objects;
+
+public class OtherType {
+  private String name;
+
+  public OtherType() {
+  }
+
+  public OtherType(String name) {
+    this.name = name;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  @Override
+  public String toString() {
+    return "OtherType{name='" + name + "'}";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    OtherType that = (OtherType) o;
+    return Objects.equals(name, that.name);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name);
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private String name;
+
+    public OtherType build() {
+      OtherType result = new OtherType();
+      result.name = this.name;
+      return result;
+    }
+
+    public Builder name(String name) {
+      this.name = name;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithNonNullableComplexType/schema.graphql
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithNonNullableComplexType/schema.graphql
@@ -1,0 +1,7 @@
+type MyType {
+  other: OtherType!
+}
+
+type OtherType {
+  name: String!
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithNonNullableListOfNullableValues/expected/DgsConstants.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithNonNullableListOfNullableValues/expected/DgsConstants.java
@@ -1,0 +1,21 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithNonNullableListOfNullableValues.expected;
+
+import java.lang.String;
+
+public class DgsConstants {
+  public static final String QUERY_TYPE = "Query";
+
+  public static class QUERY {
+    public static final String TYPE_NAME = "Query";
+
+    public static final String People = "people";
+  }
+
+  public static class PERSON {
+    public static final String TYPE_NAME = "Person";
+
+    public static final String Name = "name";
+
+    public static final String Email = "email";
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithNonNullableListOfNullableValues/expected/client/PeopleGraphQLQuery.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithNonNullableListOfNullableValues/expected/client/PeopleGraphQLQuery.java
@@ -1,0 +1,50 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithNonNullableListOfNullableValues.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.GraphQLQuery;
+import graphql.language.VariableDefinition;
+import java.lang.Override;
+import java.lang.String;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class PeopleGraphQLQuery extends GraphQLQuery {
+  public PeopleGraphQLQuery(String queryName) {
+    super("query", queryName);
+  }
+
+  public PeopleGraphQLQuery() {
+    super("query");
+  }
+
+  @Override
+  public String getOperationName() {
+    return "people";
+  }
+
+  public static Builder newRequest() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private Set<String> fieldsSet = new HashSet<>();
+
+    private final Map<String, String> variableReferences = new HashMap<>();
+
+    private final List<VariableDefinition> variableDefinitions = new ArrayList<>();
+
+    private String queryName;
+
+    public PeopleGraphQLQuery build() {
+      return new PeopleGraphQLQuery(queryName);                                     
+    }
+
+    public Builder queryName(String queryName) {
+      this.queryName = queryName;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithNonNullableListOfNullableValues/expected/client/PeopleProjectionRoot.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithNonNullableListOfNullableValues/expected/client/PeopleProjectionRoot.java
@@ -1,0 +1,24 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithNonNullableListOfNullableValues.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.BaseSubProjectionNode;
+
+public class PeopleProjectionRoot<PARENT extends BaseSubProjectionNode<?, ?>, ROOT extends BaseSubProjectionNode<?, ?>> extends BaseSubProjectionNode<PARENT, ROOT> {
+  public PeopleProjectionRoot() {
+    super(null, null, java.util.Optional.of("Person"));
+  }
+
+  public PeopleProjectionRoot<PARENT, ROOT> __typename() {
+    getFields().put("__typename", null);
+    return this;
+  }
+
+  public PeopleProjectionRoot<PARENT, ROOT> name() {
+    getFields().put("name", null);
+    return this;
+  }
+
+  public PeopleProjectionRoot<PARENT, ROOT> email() {
+    getFields().put("email", null);
+    return this;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithNonNullableListOfNullableValues/expected/datafetchers/PeopleDatafetcher.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithNonNullableListOfNullableValues/expected/datafetchers/PeopleDatafetcher.java
@@ -1,0 +1,18 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithNonNullableListOfNullableValues.expected.datafetchers;
+
+import com.netflix.graphql.dgs.DgsComponent;
+import com.netflix.graphql.dgs.DgsData;
+import com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithNonNullableListOfNullableValues.expected.types.Person;
+import graphql.schema.DataFetchingEnvironment;
+import java.util.List;
+
+@DgsComponent
+public class PeopleDatafetcher {
+  @DgsData(
+      parentType = "Query",
+      field = "people"
+  )
+  public List<Person> getPeople(DataFetchingEnvironment dataFetchingEnvironment) {
+    return null;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithNonNullableListOfNullableValues/expected/types/Person.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithNonNullableListOfNullableValues/expected/types/Person.java
@@ -1,0 +1,83 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithNonNullableListOfNullableValues.expected.types;
+
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.util.List;
+import java.util.Objects;
+
+public class Person {
+  private String name;
+
+  private List<String> email;
+
+  public Person() {
+  }
+
+  public Person(String name, List<String> email) {
+    this.name = name;
+    this.email = email;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public List<String> getEmail() {
+    return email;
+  }
+
+  public void setEmail(List<String> email) {
+    this.email = email;
+  }
+
+  @Override
+  public String toString() {
+    return "Person{name='" + name + "', email='" + email + "'}";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    Person that = (Person) o;
+    return Objects.equals(name, that.name) &&
+        Objects.equals(email, that.email);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, email);
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private String name;
+
+    private List<String> email;
+
+    public Person build() {
+      Person result = new Person();
+      result.name = this.name;
+      result.email = this.email;
+      return result;
+    }
+
+    public Builder name(String name) {
+      this.name = name;
+      return this;
+    }
+
+    public Builder email(List<String> email) {
+      this.email = email;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithNonNullableListOfNullableValues/schema.graphql
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithNonNullableListOfNullableValues/schema.graphql
@@ -1,0 +1,8 @@
+type Query {
+  people: [Person]
+}
+
+type Person {
+  name: String!
+  email: [String]!
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithNonNullablePrimitive/expected/DgsConstants.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithNonNullablePrimitive/expected/DgsConstants.java
@@ -1,0 +1,15 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithNonNullablePrimitive.expected;
+
+import java.lang.String;
+
+public class DgsConstants {
+  public static class MYTYPE {
+    public static final String TYPE_NAME = "MyType";
+
+    public static final String Count = "count";
+
+    public static final String Truth = "truth";
+
+    public static final String Floaty = "floaty";
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithNonNullablePrimitive/expected/types/MyType.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithNonNullablePrimitive/expected/types/MyType.java
@@ -1,0 +1,102 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithNonNullablePrimitive.expected.types;
+
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.util.Objects;
+
+public class MyType {
+  private int count;
+
+  private boolean truth;
+
+  private double floaty;
+
+  public MyType() {
+  }
+
+  public MyType(int count, boolean truth, double floaty) {
+    this.count = count;
+    this.truth = truth;
+    this.floaty = floaty;
+  }
+
+  public int getCount() {
+    return count;
+  }
+
+  public void setCount(int count) {
+    this.count = count;
+  }
+
+  public boolean getTruth() {
+    return truth;
+  }
+
+  public void setTruth(boolean truth) {
+    this.truth = truth;
+  }
+
+  public double getFloaty() {
+    return floaty;
+  }
+
+  public void setFloaty(double floaty) {
+    this.floaty = floaty;
+  }
+
+  @Override
+  public String toString() {
+    return "MyType{count='" + count + "', truth='" + truth + "', floaty='" + floaty + "'}";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    MyType that = (MyType) o;
+    return count == that.count &&
+        truth == that.truth &&
+        floaty == that.floaty;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(count, truth, floaty);
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private int count;
+
+    private boolean truth;
+
+    private double floaty;
+
+    public MyType build() {
+      MyType result = new MyType();
+      result.count = this.count;
+      result.truth = this.truth;
+      result.floaty = this.floaty;
+      return result;
+    }
+
+    public Builder count(int count) {
+      this.count = count;
+      return this;
+    }
+
+    public Builder truth(boolean truth) {
+      this.truth = truth;
+      return this;
+    }
+
+    public Builder floaty(double floaty) {
+      this.floaty = floaty;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithNonNullablePrimitive/schema.graphql
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithNonNullablePrimitive/schema.graphql
@@ -1,0 +1,5 @@
+type MyType {
+  count: Int!
+  truth: Boolean!
+  floaty: Float!
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithNonNullablePrimitiveInList/expected/DgsConstants.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithNonNullablePrimitiveInList/expected/DgsConstants.java
@@ -1,0 +1,15 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithNonNullablePrimitiveInList.expected;
+
+import java.lang.String;
+
+public class DgsConstants {
+  public static class MYTYPE {
+    public static final String TYPE_NAME = "MyType";
+
+    public static final String Count = "count";
+
+    public static final String Truth = "truth";
+
+    public static final String Floaty = "floaty";
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithNonNullablePrimitiveInList/expected/types/MyType.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithNonNullablePrimitiveInList/expected/types/MyType.java
@@ -1,0 +1,106 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithNonNullablePrimitiveInList.expected.types;
+
+import java.lang.Boolean;
+import java.lang.Double;
+import java.lang.Integer;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.util.List;
+import java.util.Objects;
+
+public class MyType {
+  private List<Integer> count;
+
+  private List<Boolean> truth;
+
+  private List<Double> floaty;
+
+  public MyType() {
+  }
+
+  public MyType(List<Integer> count, List<Boolean> truth, List<Double> floaty) {
+    this.count = count;
+    this.truth = truth;
+    this.floaty = floaty;
+  }
+
+  public List<Integer> getCount() {
+    return count;
+  }
+
+  public void setCount(List<Integer> count) {
+    this.count = count;
+  }
+
+  public List<Boolean> getTruth() {
+    return truth;
+  }
+
+  public void setTruth(List<Boolean> truth) {
+    this.truth = truth;
+  }
+
+  public List<Double> getFloaty() {
+    return floaty;
+  }
+
+  public void setFloaty(List<Double> floaty) {
+    this.floaty = floaty;
+  }
+
+  @Override
+  public String toString() {
+    return "MyType{count='" + count + "', truth='" + truth + "', floaty='" + floaty + "'}";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    MyType that = (MyType) o;
+    return Objects.equals(count, that.count) &&
+        Objects.equals(truth, that.truth) &&
+        Objects.equals(floaty, that.floaty);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(count, truth, floaty);
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private List<Integer> count;
+
+    private List<Boolean> truth;
+
+    private List<Double> floaty;
+
+    public MyType build() {
+      MyType result = new MyType();
+      result.count = this.count;
+      result.truth = this.truth;
+      result.floaty = this.floaty;
+      return result;
+    }
+
+    public Builder count(List<Integer> count) {
+      this.count = count;
+      return this;
+    }
+
+    public Builder truth(List<Boolean> truth) {
+      this.truth = truth;
+      return this;
+    }
+
+    public Builder floaty(List<Double> floaty) {
+      this.floaty = floaty;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithNonNullablePrimitiveInList/schema.graphql
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithNonNullablePrimitiveInList/schema.graphql
@@ -1,0 +1,5 @@
+type MyType {
+  count: [Int!]
+  truth: [Boolean!]
+  floaty: [Float!]
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithNonNullableProperties/expected/DgsConstants.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithNonNullableProperties/expected/DgsConstants.java
@@ -1,0 +1,21 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithNonNullableProperties.expected;
+
+import java.lang.String;
+
+public class DgsConstants {
+  public static final String QUERY_TYPE = "Query";
+
+  public static class QUERY {
+    public static final String TYPE_NAME = "Query";
+
+    public static final String People = "people";
+  }
+
+  public static class PERSON {
+    public static final String TYPE_NAME = "Person";
+
+    public static final String Name = "name";
+
+    public static final String Email = "email";
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithNonNullableProperties/expected/client/PeopleGraphQLQuery.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithNonNullableProperties/expected/client/PeopleGraphQLQuery.java
@@ -1,0 +1,50 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithNonNullableProperties.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.GraphQLQuery;
+import graphql.language.VariableDefinition;
+import java.lang.Override;
+import java.lang.String;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class PeopleGraphQLQuery extends GraphQLQuery {
+  public PeopleGraphQLQuery(String queryName) {
+    super("query", queryName);
+  }
+
+  public PeopleGraphQLQuery() {
+    super("query");
+  }
+
+  @Override
+  public String getOperationName() {
+    return "people";
+  }
+
+  public static Builder newRequest() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private Set<String> fieldsSet = new HashSet<>();
+
+    private final Map<String, String> variableReferences = new HashMap<>();
+
+    private final List<VariableDefinition> variableDefinitions = new ArrayList<>();
+
+    private String queryName;
+
+    public PeopleGraphQLQuery build() {
+      return new PeopleGraphQLQuery(queryName);                                     
+    }
+
+    public Builder queryName(String queryName) {
+      this.queryName = queryName;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithNonNullableProperties/expected/client/PeopleProjectionRoot.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithNonNullableProperties/expected/client/PeopleProjectionRoot.java
@@ -1,0 +1,24 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithNonNullableProperties.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.BaseSubProjectionNode;
+
+public class PeopleProjectionRoot<PARENT extends BaseSubProjectionNode<?, ?>, ROOT extends BaseSubProjectionNode<?, ?>> extends BaseSubProjectionNode<PARENT, ROOT> {
+  public PeopleProjectionRoot() {
+    super(null, null, java.util.Optional.of("Person"));
+  }
+
+  public PeopleProjectionRoot<PARENT, ROOT> __typename() {
+    getFields().put("__typename", null);
+    return this;
+  }
+
+  public PeopleProjectionRoot<PARENT, ROOT> name() {
+    getFields().put("name", null);
+    return this;
+  }
+
+  public PeopleProjectionRoot<PARENT, ROOT> email() {
+    getFields().put("email", null);
+    return this;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithNonNullableProperties/expected/datafetchers/PeopleDatafetcher.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithNonNullableProperties/expected/datafetchers/PeopleDatafetcher.java
@@ -1,0 +1,18 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithNonNullableProperties.expected.datafetchers;
+
+import com.netflix.graphql.dgs.DgsComponent;
+import com.netflix.graphql.dgs.DgsData;
+import com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithNonNullableProperties.expected.types.Person;
+import graphql.schema.DataFetchingEnvironment;
+import java.util.List;
+
+@DgsComponent
+public class PeopleDatafetcher {
+  @DgsData(
+      parentType = "Query",
+      field = "people"
+  )
+  public List<Person> getPeople(DataFetchingEnvironment dataFetchingEnvironment) {
+    return null;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithNonNullableProperties/expected/types/Person.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithNonNullableProperties/expected/types/Person.java
@@ -1,0 +1,83 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithNonNullableProperties.expected.types;
+
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.util.List;
+import java.util.Objects;
+
+public class Person {
+  private String name;
+
+  private List<String> email;
+
+  public Person() {
+  }
+
+  public Person(String name, List<String> email) {
+    this.name = name;
+    this.email = email;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public List<String> getEmail() {
+    return email;
+  }
+
+  public void setEmail(List<String> email) {
+    this.email = email;
+  }
+
+  @Override
+  public String toString() {
+    return "Person{name='" + name + "', email='" + email + "'}";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    Person that = (Person) o;
+    return Objects.equals(name, that.name) &&
+        Objects.equals(email, that.email);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, email);
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private String name;
+
+    private List<String> email;
+
+    public Person build() {
+      Person result = new Person();
+      result.name = this.name;
+      result.email = this.email;
+      return result;
+    }
+
+    public Builder name(String name) {
+      this.name = name;
+      return this;
+    }
+
+    public Builder email(List<String> email) {
+      this.email = email;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithNonNullableProperties/schema.graphql
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithNonNullableProperties/schema.graphql
@@ -1,0 +1,8 @@
+type Query {
+  people: [Person!]
+}
+
+type Person {
+  name: String!
+  email: [String!]!
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithNullablePrimitive/expected/DgsConstants.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithNullablePrimitive/expected/DgsConstants.java
@@ -1,0 +1,15 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithNullablePrimitive.expected;
+
+import java.lang.String;
+
+public class DgsConstants {
+  public static class MYTYPE {
+    public static final String TYPE_NAME = "MyType";
+
+    public static final String Count = "count";
+
+    public static final String Truth = "truth";
+
+    public static final String Floaty = "floaty";
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithNullablePrimitive/expected/types/MyType.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithNullablePrimitive/expected/types/MyType.java
@@ -1,0 +1,105 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithNullablePrimitive.expected.types;
+
+import java.lang.Boolean;
+import java.lang.Double;
+import java.lang.Integer;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.util.Objects;
+
+public class MyType {
+  private Integer count;
+
+  private Boolean truth;
+
+  private Double floaty;
+
+  public MyType() {
+  }
+
+  public MyType(Integer count, Boolean truth, Double floaty) {
+    this.count = count;
+    this.truth = truth;
+    this.floaty = floaty;
+  }
+
+  public Integer getCount() {
+    return count;
+  }
+
+  public void setCount(Integer count) {
+    this.count = count;
+  }
+
+  public Boolean getTruth() {
+    return truth;
+  }
+
+  public void setTruth(Boolean truth) {
+    this.truth = truth;
+  }
+
+  public Double getFloaty() {
+    return floaty;
+  }
+
+  public void setFloaty(Double floaty) {
+    this.floaty = floaty;
+  }
+
+  @Override
+  public String toString() {
+    return "MyType{count='" + count + "', truth='" + truth + "', floaty='" + floaty + "'}";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    MyType that = (MyType) o;
+    return Objects.equals(count, that.count) &&
+        Objects.equals(truth, that.truth) &&
+        Objects.equals(floaty, that.floaty);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(count, truth, floaty);
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private Integer count;
+
+    private Boolean truth;
+
+    private Double floaty;
+
+    public MyType build() {
+      MyType result = new MyType();
+      result.count = this.count;
+      result.truth = this.truth;
+      result.floaty = this.floaty;
+      return result;
+    }
+
+    public Builder count(Integer count) {
+      this.count = count;
+      return this;
+    }
+
+    public Builder truth(Boolean truth) {
+      this.truth = truth;
+      return this;
+    }
+
+    public Builder floaty(Double floaty) {
+      this.floaty = floaty;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithNullablePrimitive/schema.graphql
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithNullablePrimitive/schema.graphql
@@ -1,0 +1,5 @@
+type MyType {
+  count: Int
+  truth: Boolean
+  floaty: Float
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithRecursiveField/expected/DgsConstants.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithRecursiveField/expected/DgsConstants.java
@@ -1,0 +1,23 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithRecursiveField.expected;
+
+import java.lang.String;
+
+public class DgsConstants {
+  public static final String QUERY_TYPE = "Query";
+
+  public static class QUERY {
+    public static final String TYPE_NAME = "Query";
+
+    public static final String People = "people";
+  }
+
+  public static class PERSON {
+    public static final String TYPE_NAME = "Person";
+
+    public static final String Firstname = "firstname";
+
+    public static final String Lastname = "lastname";
+
+    public static final String Friends = "friends";
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithRecursiveField/expected/client/PeopleGraphQLQuery.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithRecursiveField/expected/client/PeopleGraphQLQuery.java
@@ -1,0 +1,50 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithRecursiveField.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.GraphQLQuery;
+import graphql.language.VariableDefinition;
+import java.lang.Override;
+import java.lang.String;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class PeopleGraphQLQuery extends GraphQLQuery {
+  public PeopleGraphQLQuery(String queryName) {
+    super("query", queryName);
+  }
+
+  public PeopleGraphQLQuery() {
+    super("query");
+  }
+
+  @Override
+  public String getOperationName() {
+    return "people";
+  }
+
+  public static Builder newRequest() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private Set<String> fieldsSet = new HashSet<>();
+
+    private final Map<String, String> variableReferences = new HashMap<>();
+
+    private final List<VariableDefinition> variableDefinitions = new ArrayList<>();
+
+    private String queryName;
+
+    public PeopleGraphQLQuery build() {
+      return new PeopleGraphQLQuery(queryName);                                     
+    }
+
+    public Builder queryName(String queryName) {
+      this.queryName = queryName;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithRecursiveField/expected/client/PeopleProjectionRoot.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithRecursiveField/expected/client/PeopleProjectionRoot.java
@@ -1,0 +1,31 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithRecursiveField.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.BaseSubProjectionNode;
+
+public class PeopleProjectionRoot<PARENT extends BaseSubProjectionNode<?, ?>, ROOT extends BaseSubProjectionNode<?, ?>> extends BaseSubProjectionNode<PARENT, ROOT> {
+  public PeopleProjectionRoot() {
+    super(null, null, java.util.Optional.of("Person"));
+  }
+
+  public PeopleProjectionRoot<PARENT, ROOT> __typename() {
+    getFields().put("__typename", null);
+    return this;
+  }
+
+  public PersonProjection<PeopleProjectionRoot<PARENT, ROOT>, PeopleProjectionRoot<PARENT, ROOT>> friends(
+      ) {
+    PersonProjection<PeopleProjectionRoot<PARENT, ROOT>, PeopleProjectionRoot<PARENT, ROOT>> projection = new PersonProjection<>(this, this);    
+    getFields().put("friends", projection);
+    return projection;
+  }
+
+  public PeopleProjectionRoot<PARENT, ROOT> firstname() {
+    getFields().put("firstname", null);
+    return this;
+  }
+
+  public PeopleProjectionRoot<PARENT, ROOT> lastname() {
+    getFields().put("lastname", null);
+    return this;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithRecursiveField/expected/client/PersonProjection.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithRecursiveField/expected/client/PersonProjection.java
@@ -1,0 +1,30 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithRecursiveField.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.BaseSubProjectionNode;
+
+public class PersonProjection<PARENT extends BaseSubProjectionNode<?, ?>, ROOT extends BaseSubProjectionNode<?, ?>> extends BaseSubProjectionNode<PARENT, ROOT> {
+  public PersonProjection(PARENT parent, ROOT root) {
+    super(parent, root, java.util.Optional.of("Person"));
+  }
+
+  public PersonProjection<PARENT, ROOT> __typename() {
+    getFields().put("__typename", null);
+    return this;
+  }
+
+  public PersonProjection<PersonProjection<PARENT, ROOT>, ROOT> friends() {
+     PersonProjection<PersonProjection<PARENT, ROOT>, ROOT> projection = new PersonProjection<>(this, getRoot());
+     getFields().put("friends", projection);
+     return projection;
+  }
+
+  public PersonProjection<PARENT, ROOT> firstname() {
+    getFields().put("firstname", null);
+    return this;
+  }
+
+  public PersonProjection<PARENT, ROOT> lastname() {
+    getFields().put("lastname", null);
+    return this;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithRecursiveField/expected/datafetchers/PeopleDatafetcher.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithRecursiveField/expected/datafetchers/PeopleDatafetcher.java
@@ -1,0 +1,18 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithRecursiveField.expected.datafetchers;
+
+import com.netflix.graphql.dgs.DgsComponent;
+import com.netflix.graphql.dgs.DgsData;
+import com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithRecursiveField.expected.types.Person;
+import graphql.schema.DataFetchingEnvironment;
+import java.util.List;
+
+@DgsComponent
+public class PeopleDatafetcher {
+  @DgsData(
+      parentType = "Query",
+      field = "people"
+  )
+  public List<Person> getPeople(DataFetchingEnvironment dataFetchingEnvironment) {
+    return null;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithRecursiveField/expected/types/Person.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithRecursiveField/expected/types/Person.java
@@ -1,0 +1,103 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithRecursiveField.expected.types;
+
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.util.List;
+import java.util.Objects;
+
+public class Person {
+  private String firstname;
+
+  private String lastname;
+
+  private List<Person> friends;
+
+  public Person() {
+  }
+
+  public Person(String firstname, String lastname, List<Person> friends) {
+    this.firstname = firstname;
+    this.lastname = lastname;
+    this.friends = friends;
+  }
+
+  public String getFirstname() {
+    return firstname;
+  }
+
+  public void setFirstname(String firstname) {
+    this.firstname = firstname;
+  }
+
+  public String getLastname() {
+    return lastname;
+  }
+
+  public void setLastname(String lastname) {
+    this.lastname = lastname;
+  }
+
+  public List<Person> getFriends() {
+    return friends;
+  }
+
+  public void setFriends(List<Person> friends) {
+    this.friends = friends;
+  }
+
+  @Override
+  public String toString() {
+    return "Person{firstname='" + firstname + "', lastname='" + lastname + "', friends='" + friends + "'}";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    Person that = (Person) o;
+    return Objects.equals(firstname, that.firstname) &&
+        Objects.equals(lastname, that.lastname) &&
+        Objects.equals(friends, that.friends);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(firstname, lastname, friends);
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private String firstname;
+
+    private String lastname;
+
+    private List<Person> friends;
+
+    public Person build() {
+      Person result = new Person();
+      result.firstname = this.firstname;
+      result.lastname = this.lastname;
+      result.friends = this.friends;
+      return result;
+    }
+
+    public Builder firstname(String firstname) {
+      this.firstname = firstname;
+      return this;
+    }
+
+    public Builder lastname(String lastname) {
+      this.lastname = lastname;
+      return this;
+    }
+
+    public Builder friends(List<Person> friends) {
+      this.friends = friends;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithRecursiveField/schema.graphql
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithRecursiveField/schema.graphql
@@ -1,0 +1,9 @@
+type Query {
+  people: [Person]
+}
+
+type Person {
+  firstname: String
+  lastname: String
+  friends: [Person]
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithReservedWord/expected/DgsConstants.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithReservedWord/expected/DgsConstants.java
@@ -1,0 +1,31 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithReservedWord.expected;
+
+import java.lang.String;
+
+public class DgsConstants {
+  public static final String QUERY_TYPE = "Query";
+
+  public static class SAMPLETYPE {
+    public static final String TYPE_NAME = "SampleType";
+
+    public static final String Return = "return";
+  }
+
+  public static class QUERY {
+    public static final String TYPE_NAME = "Query";
+
+    public static final String People = "people";
+  }
+
+  public static class PERSON {
+    public static final String TYPE_NAME = "Person";
+
+    public static final String Info = "info";
+
+    public static final String Interface = "interface";
+
+    public static class INFO_INPUT_ARGUMENT {
+      public static final String Package = "package";
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithReservedWord/expected/client/PeopleGraphQLQuery.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithReservedWord/expected/client/PeopleGraphQLQuery.java
@@ -1,0 +1,50 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithReservedWord.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.GraphQLQuery;
+import graphql.language.VariableDefinition;
+import java.lang.Override;
+import java.lang.String;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class PeopleGraphQLQuery extends GraphQLQuery {
+  public PeopleGraphQLQuery(String queryName) {
+    super("query", queryName);
+  }
+
+  public PeopleGraphQLQuery() {
+    super("query");
+  }
+
+  @Override
+  public String getOperationName() {
+    return "people";
+  }
+
+  public static Builder newRequest() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private Set<String> fieldsSet = new HashSet<>();
+
+    private final Map<String, String> variableReferences = new HashMap<>();
+
+    private final List<VariableDefinition> variableDefinitions = new ArrayList<>();
+
+    private String queryName;
+
+    public PeopleGraphQLQuery build() {
+      return new PeopleGraphQLQuery(queryName);                                     
+    }
+
+    public Builder queryName(String queryName) {
+      this.queryName = queryName;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithReservedWord/expected/client/PeopleProjectionRoot.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithReservedWord/expected/client/PeopleProjectionRoot.java
@@ -1,0 +1,46 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithReservedWord.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.BaseSubProjectionNode;
+import java.lang.String;
+import java.util.ArrayList;
+
+public class PeopleProjectionRoot<PARENT extends BaseSubProjectionNode<?, ?>, ROOT extends BaseSubProjectionNode<?, ?>> extends BaseSubProjectionNode<PARENT, ROOT> {
+  public PeopleProjectionRoot() {
+    super(null, null, java.util.Optional.of("Person"));
+  }
+
+  public PeopleProjectionRoot<PARENT, ROOT> __typename() {
+    getFields().put("__typename", null);
+    return this;
+  }
+
+  public StringProjection<PeopleProjectionRoot<PARENT, ROOT>, PeopleProjectionRoot<PARENT, ROOT>> info(
+      String _package) {
+    StringProjection<PeopleProjectionRoot<PARENT, ROOT>, PeopleProjectionRoot<PARENT, ROOT>> projection = new StringProjection<>(this, this);    
+    getFields().put("info", projection);
+    getInputArguments().computeIfAbsent("info", k -> new ArrayList<>());                      
+    InputArgument packageArg = new InputArgument("package", _package, false, null);
+    getInputArguments().get("info").add(packageArg);
+    return projection;
+  }
+
+  public StringProjection<PeopleProjectionRoot<PARENT, ROOT>, PeopleProjectionRoot<PARENT, ROOT>> infoWithVariableReferences(
+      String packageReference) {
+    StringProjection<PeopleProjectionRoot<PARENT, ROOT>, PeopleProjectionRoot<PARENT, ROOT>> projection = new StringProjection<>(this, this);    
+    getFields().put("info", projection);
+    getInputArguments().computeIfAbsent("info", k -> new ArrayList<>());              
+    InputArgument packageArg = new InputArgument("package", packageReference, true, new graphql.language.TypeName("String"));
+    getInputArguments().get("info").add(packageArg);
+    return projection;
+  }
+
+  public PeopleProjectionRoot<PARENT, ROOT> info() {
+    getFields().put("info", null);
+    return this;
+  }
+
+  public PeopleProjectionRoot<PARENT, ROOT> _interface() {
+    getFields().put("interface", null);
+    return this;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithReservedWord/expected/client/PeopleProjectionRoot.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithReservedWord/expected/client/PeopleProjectionRoot.java
@@ -19,18 +19,18 @@ public class PeopleProjectionRoot<PARENT extends BaseSubProjectionNode<?, ?>, RO
     StringProjection<PeopleProjectionRoot<PARENT, ROOT>, PeopleProjectionRoot<PARENT, ROOT>> projection = new StringProjection<>(this, this);    
     getFields().put("info", projection);
     getInputArguments().computeIfAbsent("info", k -> new ArrayList<>());                      
-    InputArgument packageArg = new InputArgument("package", _package, false, null);
-    getInputArguments().get("info").add(packageArg);
+    InputArgument _packageArg = new InputArgument("package", _package, false, null);
+    getInputArguments().get("info").add(_packageArg);
     return projection;
   }
 
   public StringProjection<PeopleProjectionRoot<PARENT, ROOT>, PeopleProjectionRoot<PARENT, ROOT>> infoWithVariableReferences(
-      String packageReference) {
+      String _packageReference) {
     StringProjection<PeopleProjectionRoot<PARENT, ROOT>, PeopleProjectionRoot<PARENT, ROOT>> projection = new StringProjection<>(this, this);    
     getFields().put("info", projection);
     getInputArguments().computeIfAbsent("info", k -> new ArrayList<>());              
-    InputArgument packageArg = new InputArgument("package", packageReference, true, new graphql.language.TypeName("String"));
-    getInputArguments().get("info").add(packageArg);
+    InputArgument _packageArg = new InputArgument("package", _packageReference, true, new graphql.language.TypeName("String"));
+    getInputArguments().get("info").add(_packageArg);
     return projection;
   }
 

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithReservedWord/expected/client/StringProjection.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithReservedWord/expected/client/StringProjection.java
@@ -1,0 +1,14 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithReservedWord.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.BaseSubProjectionNode;
+
+public class StringProjection<PARENT extends BaseSubProjectionNode<?, ?>, ROOT extends BaseSubProjectionNode<?, ?>> extends BaseSubProjectionNode<PARENT, ROOT> {
+  public StringProjection(PARENT parent, ROOT root) {
+    super(parent, root, java.util.Optional.of("String"));
+  }
+
+  public StringProjection<PARENT, ROOT> __typename() {
+    getFields().put("__typename", null);
+    return this;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithReservedWord/expected/datafetchers/PeopleDatafetcher.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithReservedWord/expected/datafetchers/PeopleDatafetcher.java
@@ -1,0 +1,18 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithReservedWord.expected.datafetchers;
+
+import com.netflix.graphql.dgs.DgsComponent;
+import com.netflix.graphql.dgs.DgsData;
+import com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithReservedWord.expected.types.Person;
+import graphql.schema.DataFetchingEnvironment;
+import java.util.List;
+
+@DgsComponent
+public class PeopleDatafetcher {
+  @DgsData(
+      parentType = "Query",
+      field = "people"
+  )
+  public List<Person> getPeople(DataFetchingEnvironment dataFetchingEnvironment) {
+    return null;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithReservedWord/expected/types/Person.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithReservedWord/expected/types/Person.java
@@ -1,0 +1,82 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithReservedWord.expected.types;
+
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.util.Objects;
+
+public class Person {
+  private String info;
+
+  private String _interface;
+
+  public Person() {
+  }
+
+  public Person(String info, String _interface) {
+    this.info = info;
+    this._interface = _interface;
+  }
+
+  public String getInfo() {
+    return info;
+  }
+
+  public void setInfo(String info) {
+    this.info = info;
+  }
+
+  public String getInterface() {
+    return _interface;
+  }
+
+  public void setInterface(String _interface) {
+    this._interface = _interface;
+  }
+
+  @Override
+  public String toString() {
+    return "Person{info='" + info + "', interface='" + _interface + "'}";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    Person that = (Person) o;
+    return Objects.equals(info, that.info) &&
+        Objects.equals(_interface, that._interface);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(info, _interface);
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private String info;
+
+    private String _interface;
+
+    public Person build() {
+      Person result = new Person();
+      result.info = this.info;
+      result._interface = this._interface;
+      return result;
+    }
+
+    public Builder info(String info) {
+      this.info = info;
+      return this;
+    }
+
+    public Builder _interface(String _interface) {
+      this._interface = _interface;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithReservedWord/expected/types/SampleType.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithReservedWord/expected/types/SampleType.java
@@ -1,0 +1,62 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithReservedWord.expected.types;
+
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.util.Objects;
+
+public class SampleType {
+  private String _return;
+
+  public SampleType() {
+  }
+
+  public SampleType(String _return) {
+    this._return = _return;
+  }
+
+  public String getReturn() {
+    return _return;
+  }
+
+  public void setReturn(String _return) {
+    this._return = _return;
+  }
+
+  @Override
+  public String toString() {
+    return "SampleType{return='" + _return + "'}";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    SampleType that = (SampleType) o;
+    return Objects.equals(_return, that._return);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_return);
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private String _return;
+
+    public SampleType build() {
+      SampleType result = new SampleType();
+      result._return = this._return;
+      return result;
+    }
+
+    public Builder _return(String _return) {
+      this._return = _return;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithReservedWord/schema.graphql
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithReservedWord/schema.graphql
@@ -1,0 +1,12 @@
+type SampleType {
+  return: String!
+}
+
+type Query {
+  people: [Person]
+}
+
+type Person {
+  info(package: String): String
+  interface: String
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithStringProperties/expected/DgsConstants.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithStringProperties/expected/DgsConstants.java
@@ -1,0 +1,21 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithStringProperties.expected;
+
+import java.lang.String;
+
+public class DgsConstants {
+  public static final String QUERY_TYPE = "Query";
+
+  public static class QUERY {
+    public static final String TYPE_NAME = "Query";
+
+    public static final String People = "people";
+  }
+
+  public static class PERSON {
+    public static final String TYPE_NAME = "Person";
+
+    public static final String Firstname = "firstname";
+
+    public static final String Lastname = "lastname";
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithStringProperties/expected/client/PeopleGraphQLQuery.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithStringProperties/expected/client/PeopleGraphQLQuery.java
@@ -1,0 +1,50 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithStringProperties.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.GraphQLQuery;
+import graphql.language.VariableDefinition;
+import java.lang.Override;
+import java.lang.String;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class PeopleGraphQLQuery extends GraphQLQuery {
+  public PeopleGraphQLQuery(String queryName) {
+    super("query", queryName);
+  }
+
+  public PeopleGraphQLQuery() {
+    super("query");
+  }
+
+  @Override
+  public String getOperationName() {
+    return "people";
+  }
+
+  public static Builder newRequest() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private Set<String> fieldsSet = new HashSet<>();
+
+    private final Map<String, String> variableReferences = new HashMap<>();
+
+    private final List<VariableDefinition> variableDefinitions = new ArrayList<>();
+
+    private String queryName;
+
+    public PeopleGraphQLQuery build() {
+      return new PeopleGraphQLQuery(queryName);                                     
+    }
+
+    public Builder queryName(String queryName) {
+      this.queryName = queryName;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithStringProperties/expected/client/PeopleProjectionRoot.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithStringProperties/expected/client/PeopleProjectionRoot.java
@@ -1,0 +1,24 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithStringProperties.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.BaseSubProjectionNode;
+
+public class PeopleProjectionRoot<PARENT extends BaseSubProjectionNode<?, ?>, ROOT extends BaseSubProjectionNode<?, ?>> extends BaseSubProjectionNode<PARENT, ROOT> {
+  public PeopleProjectionRoot() {
+    super(null, null, java.util.Optional.of("Person"));
+  }
+
+  public PeopleProjectionRoot<PARENT, ROOT> __typename() {
+    getFields().put("__typename", null);
+    return this;
+  }
+
+  public PeopleProjectionRoot<PARENT, ROOT> firstname() {
+    getFields().put("firstname", null);
+    return this;
+  }
+
+  public PeopleProjectionRoot<PARENT, ROOT> lastname() {
+    getFields().put("lastname", null);
+    return this;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithStringProperties/expected/datafetchers/PeopleDatafetcher.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithStringProperties/expected/datafetchers/PeopleDatafetcher.java
@@ -1,0 +1,18 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithStringProperties.expected.datafetchers;
+
+import com.netflix.graphql.dgs.DgsComponent;
+import com.netflix.graphql.dgs.DgsData;
+import com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithStringProperties.expected.types.Person;
+import graphql.schema.DataFetchingEnvironment;
+import java.util.List;
+
+@DgsComponent
+public class PeopleDatafetcher {
+  @DgsData(
+      parentType = "Query",
+      field = "people"
+  )
+  public List<Person> getPeople(DataFetchingEnvironment dataFetchingEnvironment) {
+    return null;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithStringProperties/expected/types/Person.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithStringProperties/expected/types/Person.java
@@ -1,0 +1,82 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithStringProperties.expected.types;
+
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.util.Objects;
+
+public class Person {
+  private String firstname;
+
+  private String lastname;
+
+  public Person() {
+  }
+
+  public Person(String firstname, String lastname) {
+    this.firstname = firstname;
+    this.lastname = lastname;
+  }
+
+  public String getFirstname() {
+    return firstname;
+  }
+
+  public void setFirstname(String firstname) {
+    this.firstname = firstname;
+  }
+
+  public String getLastname() {
+    return lastname;
+  }
+
+  public void setLastname(String lastname) {
+    this.lastname = lastname;
+  }
+
+  @Override
+  public String toString() {
+    return "Person{firstname='" + firstname + "', lastname='" + lastname + "'}";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    Person that = (Person) o;
+    return Objects.equals(firstname, that.firstname) &&
+        Objects.equals(lastname, that.lastname);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(firstname, lastname);
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private String firstname;
+
+    private String lastname;
+
+    public Person build() {
+      Person result = new Person();
+      result.firstname = this.firstname;
+      result.lastname = this.lastname;
+      return result;
+    }
+
+    public Builder firstname(String firstname) {
+      this.firstname = firstname;
+      return this;
+    }
+
+    public Builder lastname(String lastname) {
+      this.lastname = lastname;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithStringProperties/schema.graphql
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithStringProperties/schema.graphql
@@ -1,0 +1,8 @@
+type Query {
+  people: [Person]
+}
+
+type Person {
+  firstname: String
+  lastname: String
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithStringProperties/test/DataClassQueryTest.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/dataClassWithStringProperties/test/DataClassQueryTest.java
@@ -1,0 +1,52 @@
+/*
+ *
+ *  Copyright 2020 Netflix, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithStringProperties.test;
+
+import com.netflix.graphql.dgs.client.codegen.GraphQLQueryRequest;
+import com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithStringProperties.expected.client.PeopleGraphQLQuery;
+import com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithStringProperties.expected.client.PeopleProjectionRoot;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DataClassQueryTest {
+
+    @Test
+    void testQuery() {
+        var query = PeopleGraphQLQuery.newRequest()
+                .queryName("TestQuery")
+                .build();
+
+        var projection = new PeopleProjectionRoot<>()
+                .firstname()
+                .lastname();
+
+        var request = new GraphQLQueryRequest(query, projection);
+
+        assertThat(request.serialize())
+                .isEqualTo("""
+                        query TestQuery {
+                          people {
+                            firstname
+                            lastname
+                          }
+                        }""");
+    }
+
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/extendedDataClassWithInterface/expected/DgsConstants.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/extendedDataClassWithInterface/expected/DgsConstants.java
@@ -1,0 +1,25 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.extendedDataClassWithInterface.expected;
+
+import java.lang.String;
+
+public class DgsConstants {
+  public static class EXAMPLE {
+    public static final String TYPE_NAME = "Example";
+
+    public static final String Name = "name";
+
+    public static final String Age = "age";
+  }
+
+  public static class A {
+    public static final String TYPE_NAME = "A";
+
+    public static final String Name = "name";
+  }
+
+  public static class B {
+    public static final String TYPE_NAME = "B";
+
+    public static final String Age = "age";
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/extendedDataClassWithInterface/expected/types/A.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/extendedDataClassWithInterface/expected/types/A.java
@@ -1,0 +1,17 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.extendedDataClassWithInterface.expected.types;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import java.lang.String;
+
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NAME,
+    include = JsonTypeInfo.As.PROPERTY,
+    property = "__typename"
+)
+@JsonSubTypes(@JsonSubTypes.Type(value = Example.class, name = "Example"))
+public interface A {
+  String getName();
+
+  void setName(String name);
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/extendedDataClassWithInterface/expected/types/B.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/extendedDataClassWithInterface/expected/types/B.java
@@ -1,0 +1,17 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.extendedDataClassWithInterface.expected.types;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import java.lang.Integer;
+
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NAME,
+    include = JsonTypeInfo.As.PROPERTY,
+    property = "__typename"
+)
+@JsonSubTypes(@JsonSubTypes.Type(value = Example.class, name = "Example"))
+public interface B {
+  Integer getAge();
+
+  void setAge(Integer age);
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/extendedDataClassWithInterface/expected/types/Example.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/extendedDataClassWithInterface/expected/types/Example.java
@@ -1,0 +1,87 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.extendedDataClassWithInterface.expected.types;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import java.lang.Integer;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.util.Objects;
+
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NONE
+)
+public class Example implements com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.extendedDataClassWithInterface.expected.types.A, com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.extendedDataClassWithInterface.expected.types.B {
+  private String name;
+
+  private Integer age;
+
+  public Example() {
+  }
+
+  public Example(String name, Integer age) {
+    this.name = name;
+    this.age = age;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public Integer getAge() {
+    return age;
+  }
+
+  public void setAge(Integer age) {
+    this.age = age;
+  }
+
+  @Override
+  public String toString() {
+    return "Example{name='" + name + "', age='" + age + "'}";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    Example that = (Example) o;
+    return Objects.equals(name, that.name) &&
+        Objects.equals(age, that.age);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, age);
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private String name;
+
+    private Integer age;
+
+    public Example build() {
+      Example result = new Example();
+      result.name = this.name;
+      result.age = this.age;
+      return result;
+    }
+
+    public Builder name(String name) {
+      this.name = name;
+      return this;
+    }
+
+    public Builder age(Integer age) {
+      this.age = age;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/extendedDataClassWithInterface/schema.graphql
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/dataclasses/extendedDataClassWithInterface/schema.graphql
@@ -1,0 +1,11 @@
+interface A { name : String }
+
+type Example implements A {
+    name: String
+}
+
+interface B { age :Int }
+
+extend type Example implements B{
+    age :Int
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/enums/enumDocs/expected/DgsConstants.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/enums/enumDocs/expected/DgsConstants.java
@@ -1,0 +1,4 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.enums.enumDocs.expected;
+
+public class DgsConstants {
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/enums/enumDocs/expected/types/Color.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/enums/enumDocs/expected/types/Color.java
@@ -1,0 +1,12 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.enums.enumDocs.expected.types;
+
+/**
+ * Some options
+ */
+public enum Color {
+  red,
+
+  white,
+
+  blue
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/enums/enumDocs/schema.graphql
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/enums/enumDocs/schema.graphql
@@ -1,0 +1,6 @@
+"""
+Some options
+"""
+enum Color {
+  red,white,blue
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/enums/enumType/expected/DgsConstants.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/enums/enumType/expected/DgsConstants.java
@@ -1,0 +1,13 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.enums.enumType.expected;
+
+import java.lang.String;
+
+public class DgsConstants {
+  public static final String QUERY_TYPE = "Query";
+
+  public static class QUERY {
+    public static final String TYPE_NAME = "Query";
+
+    public static final String Types = "types";
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/enums/enumType/expected/client/TypesGraphQLQuery.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/enums/enumType/expected/client/TypesGraphQLQuery.java
@@ -1,0 +1,50 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.enums.enumType.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.GraphQLQuery;
+import graphql.language.VariableDefinition;
+import java.lang.Override;
+import java.lang.String;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class TypesGraphQLQuery extends GraphQLQuery {
+  public TypesGraphQLQuery(String queryName) {
+    super("query", queryName);
+  }
+
+  public TypesGraphQLQuery() {
+    super("query");
+  }
+
+  @Override
+  public String getOperationName() {
+    return "types";
+  }
+
+  public static Builder newRequest() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private Set<String> fieldsSet = new HashSet<>();
+
+    private final Map<String, String> variableReferences = new HashMap<>();
+
+    private final List<VariableDefinition> variableDefinitions = new ArrayList<>();
+
+    private String queryName;
+
+    public TypesGraphQLQuery build() {
+      return new TypesGraphQLQuery(queryName);                                     
+    }
+
+    public Builder queryName(String queryName) {
+      this.queryName = queryName;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/enums/enumType/expected/client/TypesProjectionRoot.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/enums/enumType/expected/client/TypesProjectionRoot.java
@@ -1,0 +1,14 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.enums.enumType.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.BaseSubProjectionNode;
+
+public class TypesProjectionRoot<PARENT extends BaseSubProjectionNode<?, ?>, ROOT extends BaseSubProjectionNode<?, ?>> extends BaseSubProjectionNode<PARENT, ROOT> {
+  public TypesProjectionRoot() {
+    super(null, null, java.util.Optional.of("EmployeeTypes"));
+  }
+
+  public TypesProjectionRoot<PARENT, ROOT> __typename() {
+    getFields().put("__typename", null);
+    return this;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/enums/enumType/expected/datafetchers/TypesDatafetcher.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/enums/enumType/expected/datafetchers/TypesDatafetcher.java
@@ -1,0 +1,18 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.enums.enumType.expected.datafetchers;
+
+import com.netflix.graphql.dgs.DgsComponent;
+import com.netflix.graphql.dgs.DgsData;
+import com.netflix.graphql.dgs.codegen.java.testcases.enums.enumType.expected.types.EmployeeTypes;
+import graphql.schema.DataFetchingEnvironment;
+import java.util.List;
+
+@DgsComponent
+public class TypesDatafetcher {
+  @DgsData(
+      parentType = "Query",
+      field = "types"
+  )
+  public List<EmployeeTypes> getTypes(DataFetchingEnvironment dataFetchingEnvironment) {
+    return null;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/enums/enumType/expected/types/EmployeeTypes.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/enums/enumType/expected/types/EmployeeTypes.java
@@ -1,0 +1,9 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.enums.enumType.expected.types;
+
+public enum EmployeeTypes {
+  ENGINEER,
+
+  MANAGER,
+
+  DIRECTOR
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/enums/enumType/schema.graphql
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/enums/enumType/schema.graphql
@@ -1,0 +1,9 @@
+type Query {
+  types: [EmployeeTypes]
+}
+
+enum EmployeeTypes {
+  ENGINEER
+  MANAGER
+  DIRECTOR
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/enums/enumWithExtendedType/expected/DgsConstants.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/enums/enumWithExtendedType/expected/DgsConstants.java
@@ -1,0 +1,13 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.enums.enumWithExtendedType.expected;
+
+import java.lang.String;
+
+public class DgsConstants {
+  public static final String QUERY_TYPE = "Query";
+
+  public static class QUERY {
+    public static final String TYPE_NAME = "Query";
+
+    public static final String Types = "types";
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/enums/enumWithExtendedType/expected/client/TypesGraphQLQuery.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/enums/enumWithExtendedType/expected/client/TypesGraphQLQuery.java
@@ -1,0 +1,50 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.enums.enumWithExtendedType.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.GraphQLQuery;
+import graphql.language.VariableDefinition;
+import java.lang.Override;
+import java.lang.String;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class TypesGraphQLQuery extends GraphQLQuery {
+  public TypesGraphQLQuery(String queryName) {
+    super("query", queryName);
+  }
+
+  public TypesGraphQLQuery() {
+    super("query");
+  }
+
+  @Override
+  public String getOperationName() {
+    return "types";
+  }
+
+  public static Builder newRequest() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private Set<String> fieldsSet = new HashSet<>();
+
+    private final Map<String, String> variableReferences = new HashMap<>();
+
+    private final List<VariableDefinition> variableDefinitions = new ArrayList<>();
+
+    private String queryName;
+
+    public TypesGraphQLQuery build() {
+      return new TypesGraphQLQuery(queryName);                                     
+    }
+
+    public Builder queryName(String queryName) {
+      this.queryName = queryName;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/enums/enumWithExtendedType/expected/client/TypesProjectionRoot.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/enums/enumWithExtendedType/expected/client/TypesProjectionRoot.java
@@ -1,0 +1,14 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.enums.enumWithExtendedType.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.BaseSubProjectionNode;
+
+public class TypesProjectionRoot<PARENT extends BaseSubProjectionNode<?, ?>, ROOT extends BaseSubProjectionNode<?, ?>> extends BaseSubProjectionNode<PARENT, ROOT> {
+  public TypesProjectionRoot() {
+    super(null, null, java.util.Optional.of("EmployeeTypes"));
+  }
+
+  public TypesProjectionRoot<PARENT, ROOT> __typename() {
+    getFields().put("__typename", null);
+    return this;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/enums/enumWithExtendedType/expected/datafetchers/TypesDatafetcher.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/enums/enumWithExtendedType/expected/datafetchers/TypesDatafetcher.java
@@ -1,0 +1,18 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.enums.enumWithExtendedType.expected.datafetchers;
+
+import com.netflix.graphql.dgs.DgsComponent;
+import com.netflix.graphql.dgs.DgsData;
+import com.netflix.graphql.dgs.codegen.java.testcases.enums.enumWithExtendedType.expected.types.EmployeeTypes;
+import graphql.schema.DataFetchingEnvironment;
+import java.util.List;
+
+@DgsComponent
+public class TypesDatafetcher {
+  @DgsData(
+      parentType = "Query",
+      field = "types"
+  )
+  public List<EmployeeTypes> getTypes(DataFetchingEnvironment dataFetchingEnvironment) {
+    return null;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/enums/enumWithExtendedType/expected/types/EmployeeTypes.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/enums/enumWithExtendedType/expected/types/EmployeeTypes.java
@@ -1,0 +1,11 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.enums.enumWithExtendedType.expected.types;
+
+public enum EmployeeTypes {
+  ENGINEER,
+
+  MANAGER,
+
+  DIRECTOR,
+
+  QA
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/enums/enumWithExtendedType/schema.graphql
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/enums/enumWithExtendedType/schema.graphql
@@ -1,0 +1,13 @@
+type Query {
+  types: [EmployeeTypes]
+}
+
+enum EmployeeTypes {
+  ENGINEER
+  MANAGER
+  DIRECTOR
+}
+
+extend enum EmployeeTypes {
+  QA
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/input/expected/DgsConstants.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/input/expected/DgsConstants.java
@@ -1,0 +1,23 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.inputs.input.expected;
+
+import java.lang.String;
+
+public class DgsConstants {
+  public static final String QUERY_TYPE = "Query";
+
+  public static class QUERY {
+    public static final String TYPE_NAME = "Query";
+
+    public static final String Movies = "movies";
+
+    public static class MOVIES_INPUT_ARGUMENT {
+      public static final String Filter = "filter";
+    }
+  }
+
+  public static class MOVIEFILTER {
+    public static final String TYPE_NAME = "MovieFilter";
+
+    public static final String Genre = "genre";
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/input/expected/client/MoviesGraphQLQuery.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/input/expected/client/MoviesGraphQLQuery.java
@@ -1,0 +1,85 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.inputs.input.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.GraphQLQuery;
+import com.netflix.graphql.dgs.codegen.java.testcases.inputs.input.expected.types.MovieFilter;
+import graphql.language.VariableDefinition;
+import java.lang.Override;
+import java.lang.String;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class MoviesGraphQLQuery extends GraphQLQuery {
+  public MoviesGraphQLQuery(MovieFilter filter, String queryName, Set<String> fieldsSet) {
+    super("query", queryName);
+    if (filter != null || fieldsSet.contains("filter")) {
+        getInput().put("filter", filter);
+    }
+  }
+
+  public MoviesGraphQLQuery(MovieFilter filter, String queryName, Set<String> fieldsSet,
+      Map<String, String> variableReferences, List<VariableDefinition> variableDefinitions) {
+    super("query", queryName);
+    if (filter != null || fieldsSet.contains("filter")) {
+        getInput().put("filter", filter);
+    }
+    if(variableDefinitions != null) {
+       getVariableDefinitions().addAll(variableDefinitions);
+    }
+
+    if(variableReferences != null) {
+       getVariableReferences().putAll(variableReferences);
+    }                      
+  }
+
+  public MoviesGraphQLQuery() {
+    super("query");
+  }
+
+  @Override
+  public String getOperationName() {
+    return "movies";
+  }
+
+  public static Builder newRequest() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private Set<String> fieldsSet = new HashSet<>();
+
+    private final Map<String, String> variableReferences = new HashMap<>();
+
+    private final List<VariableDefinition> variableDefinitions = new ArrayList<>();
+
+    private MovieFilter filter;
+
+    private String queryName;
+
+    public MoviesGraphQLQuery build() {
+      return new MoviesGraphQLQuery(filter, queryName, fieldsSet, variableReferences, variableDefinitions);
+               
+    }
+
+    public Builder filter(MovieFilter filter) {
+      this.filter = filter;
+      this.fieldsSet.add("filter");
+      return this;
+    }
+
+    public Builder filterReference(String variableRef) {
+      this.variableReferences.put("filter", variableRef);
+      this.variableDefinitions.add(graphql.language.VariableDefinition.newVariableDefinition(variableRef, new graphql.language.TypeName("MovieFilter")).build());
+      this.fieldsSet.add("filter");
+      return this;
+    }
+
+    public Builder queryName(String queryName) {
+      this.queryName = queryName;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/input/expected/datafetchers/MoviesDatafetcher.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/input/expected/datafetchers/MoviesDatafetcher.java
@@ -1,0 +1,18 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.inputs.input.expected.datafetchers;
+
+import com.netflix.graphql.dgs.DgsComponent;
+import com.netflix.graphql.dgs.DgsData;
+import graphql.schema.DataFetchingEnvironment;
+import java.lang.String;
+import java.util.List;
+
+@DgsComponent
+public class MoviesDatafetcher {
+  @DgsData(
+      parentType = "Query",
+      field = "movies"
+  )
+  public List<String> getMovies(DataFetchingEnvironment dataFetchingEnvironment) {
+    return null;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/input/expected/types/MovieFilter.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/input/expected/types/MovieFilter.java
@@ -1,0 +1,62 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.inputs.input.expected.types;
+
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.util.Objects;
+
+public class MovieFilter {
+  private String genre;
+
+  public MovieFilter() {
+  }
+
+  public MovieFilter(String genre) {
+    this.genre = genre;
+  }
+
+  public String getGenre() {
+    return genre;
+  }
+
+  public void setGenre(String genre) {
+    this.genre = genre;
+  }
+
+  @Override
+  public String toString() {
+    return "MovieFilter{genre='" + genre + "'}";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    MovieFilter that = (MovieFilter) o;
+    return Objects.equals(genre, that.genre);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(genre);
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private String genre;
+
+    public MovieFilter build() {
+      MovieFilter result = new MovieFilter();
+      result.genre = this.genre;
+      return result;
+    }
+
+    public Builder genre(String genre) {
+      this.genre = genre;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/input/schema.graphql
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/input/schema.graphql
@@ -1,0 +1,7 @@
+type Query {
+  movies(filter: MovieFilter): [String]
+}
+
+input MovieFilter {
+  genre: String
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/input/test/InputQueryTest.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/input/test/InputQueryTest.java
@@ -1,0 +1,97 @@
+/*
+ *
+ *  Copyright 2020 Netflix, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package com.netflix.graphql.dgs.codegen.java.testcases.inputs.input.test;
+
+import com.netflix.graphql.dgs.client.codegen.GraphQLQueryRequest;
+import com.netflix.graphql.dgs.codegen.java.testcases.inputs.input.expected.client.MoviesGraphQLQuery;
+import com.netflix.graphql.dgs.codegen.java.testcases.inputs.input.expected.types.MovieFilter;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class InputQueryTest {
+
+    @Test
+    void testQueryWithNoFilter() {
+        var query = MoviesGraphQLQuery.newRequest()
+                .queryName("TestQuery")
+                .build();
+
+        var request = new GraphQLQueryRequest(query);
+
+        assertThat(request.serialize())
+                .isEqualTo("""
+                        query TestQuery {
+                          movies
+                        }""");
+    }
+
+    @Test
+    void testQueryWithEmptyFilter() {
+        var query = MoviesGraphQLQuery.newRequest()
+                .queryName("TestQuery")
+                .filter(new MovieFilter())
+                .build();
+
+        var request = new GraphQLQueryRequest(query);
+
+        assertThat(request.serialize())
+                .isEqualTo("""
+                        query TestQuery {
+                          movies(filter: {})
+                        }""");
+    }
+
+    @Test
+    void testQueryWithFilter() {
+        var query = MoviesGraphQLQuery.newRequest()
+                .queryName("TestQuery")
+                .filter(MovieFilter.newBuilder()
+                        .genre("horror")
+                        .build())
+                .build();
+
+        var request = new GraphQLQueryRequest(query);
+
+        assertThat(request.serialize())
+                .isEqualTo("""
+                        query TestQuery {
+                          movies(filter: {genre : "horror"})
+                        }""");
+    }
+
+    @Test
+    void testQueryWithNewline() {
+        var query = MoviesGraphQLQuery.newRequest()
+                .queryName("TestQuery")
+                .filter(MovieFilter.newBuilder()
+                        .genre("horror\ncomedy")
+                        .build())
+                .build();
+
+        var request = new GraphQLQueryRequest(query);
+
+        assertThat(request.serialize())
+                .isEqualTo("""
+                        query TestQuery {
+                          movies(filter: {genre : "horror\\ncomedy"})
+                        }""");
+    }
+
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/inputWithDefaultBigDecimal/expected/DgsConstants.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/inputWithDefaultBigDecimal/expected/DgsConstants.java
@@ -1,0 +1,27 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.inputs.inputWithDefaultBigDecimal.expected;
+
+import java.lang.String;
+
+public class DgsConstants {
+  public static final String QUERY_TYPE = "Query";
+
+  public static class QUERY {
+    public static final String TYPE_NAME = "Query";
+
+    public static final String Orders = "orders";
+
+    public static class ORDERS_INPUT_ARGUMENT {
+      public static final String Filter = "filter";
+    }
+  }
+
+  public static class ORDERFILTER {
+    public static final String TYPE_NAME = "OrderFilter";
+
+    public static final String Min = "min";
+
+    public static final String Avg = "avg";
+
+    public static final String Max = "max";
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/inputWithDefaultBigDecimal/expected/client/OrdersGraphQLQuery.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/inputWithDefaultBigDecimal/expected/client/OrdersGraphQLQuery.java
@@ -1,0 +1,85 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.inputs.inputWithDefaultBigDecimal.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.GraphQLQuery;
+import com.netflix.graphql.dgs.codegen.java.testcases.inputs.inputWithDefaultBigDecimal.expected.types.OrderFilter;
+import graphql.language.VariableDefinition;
+import java.lang.Override;
+import java.lang.String;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class OrdersGraphQLQuery extends GraphQLQuery {
+  public OrdersGraphQLQuery(OrderFilter filter, String queryName, Set<String> fieldsSet) {
+    super("query", queryName);
+    if (filter != null || fieldsSet.contains("filter")) {
+        getInput().put("filter", filter);
+    }
+  }
+
+  public OrdersGraphQLQuery(OrderFilter filter, String queryName, Set<String> fieldsSet,
+      Map<String, String> variableReferences, List<VariableDefinition> variableDefinitions) {
+    super("query", queryName);
+    if (filter != null || fieldsSet.contains("filter")) {
+        getInput().put("filter", filter);
+    }
+    if(variableDefinitions != null) {
+       getVariableDefinitions().addAll(variableDefinitions);
+    }
+
+    if(variableReferences != null) {
+       getVariableReferences().putAll(variableReferences);
+    }                      
+  }
+
+  public OrdersGraphQLQuery() {
+    super("query");
+  }
+
+  @Override
+  public String getOperationName() {
+    return "orders";
+  }
+
+  public static Builder newRequest() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private Set<String> fieldsSet = new HashSet<>();
+
+    private final Map<String, String> variableReferences = new HashMap<>();
+
+    private final List<VariableDefinition> variableDefinitions = new ArrayList<>();
+
+    private OrderFilter filter;
+
+    private String queryName;
+
+    public OrdersGraphQLQuery build() {
+      return new OrdersGraphQLQuery(filter, queryName, fieldsSet, variableReferences, variableDefinitions);
+               
+    }
+
+    public Builder filter(OrderFilter filter) {
+      this.filter = filter;
+      this.fieldsSet.add("filter");
+      return this;
+    }
+
+    public Builder filterReference(String variableRef) {
+      this.variableReferences.put("filter", variableRef);
+      this.variableDefinitions.add(graphql.language.VariableDefinition.newVariableDefinition(variableRef, new graphql.language.TypeName("OrderFilter")).build());
+      this.fieldsSet.add("filter");
+      return this;
+    }
+
+    public Builder queryName(String queryName) {
+      this.queryName = queryName;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/inputWithDefaultBigDecimal/expected/datafetchers/OrdersDatafetcher.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/inputWithDefaultBigDecimal/expected/datafetchers/OrdersDatafetcher.java
@@ -1,0 +1,17 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.inputs.inputWithDefaultBigDecimal.expected.datafetchers;
+
+import com.netflix.graphql.dgs.DgsComponent;
+import com.netflix.graphql.dgs.DgsData;
+import graphql.schema.DataFetchingEnvironment;
+import java.lang.String;
+
+@DgsComponent
+public class OrdersDatafetcher {
+  @DgsData(
+      parentType = "Query",
+      field = "orders"
+  )
+  public String getOrders(DataFetchingEnvironment dataFetchingEnvironment) {
+    return "";
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/inputWithDefaultBigDecimal/expected/types/OrderFilter.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/inputWithDefaultBigDecimal/expected/types/OrderFilter.java
@@ -1,0 +1,103 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.inputs.inputWithDefaultBigDecimal.expected.types;
+
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.math.BigDecimal;
+import java.util.Objects;
+
+public class OrderFilter {
+  private BigDecimal min = new BigDecimal("1.1");
+
+  private BigDecimal avg = new BigDecimal(1.12);
+
+  private BigDecimal max = new BigDecimal(3.14E+19);
+
+  public OrderFilter() {
+  }
+
+  public OrderFilter(BigDecimal min, BigDecimal avg, BigDecimal max) {
+    this.min = min;
+    this.avg = avg;
+    this.max = max;
+  }
+
+  public BigDecimal getMin() {
+    return min;
+  }
+
+  public void setMin(BigDecimal min) {
+    this.min = min;
+  }
+
+  public BigDecimal getAvg() {
+    return avg;
+  }
+
+  public void setAvg(BigDecimal avg) {
+    this.avg = avg;
+  }
+
+  public BigDecimal getMax() {
+    return max;
+  }
+
+  public void setMax(BigDecimal max) {
+    this.max = max;
+  }
+
+  @Override
+  public String toString() {
+    return "OrderFilter{min='" + min + "', avg='" + avg + "', max='" + max + "'}";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    OrderFilter that = (OrderFilter) o;
+    return Objects.equals(min, that.min) &&
+        Objects.equals(avg, that.avg) &&
+        Objects.equals(max, that.max);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(min, avg, max);
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private BigDecimal min = new BigDecimal("1.1");
+
+    private BigDecimal avg = new BigDecimal(1.12);
+
+    private BigDecimal max = new BigDecimal(3.14E+19);
+
+    public OrderFilter build() {
+      OrderFilter result = new OrderFilter();
+      result.min = this.min;
+      result.avg = this.avg;
+      result.max = this.max;
+      return result;
+    }
+
+    public Builder min(BigDecimal min) {
+      this.min = min;
+      return this;
+    }
+
+    public Builder avg(BigDecimal avg) {
+      this.avg = avg;
+      return this;
+    }
+
+    public Builder max(BigDecimal max) {
+      this.max = max;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/inputWithDefaultBigDecimal/schema.graphql
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/inputWithDefaultBigDecimal/schema.graphql
@@ -1,0 +1,11 @@
+scalar Decimal
+
+type Query {
+  orders(filter: OrderFilter): String
+}
+
+input OrderFilter {
+  min: Decimal! = "1.1"
+  avg: Decimal! = 1.12
+  max: Decimal! = 3.14e19
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/inputWithDefaultCurrency/expected/DgsConstants.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/inputWithDefaultCurrency/expected/DgsConstants.java
@@ -1,0 +1,23 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.inputs.inputWithDefaultCurrency.expected;
+
+import java.lang.String;
+
+public class DgsConstants {
+  public static final String QUERY_TYPE = "Query";
+
+  public static class QUERY {
+    public static final String TYPE_NAME = "Query";
+
+    public static final String Orders = "orders";
+
+    public static class ORDERS_INPUT_ARGUMENT {
+      public static final String Filter = "filter";
+    }
+  }
+
+  public static class ORDERFILTER {
+    public static final String TYPE_NAME = "OrderFilter";
+
+    public static final String Value = "value";
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/inputWithDefaultCurrency/expected/client/OrdersGraphQLQuery.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/inputWithDefaultCurrency/expected/client/OrdersGraphQLQuery.java
@@ -1,0 +1,85 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.inputs.inputWithDefaultCurrency.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.GraphQLQuery;
+import com.netflix.graphql.dgs.codegen.java.testcases.inputs.inputWithDefaultCurrency.expected.types.OrderFilter;
+import graphql.language.VariableDefinition;
+import java.lang.Override;
+import java.lang.String;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class OrdersGraphQLQuery extends GraphQLQuery {
+  public OrdersGraphQLQuery(OrderFilter filter, String queryName, Set<String> fieldsSet) {
+    super("query", queryName);
+    if (filter != null || fieldsSet.contains("filter")) {
+        getInput().put("filter", filter);
+    }
+  }
+
+  public OrdersGraphQLQuery(OrderFilter filter, String queryName, Set<String> fieldsSet,
+      Map<String, String> variableReferences, List<VariableDefinition> variableDefinitions) {
+    super("query", queryName);
+    if (filter != null || fieldsSet.contains("filter")) {
+        getInput().put("filter", filter);
+    }
+    if(variableDefinitions != null) {
+       getVariableDefinitions().addAll(variableDefinitions);
+    }
+
+    if(variableReferences != null) {
+       getVariableReferences().putAll(variableReferences);
+    }                      
+  }
+
+  public OrdersGraphQLQuery() {
+    super("query");
+  }
+
+  @Override
+  public String getOperationName() {
+    return "orders";
+  }
+
+  public static Builder newRequest() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private Set<String> fieldsSet = new HashSet<>();
+
+    private final Map<String, String> variableReferences = new HashMap<>();
+
+    private final List<VariableDefinition> variableDefinitions = new ArrayList<>();
+
+    private OrderFilter filter;
+
+    private String queryName;
+
+    public OrdersGraphQLQuery build() {
+      return new OrdersGraphQLQuery(filter, queryName, fieldsSet, variableReferences, variableDefinitions);
+               
+    }
+
+    public Builder filter(OrderFilter filter) {
+      this.filter = filter;
+      this.fieldsSet.add("filter");
+      return this;
+    }
+
+    public Builder filterReference(String variableRef) {
+      this.variableReferences.put("filter", variableRef);
+      this.variableDefinitions.add(graphql.language.VariableDefinition.newVariableDefinition(variableRef, new graphql.language.TypeName("OrderFilter")).build());
+      this.fieldsSet.add("filter");
+      return this;
+    }
+
+    public Builder queryName(String queryName) {
+      this.queryName = queryName;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/inputWithDefaultCurrency/expected/datafetchers/OrdersDatafetcher.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/inputWithDefaultCurrency/expected/datafetchers/OrdersDatafetcher.java
@@ -1,0 +1,17 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.inputs.inputWithDefaultCurrency.expected.datafetchers;
+
+import com.netflix.graphql.dgs.DgsComponent;
+import com.netflix.graphql.dgs.DgsData;
+import graphql.schema.DataFetchingEnvironment;
+import java.lang.String;
+
+@DgsComponent
+public class OrdersDatafetcher {
+  @DgsData(
+      parentType = "Query",
+      field = "orders"
+  )
+  public String getOrders(DataFetchingEnvironment dataFetchingEnvironment) {
+    return "";
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/inputWithDefaultCurrency/expected/types/OrderFilter.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/inputWithDefaultCurrency/expected/types/OrderFilter.java
@@ -1,0 +1,63 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.inputs.inputWithDefaultCurrency.expected.types;
+
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.util.Currency;
+import java.util.Objects;
+
+public class OrderFilter {
+  private Currency value = Currency.getInstance("USD");
+
+  public OrderFilter() {
+  }
+
+  public OrderFilter(Currency value) {
+    this.value = value;
+  }
+
+  public Currency getValue() {
+    return value;
+  }
+
+  public void setValue(Currency value) {
+    this.value = value;
+  }
+
+  @Override
+  public String toString() {
+    return "OrderFilter{value='" + value + "'}";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    OrderFilter that = (OrderFilter) o;
+    return Objects.equals(value, that.value);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(value);
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private Currency value = Currency.getInstance("USD");
+
+    public OrderFilter build() {
+      OrderFilter result = new OrderFilter();
+      result.value = this.value;
+      return result;
+    }
+
+    public Builder value(Currency value) {
+      this.value = value;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/inputWithDefaultCurrency/schema.graphql
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/inputWithDefaultCurrency/schema.graphql
@@ -1,0 +1,9 @@
+scalar Currency
+
+type Query {
+  orders(filter: OrderFilter): String
+}
+
+input OrderFilter {
+  value: Currency! = "USD"
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/inputWithDefaultEnumValueForArray/expected/DgsConstants.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/inputWithDefaultEnumValueForArray/expected/DgsConstants.java
@@ -1,0 +1,11 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.inputs.inputWithDefaultEnumValueForArray.expected;
+
+import java.lang.String;
+
+public class DgsConstants {
+  public static class SOMETYPE {
+    public static final String TYPE_NAME = "SomeType";
+
+    public static final String Colors = "colors";
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/inputWithDefaultEnumValueForArray/expected/types/Color.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/inputWithDefaultEnumValueForArray/expected/types/Color.java
@@ -1,0 +1,7 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.inputs.inputWithDefaultEnumValueForArray.expected.types;
+
+public enum Color {
+  red,
+
+  blue
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/inputWithDefaultEnumValueForArray/expected/types/SomeType.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/inputWithDefaultEnumValueForArray/expected/types/SomeType.java
@@ -1,0 +1,64 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.inputs.inputWithDefaultEnumValueForArray.expected.types;
+
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+public class SomeType {
+  private List<Color> colors = Arrays.asList(Color.red);
+
+  public SomeType() {
+  }
+
+  public SomeType(List<Color> colors) {
+    this.colors = colors;
+  }
+
+  public List<Color> getColors() {
+    return colors;
+  }
+
+  public void setColors(List<Color> colors) {
+    this.colors = colors;
+  }
+
+  @Override
+  public String toString() {
+    return "SomeType{colors='" + colors + "'}";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    SomeType that = (SomeType) o;
+    return Objects.equals(colors, that.colors);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(colors);
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private List<Color> colors = Arrays.asList(Color.red);
+
+    public SomeType build() {
+      SomeType result = new SomeType();
+      result.colors = this.colors;
+      return result;
+    }
+
+    public Builder colors(List<Color> colors) {
+      this.colors = colors;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/inputWithDefaultEnumValueForArray/schema.graphql
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/inputWithDefaultEnumValueForArray/schema.graphql
@@ -1,0 +1,8 @@
+input SomeType {
+  colors: [Color] = [red]
+}
+
+enum Color {
+  red,
+  blue
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/inputWithDefaultIntValueForArray/expected/DgsConstants.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/inputWithDefaultIntValueForArray/expected/DgsConstants.java
@@ -1,0 +1,11 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.inputs.inputWithDefaultIntValueForArray.expected;
+
+import java.lang.String;
+
+public class DgsConstants {
+  public static class SOMETYPE {
+    public static final String TYPE_NAME = "SomeType";
+
+    public static final String Numbers = "numbers";
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/inputWithDefaultIntValueForArray/expected/types/SomeType.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/inputWithDefaultIntValueForArray/expected/types/SomeType.java
@@ -1,0 +1,65 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.inputs.inputWithDefaultIntValueForArray.expected.types;
+
+import java.lang.Integer;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+public class SomeType {
+  private List<Integer> numbers = Arrays.asList(1, 2, 3);
+
+  public SomeType() {
+  }
+
+  public SomeType(List<Integer> numbers) {
+    this.numbers = numbers;
+  }
+
+  public List<Integer> getNumbers() {
+    return numbers;
+  }
+
+  public void setNumbers(List<Integer> numbers) {
+    this.numbers = numbers;
+  }
+
+  @Override
+  public String toString() {
+    return "SomeType{numbers='" + numbers + "'}";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    SomeType that = (SomeType) o;
+    return Objects.equals(numbers, that.numbers);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(numbers);
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private List<Integer> numbers = Arrays.asList(1, 2, 3);
+
+    public SomeType build() {
+      SomeType result = new SomeType();
+      result.numbers = this.numbers;
+      return result;
+    }
+
+    public Builder numbers(List<Integer> numbers) {
+      this.numbers = numbers;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/inputWithDefaultIntValueForArray/schema.graphql
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/inputWithDefaultIntValueForArray/schema.graphql
@@ -1,0 +1,3 @@
+input SomeType {
+  numbers: [Int] = [1, 2, 3]
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/inputWithDefaultStringValueForArray/expected/DgsConstants.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/inputWithDefaultStringValueForArray/expected/DgsConstants.java
@@ -1,0 +1,11 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.inputs.inputWithDefaultStringValueForArray.expected;
+
+import java.lang.String;
+
+public class DgsConstants {
+  public static class SOMETYPE {
+    public static final String TYPE_NAME = "SomeType";
+
+    public static final String Names = "names";
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/inputWithDefaultStringValueForArray/expected/types/SomeType.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/inputWithDefaultStringValueForArray/expected/types/SomeType.java
@@ -1,0 +1,64 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.inputs.inputWithDefaultStringValueForArray.expected.types;
+
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+public class SomeType {
+  private List<String> names = Arrays.asList("A", "B");
+
+  public SomeType() {
+  }
+
+  public SomeType(List<String> names) {
+    this.names = names;
+  }
+
+  public List<String> getNames() {
+    return names;
+  }
+
+  public void setNames(List<String> names) {
+    this.names = names;
+  }
+
+  @Override
+  public String toString() {
+    return "SomeType{names='" + names + "'}";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    SomeType that = (SomeType) o;
+    return Objects.equals(names, that.names);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(names);
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private List<String> names = Arrays.asList("A", "B");
+
+    public SomeType build() {
+      SomeType result = new SomeType();
+      result.names = this.names;
+      return result;
+    }
+
+    public Builder names(List<String> names) {
+      this.names = names;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/inputWithDefaultStringValueForArray/schema.graphql
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/inputWithDefaultStringValueForArray/schema.graphql
@@ -1,0 +1,3 @@
+input SomeType {
+  names: [String] = ["A", "B"]
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/inputWithDefaultValueForArray/expected/DgsConstants.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/inputWithDefaultValueForArray/expected/DgsConstants.java
@@ -1,0 +1,11 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.inputs.inputWithDefaultValueForArray.expected;
+
+import java.lang.String;
+
+public class DgsConstants {
+  public static class SOMETYPE {
+    public static final String TYPE_NAME = "SomeType";
+
+    public static final String Names = "names";
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/inputWithDefaultValueForArray/expected/types/SomeType.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/inputWithDefaultValueForArray/expected/types/SomeType.java
@@ -1,0 +1,64 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.inputs.inputWithDefaultValueForArray.expected.types;
+
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+public class SomeType {
+  private List<String> names = Collections.emptyList();
+
+  public SomeType() {
+  }
+
+  public SomeType(List<String> names) {
+    this.names = names;
+  }
+
+  public List<String> getNames() {
+    return names;
+  }
+
+  public void setNames(List<String> names) {
+    this.names = names;
+  }
+
+  @Override
+  public String toString() {
+    return "SomeType{names='" + names + "'}";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    SomeType that = (SomeType) o;
+    return Objects.equals(names, that.names);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(names);
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private List<String> names = Collections.emptyList();
+
+    public SomeType build() {
+      SomeType result = new SomeType();
+      result.names = this.names;
+      return result;
+    }
+
+    public Builder names(List<String> names) {
+      this.names = names;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/inputWithDefaultValueForArray/schema.graphql
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/inputWithDefaultValueForArray/schema.graphql
@@ -1,0 +1,3 @@
+input SomeType {
+  names: [String] = []
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/inputWithDefaultValueForEnum/expected/DgsConstants.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/inputWithDefaultValueForEnum/expected/DgsConstants.java
@@ -1,0 +1,11 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.inputs.inputWithDefaultValueForEnum.expected;
+
+import java.lang.String;
+
+public class DgsConstants {
+  public static class COLORFILTER {
+    public static final String TYPE_NAME = "ColorFilter";
+
+    public static final String Color = "color";
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/inputWithDefaultValueForEnum/expected/types/Color.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/inputWithDefaultValueForEnum/expected/types/Color.java
@@ -1,0 +1,5 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.inputs.inputWithDefaultValueForEnum.expected.types;
+
+public enum Color {
+  red
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/inputWithDefaultValueForEnum/expected/types/ColorFilter.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/inputWithDefaultValueForEnum/expected/types/ColorFilter.java
@@ -1,0 +1,62 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.inputs.inputWithDefaultValueForEnum.expected.types;
+
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.util.Objects;
+
+public class ColorFilter {
+  private Color color = Color.red;
+
+  public ColorFilter() {
+  }
+
+  public ColorFilter(Color color) {
+    this.color = color;
+  }
+
+  public Color getColor() {
+    return color;
+  }
+
+  public void setColor(Color color) {
+    this.color = color;
+  }
+
+  @Override
+  public String toString() {
+    return "ColorFilter{color='" + color + "'}";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    ColorFilter that = (ColorFilter) o;
+    return Objects.equals(color, that.color);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(color);
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private Color color = Color.red;
+
+    public ColorFilter build() {
+      ColorFilter result = new ColorFilter();
+      result.color = this.color;
+      return result;
+    }
+
+    public Builder color(Color color) {
+      this.color = color;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/inputWithDefaultValueForEnum/schema.graphql
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/inputWithDefaultValueForEnum/schema.graphql
@@ -1,0 +1,7 @@
+enum Color {
+  red
+}
+
+input ColorFilter {
+  color: Color = red
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/inputWithDefaultValueForNonNullableFields/expected/DgsConstants.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/inputWithDefaultValueForNonNullableFields/expected/DgsConstants.java
@@ -1,0 +1,25 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.inputs.inputWithDefaultValueForNonNullableFields.expected;
+
+import java.lang.String;
+
+public class DgsConstants {
+  public static class PERSON {
+    public static final String TYPE_NAME = "Person";
+
+    public static final String Name = "name";
+
+    public static final String Age = "age";
+
+    public static final String Car = "car";
+
+    public static final String Hobbies = "hobbies";
+
+    public static final String IsHappy = "isHappy";
+  }
+
+  public static class CAR {
+    public static final String TYPE_NAME = "Car";
+
+    public static final String Brand = "brand";
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/inputWithDefaultValueForNonNullableFields/expected/types/Car.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/inputWithDefaultValueForNonNullableFields/expected/types/Car.java
@@ -1,0 +1,62 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.inputs.inputWithDefaultValueForNonNullableFields.expected.types;
+
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.util.Objects;
+
+public class Car {
+  private String brand = "BMW";
+
+  public Car() {
+  }
+
+  public Car(String brand) {
+    this.brand = brand;
+  }
+
+  public String getBrand() {
+    return brand;
+  }
+
+  public void setBrand(String brand) {
+    this.brand = brand;
+  }
+
+  @Override
+  public String toString() {
+    return "Car{brand='" + brand + "'}";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    Car that = (Car) o;
+    return Objects.equals(brand, that.brand);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(brand);
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private String brand = "BMW";
+
+    public Car build() {
+      Car result = new Car();
+      result.brand = this.brand;
+      return result;
+    }
+
+    public Builder brand(String brand) {
+      this.brand = brand;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/inputWithDefaultValueForNonNullableFields/expected/types/Hobby.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/inputWithDefaultValueForNonNullableFields/expected/types/Hobby.java
@@ -1,0 +1,7 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.inputs.inputWithDefaultValueForNonNullableFields.expected.types;
+
+public enum Hobby {
+  Football,
+
+  Hokey
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/inputWithDefaultValueForNonNullableFields/expected/types/Person.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/inputWithDefaultValueForNonNullableFields/expected/types/Person.java
@@ -1,0 +1,144 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.inputs.inputWithDefaultValueForNonNullableFields.expected.types;
+
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+public class Person {
+  private String name = "Damian";
+
+  private int age = 18;
+
+  private Car car = new Car(){{setBrand("Ford");}};
+
+  private List<Hobby> hobbies = Arrays.asList(Hobby.Hokey);
+
+  private boolean isHappy = true;
+
+  public Person() {
+  }
+
+  public Person(String name, int age, Car car, List<Hobby> hobbies, boolean isHappy) {
+    this.name = name;
+    this.age = age;
+    this.car = car;
+    this.hobbies = hobbies;
+    this.isHappy = isHappy;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public int getAge() {
+    return age;
+  }
+
+  public void setAge(int age) {
+    this.age = age;
+  }
+
+  public Car getCar() {
+    return car;
+  }
+
+  public void setCar(Car car) {
+    this.car = car;
+  }
+
+  public List<Hobby> getHobbies() {
+    return hobbies;
+  }
+
+  public void setHobbies(List<Hobby> hobbies) {
+    this.hobbies = hobbies;
+  }
+
+  public boolean getIsHappy() {
+    return isHappy;
+  }
+
+  public void setIsHappy(boolean isHappy) {
+    this.isHappy = isHappy;
+  }
+
+  @Override
+  public String toString() {
+    return "Person{name='" + name + "', age='" + age + "', car='" + car + "', hobbies='" + hobbies + "', isHappy='" + isHappy + "'}";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    Person that = (Person) o;
+    return Objects.equals(name, that.name) &&
+        age == that.age &&
+        Objects.equals(car, that.car) &&
+        Objects.equals(hobbies, that.hobbies) &&
+        isHappy == that.isHappy;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, age, car, hobbies, isHappy);
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private String name = "Damian";
+
+    private int age = 18;
+
+    private Car car = new Car(){{setBrand("Ford");}};
+
+    private List<Hobby> hobbies = Arrays.asList(Hobby.Hokey);
+
+    private boolean isHappy = true;
+
+    public Person build() {
+      Person result = new Person();
+      result.name = this.name;
+      result.age = this.age;
+      result.car = this.car;
+      result.hobbies = this.hobbies;
+      result.isHappy = this.isHappy;
+      return result;
+    }
+
+    public Builder name(String name) {
+      this.name = name;
+      return this;
+    }
+
+    public Builder age(int age) {
+      this.age = age;
+      return this;
+    }
+
+    public Builder car(Car car) {
+      this.car = car;
+      return this;
+    }
+
+    public Builder hobbies(List<Hobby> hobbies) {
+      this.hobbies = hobbies;
+      return this;
+    }
+
+    public Builder isHappy(boolean isHappy) {
+      this.isHappy = isHappy;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/inputWithDefaultValueForNonNullableFields/schema.graphql
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/inputWithDefaultValueForNonNullableFields/schema.graphql
@@ -1,0 +1,16 @@
+input Person {
+    name: String! = "Damian"
+    age: Int! = 18
+    car: Car! = { brand: "Ford" }
+    hobbies: [Hobby!]! = [Hokey]
+    isHappy: Boolean! = true
+}
+
+enum Hobby {
+    Football
+    Hokey
+}
+
+input Car {
+    brand: String! = "BMW"
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/inputWithDefaultValueForObject/expected/DgsConstants.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/inputWithDefaultValueForObject/expected/DgsConstants.java
@@ -1,0 +1,27 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.inputs.inputWithDefaultValueForObject.expected;
+
+import java.lang.String;
+
+public class DgsConstants {
+  public static class PERSON {
+    public static final String TYPE_NAME = "Person";
+
+    public static final String Name = "name";
+
+    public static final String Age = "age";
+
+    public static final String Car = "car";
+  }
+
+  public static class CAR {
+    public static final String TYPE_NAME = "Car";
+
+    public static final String Brand = "brand";
+  }
+
+  public static class MOVIEFILTER {
+    public static final String TYPE_NAME = "MovieFilter";
+
+    public static final String Director = "director";
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/inputWithDefaultValueForObject/expected/types/Car.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/inputWithDefaultValueForObject/expected/types/Car.java
@@ -1,0 +1,62 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.inputs.inputWithDefaultValueForObject.expected.types;
+
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.util.Objects;
+
+public class Car {
+  private String brand = "BMW";
+
+  public Car() {
+  }
+
+  public Car(String brand) {
+    this.brand = brand;
+  }
+
+  public String getBrand() {
+    return brand;
+  }
+
+  public void setBrand(String brand) {
+    this.brand = brand;
+  }
+
+  @Override
+  public String toString() {
+    return "Car{brand='" + brand + "'}";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    Car that = (Car) o;
+    return Objects.equals(brand, that.brand);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(brand);
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private String brand = "BMW";
+
+    public Car build() {
+      Car result = new Car();
+      result.brand = this.brand;
+      return result;
+    }
+
+    public Builder brand(String brand) {
+      this.brand = brand;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/inputWithDefaultValueForObject/expected/types/MovieFilter.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/inputWithDefaultValueForObject/expected/types/MovieFilter.java
@@ -1,0 +1,62 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.inputs.inputWithDefaultValueForObject.expected.types;
+
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.util.Objects;
+
+public class MovieFilter {
+  private Person director = new Person(){{setName("Damian");setCar(new Car(){{setBrand("Tesla");}});}};
+
+  public MovieFilter() {
+  }
+
+  public MovieFilter(Person director) {
+    this.director = director;
+  }
+
+  public Person getDirector() {
+    return director;
+  }
+
+  public void setDirector(Person director) {
+    this.director = director;
+  }
+
+  @Override
+  public String toString() {
+    return "MovieFilter{director='" + director + "'}";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    MovieFilter that = (MovieFilter) o;
+    return Objects.equals(director, that.director);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(director);
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private Person director = new Person(){{setName("Damian");setCar(new Car(){{setBrand("Tesla");}});}};
+
+    public MovieFilter build() {
+      MovieFilter result = new MovieFilter();
+      result.director = this.director;
+      return result;
+    }
+
+    public Builder director(Person director) {
+      this.director = director;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/inputWithDefaultValueForObject/expected/types/Person.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/inputWithDefaultValueForObject/expected/types/Person.java
@@ -1,0 +1,103 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.inputs.inputWithDefaultValueForObject.expected.types;
+
+import java.lang.Integer;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.util.Objects;
+
+public class Person {
+  private String name = "John";
+
+  private Integer age = 23;
+
+  private Car car = new Car(){{setBrand("Ford");}};
+
+  public Person() {
+  }
+
+  public Person(String name, Integer age, Car car) {
+    this.name = name;
+    this.age = age;
+    this.car = car;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public Integer getAge() {
+    return age;
+  }
+
+  public void setAge(Integer age) {
+    this.age = age;
+  }
+
+  public Car getCar() {
+    return car;
+  }
+
+  public void setCar(Car car) {
+    this.car = car;
+  }
+
+  @Override
+  public String toString() {
+    return "Person{name='" + name + "', age='" + age + "', car='" + car + "'}";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    Person that = (Person) o;
+    return Objects.equals(name, that.name) &&
+        Objects.equals(age, that.age) &&
+        Objects.equals(car, that.car);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, age, car);
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private String name = "John";
+
+    private Integer age = 23;
+
+    private Car car = new Car(){{setBrand("Ford");}};
+
+    public Person build() {
+      Person result = new Person();
+      result.name = this.name;
+      result.age = this.age;
+      result.car = this.car;
+      return result;
+    }
+
+    public Builder name(String name) {
+      this.name = name;
+      return this;
+    }
+
+    public Builder age(Integer age) {
+      this.age = age;
+      return this;
+    }
+
+    public Builder car(Car car) {
+      this.car = car;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/inputWithDefaultValueForObject/schema.graphql
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/inputWithDefaultValueForObject/schema.graphql
@@ -1,0 +1,13 @@
+input Person {
+    name: String = "John"
+    age: Int = 23
+    car: Car = { brand: "Ford" }
+}
+
+input Car {
+    brand: String! = "BMW"
+}
+
+input MovieFilter {
+    director: Person = { name: "Damian", car: { brand: "Tesla" } }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/inputWithExtendedType/expected/DgsConstants.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/inputWithExtendedType/expected/DgsConstants.java
@@ -1,0 +1,25 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.inputs.inputWithExtendedType.expected;
+
+import java.lang.String;
+
+public class DgsConstants {
+  public static final String QUERY_TYPE = "Query";
+
+  public static class QUERY {
+    public static final String TYPE_NAME = "Query";
+
+    public static final String Movies = "movies";
+
+    public static class MOVIES_INPUT_ARGUMENT {
+      public static final String Filter = "filter";
+    }
+  }
+
+  public static class MOVIEFILTER {
+    public static final String TYPE_NAME = "MovieFilter";
+
+    public static final String Genre = "genre";
+
+    public static final String ReleaseYear = "releaseYear";
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/inputWithExtendedType/expected/client/MoviesGraphQLQuery.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/inputWithExtendedType/expected/client/MoviesGraphQLQuery.java
@@ -1,0 +1,85 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.inputs.inputWithExtendedType.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.GraphQLQuery;
+import com.netflix.graphql.dgs.codegen.java.testcases.inputs.inputWithExtendedType.expected.types.MovieFilter;
+import graphql.language.VariableDefinition;
+import java.lang.Override;
+import java.lang.String;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class MoviesGraphQLQuery extends GraphQLQuery {
+  public MoviesGraphQLQuery(MovieFilter filter, String queryName, Set<String> fieldsSet) {
+    super("query", queryName);
+    if (filter != null || fieldsSet.contains("filter")) {
+        getInput().put("filter", filter);
+    }
+  }
+
+  public MoviesGraphQLQuery(MovieFilter filter, String queryName, Set<String> fieldsSet,
+      Map<String, String> variableReferences, List<VariableDefinition> variableDefinitions) {
+    super("query", queryName);
+    if (filter != null || fieldsSet.contains("filter")) {
+        getInput().put("filter", filter);
+    }
+    if(variableDefinitions != null) {
+       getVariableDefinitions().addAll(variableDefinitions);
+    }
+
+    if(variableReferences != null) {
+       getVariableReferences().putAll(variableReferences);
+    }                      
+  }
+
+  public MoviesGraphQLQuery() {
+    super("query");
+  }
+
+  @Override
+  public String getOperationName() {
+    return "movies";
+  }
+
+  public static Builder newRequest() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private Set<String> fieldsSet = new HashSet<>();
+
+    private final Map<String, String> variableReferences = new HashMap<>();
+
+    private final List<VariableDefinition> variableDefinitions = new ArrayList<>();
+
+    private MovieFilter filter;
+
+    private String queryName;
+
+    public MoviesGraphQLQuery build() {
+      return new MoviesGraphQLQuery(filter, queryName, fieldsSet, variableReferences, variableDefinitions);
+               
+    }
+
+    public Builder filter(MovieFilter filter) {
+      this.filter = filter;
+      this.fieldsSet.add("filter");
+      return this;
+    }
+
+    public Builder filterReference(String variableRef) {
+      this.variableReferences.put("filter", variableRef);
+      this.variableDefinitions.add(graphql.language.VariableDefinition.newVariableDefinition(variableRef, new graphql.language.TypeName("MovieFilter")).build());
+      this.fieldsSet.add("filter");
+      return this;
+    }
+
+    public Builder queryName(String queryName) {
+      this.queryName = queryName;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/inputWithExtendedType/expected/datafetchers/MoviesDatafetcher.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/inputWithExtendedType/expected/datafetchers/MoviesDatafetcher.java
@@ -1,0 +1,18 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.inputs.inputWithExtendedType.expected.datafetchers;
+
+import com.netflix.graphql.dgs.DgsComponent;
+import com.netflix.graphql.dgs.DgsData;
+import graphql.schema.DataFetchingEnvironment;
+import java.lang.String;
+import java.util.List;
+
+@DgsComponent
+public class MoviesDatafetcher {
+  @DgsData(
+      parentType = "Query",
+      field = "movies"
+  )
+  public List<String> getMovies(DataFetchingEnvironment dataFetchingEnvironment) {
+    return null;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/inputWithExtendedType/expected/types/MovieFilter.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/inputWithExtendedType/expected/types/MovieFilter.java
@@ -1,0 +1,83 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.inputs.inputWithExtendedType.expected.types;
+
+import java.lang.Integer;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.util.Objects;
+
+public class MovieFilter {
+  private String genre;
+
+  private Integer releaseYear;
+
+  public MovieFilter() {
+  }
+
+  public MovieFilter(String genre, Integer releaseYear) {
+    this.genre = genre;
+    this.releaseYear = releaseYear;
+  }
+
+  public String getGenre() {
+    return genre;
+  }
+
+  public void setGenre(String genre) {
+    this.genre = genre;
+  }
+
+  public Integer getReleaseYear() {
+    return releaseYear;
+  }
+
+  public void setReleaseYear(Integer releaseYear) {
+    this.releaseYear = releaseYear;
+  }
+
+  @Override
+  public String toString() {
+    return "MovieFilter{genre='" + genre + "', releaseYear='" + releaseYear + "'}";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    MovieFilter that = (MovieFilter) o;
+    return Objects.equals(genre, that.genre) &&
+        Objects.equals(releaseYear, that.releaseYear);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(genre, releaseYear);
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private String genre;
+
+    private Integer releaseYear;
+
+    public MovieFilter build() {
+      MovieFilter result = new MovieFilter();
+      result.genre = this.genre;
+      result.releaseYear = this.releaseYear;
+      return result;
+    }
+
+    public Builder genre(String genre) {
+      this.genre = genre;
+      return this;
+    }
+
+    public Builder releaseYear(Integer releaseYear) {
+      this.releaseYear = releaseYear;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/inputWithExtendedType/schema.graphql
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/inputWithExtendedType/schema.graphql
@@ -1,0 +1,11 @@
+type Query {
+  movies(filter: MovieFilter): [String]
+}
+
+input MovieFilter {
+  genre: String
+}
+
+extend input MovieFilter {
+  releaseYear: Int
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/inputWithReservedWord/expected/DgsConstants.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/inputWithReservedWord/expected/DgsConstants.java
@@ -1,0 +1,11 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.inputs.inputWithReservedWord.expected;
+
+import java.lang.String;
+
+public class DgsConstants {
+  public static class SAMPLEINPUT {
+    public static final String TYPE_NAME = "SampleInput";
+
+    public static final String Return = "return";
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/inputWithReservedWord/expected/types/SampleInput.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/inputWithReservedWord/expected/types/SampleInput.java
@@ -1,0 +1,62 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.inputs.inputWithReservedWord.expected.types;
+
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.util.Objects;
+
+public class SampleInput {
+  private String _return;
+
+  public SampleInput() {
+  }
+
+  public SampleInput(String _return) {
+    this._return = _return;
+  }
+
+  public String getReturn() {
+    return _return;
+  }
+
+  public void setReturn(String _return) {
+    this._return = _return;
+  }
+
+  @Override
+  public String toString() {
+    return "SampleInput{return='" + _return + "'}";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    SampleInput that = (SampleInput) o;
+    return Objects.equals(_return, that._return);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_return);
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private String _return;
+
+    public SampleInput build() {
+      SampleInput result = new SampleInput();
+      result._return = this._return;
+      return result;
+    }
+
+    public Builder _return(String _return) {
+      this._return = _return;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/inputWithReservedWord/schema.graphql
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/inputs/inputWithReservedWord/schema.graphql
@@ -1,0 +1,3 @@
+input SampleInput {
+  return: String!
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/interfaces/interfaceClassWithInterfaceFields/expected/DgsConstants.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/interfaces/interfaceClassWithInterfaceFields/expected/DgsConstants.java
@@ -1,0 +1,53 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.interfaces.interfaceClassWithInterfaceFields.expected;
+
+import java.lang.String;
+
+public class DgsConstants {
+  public static class DOG {
+    public static final String TYPE_NAME = "Dog";
+
+    public static final String Id = "id";
+
+    public static final String Name = "name";
+
+    public static final String Address = "address";
+
+    public static final String Mother = "mother";
+
+    public static final String Father = "father";
+
+    public static final String Parents = "parents";
+  }
+
+  public static class BIRD {
+    public static final String TYPE_NAME = "Bird";
+
+    public static final String Id = "id";
+
+    public static final String Name = "name";
+
+    public static final String Address = "address";
+
+    public static final String Mother = "mother";
+
+    public static final String Father = "father";
+
+    public static final String Parents = "parents";
+  }
+
+  public static class PET {
+    public static final String TYPE_NAME = "Pet";
+
+    public static final String Id = "id";
+
+    public static final String Name = "name";
+
+    public static final String Address = "address";
+
+    public static final String Mother = "mother";
+
+    public static final String Father = "father";
+
+    public static final String Parents = "parents";
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/interfaces/interfaceClassWithInterfaceFields/expected/types/Bird.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/interfaces/interfaceClassWithInterfaceFields/expected/types/Bird.java
@@ -1,0 +1,168 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.interfaces.interfaceClassWithInterfaceFields.expected.types;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.util.List;
+import java.util.Objects;
+
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NONE
+)
+public class Bird implements com.netflix.graphql.dgs.codegen.java.testcases.interfaces.interfaceClassWithInterfaceFields.expected.types.Pet {
+  private String id;
+
+  private String name;
+
+  private List<String> address;
+
+  private Bird mother;
+
+  private Bird father;
+
+  private List<Bird> parents;
+
+  public Bird() {
+  }
+
+  public Bird(String id, String name, List<String> address, Bird mother, Bird father,
+      List<Bird> parents) {
+    this.id = id;
+    this.name = name;
+    this.address = address;
+    this.mother = mother;
+    this.father = father;
+    this.parents = parents;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(String id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public List<String> getAddress() {
+    return address;
+  }
+
+  public void setAddress(List<String> address) {
+    this.address = address;
+  }
+
+  public Bird getMother() {
+    return mother;
+  }
+
+  public void setMother(Bird mother) {
+    this.mother = mother;
+  }
+
+  public Bird getFather() {
+    return father;
+  }
+
+  public void setFather(Bird father) {
+    this.father = father;
+  }
+
+  public List<Bird> getParents() {
+    return parents;
+  }
+
+  public void setParents(List<Bird> parents) {
+    this.parents = parents;
+  }
+
+  @Override
+  public String toString() {
+    return "Bird{id='" + id + "', name='" + name + "', address='" + address + "', mother='" + mother + "', father='" + father + "', parents='" + parents + "'}";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    Bird that = (Bird) o;
+    return Objects.equals(id, that.id) &&
+        Objects.equals(name, that.name) &&
+        Objects.equals(address, that.address) &&
+        Objects.equals(mother, that.mother) &&
+        Objects.equals(father, that.father) &&
+        Objects.equals(parents, that.parents);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, name, address, mother, father, parents);
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private String id;
+
+    private String name;
+
+    private List<String> address;
+
+    private Bird mother;
+
+    private Bird father;
+
+    private List<Bird> parents;
+
+    public Bird build() {
+      Bird result = new Bird();
+      result.id = this.id;
+      result.name = this.name;
+      result.address = this.address;
+      result.mother = this.mother;
+      result.father = this.father;
+      result.parents = this.parents;
+      return result;
+    }
+
+    public Builder id(String id) {
+      this.id = id;
+      return this;
+    }
+
+    public Builder name(String name) {
+      this.name = name;
+      return this;
+    }
+
+    public Builder address(List<String> address) {
+      this.address = address;
+      return this;
+    }
+
+    public Builder mother(Bird mother) {
+      this.mother = mother;
+      return this;
+    }
+
+    public Builder father(Bird father) {
+      this.father = father;
+      return this;
+    }
+
+    public Builder parents(List<Bird> parents) {
+      this.parents = parents;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/interfaces/interfaceClassWithInterfaceFields/expected/types/Dog.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/interfaces/interfaceClassWithInterfaceFields/expected/types/Dog.java
@@ -1,0 +1,168 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.interfaces.interfaceClassWithInterfaceFields.expected.types;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.util.List;
+import java.util.Objects;
+
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NONE
+)
+public class Dog implements com.netflix.graphql.dgs.codegen.java.testcases.interfaces.interfaceClassWithInterfaceFields.expected.types.Pet {
+  private String id;
+
+  private String name;
+
+  private List<String> address;
+
+  private Dog mother;
+
+  private Dog father;
+
+  private List<Dog> parents;
+
+  public Dog() {
+  }
+
+  public Dog(String id, String name, List<String> address, Dog mother, Dog father,
+      List<Dog> parents) {
+    this.id = id;
+    this.name = name;
+    this.address = address;
+    this.mother = mother;
+    this.father = father;
+    this.parents = parents;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(String id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public List<String> getAddress() {
+    return address;
+  }
+
+  public void setAddress(List<String> address) {
+    this.address = address;
+  }
+
+  public Dog getMother() {
+    return mother;
+  }
+
+  public void setMother(Dog mother) {
+    this.mother = mother;
+  }
+
+  public Dog getFather() {
+    return father;
+  }
+
+  public void setFather(Dog father) {
+    this.father = father;
+  }
+
+  public List<Dog> getParents() {
+    return parents;
+  }
+
+  public void setParents(List<Dog> parents) {
+    this.parents = parents;
+  }
+
+  @Override
+  public String toString() {
+    return "Dog{id='" + id + "', name='" + name + "', address='" + address + "', mother='" + mother + "', father='" + father + "', parents='" + parents + "'}";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    Dog that = (Dog) o;
+    return Objects.equals(id, that.id) &&
+        Objects.equals(name, that.name) &&
+        Objects.equals(address, that.address) &&
+        Objects.equals(mother, that.mother) &&
+        Objects.equals(father, that.father) &&
+        Objects.equals(parents, that.parents);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, name, address, mother, father, parents);
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private String id;
+
+    private String name;
+
+    private List<String> address;
+
+    private Dog mother;
+
+    private Dog father;
+
+    private List<Dog> parents;
+
+    public Dog build() {
+      Dog result = new Dog();
+      result.id = this.id;
+      result.name = this.name;
+      result.address = this.address;
+      result.mother = this.mother;
+      result.father = this.father;
+      result.parents = this.parents;
+      return result;
+    }
+
+    public Builder id(String id) {
+      this.id = id;
+      return this;
+    }
+
+    public Builder name(String name) {
+      this.name = name;
+      return this;
+    }
+
+    public Builder address(List<String> address) {
+      this.address = address;
+      return this;
+    }
+
+    public Builder mother(Dog mother) {
+      this.mother = mother;
+      return this;
+    }
+
+    public Builder father(Dog father) {
+      this.father = father;
+      return this;
+    }
+
+    public Builder parents(List<Dog> parents) {
+      this.parents = parents;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/interfaces/interfaceClassWithInterfaceFields/expected/types/Pet.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/interfaces/interfaceClassWithInterfaceFields/expected/types/Pet.java
@@ -1,0 +1,33 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.interfaces.interfaceClassWithInterfaceFields.expected.types;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import java.lang.String;
+import java.util.List;
+
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NAME,
+    include = JsonTypeInfo.As.PROPERTY,
+    property = "__typename"
+)
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = Dog.class, name = "Dog"),
+    @JsonSubTypes.Type(value = Bird.class, name = "Bird")
+})
+public interface Pet {
+  String getId();
+
+  void setId(String id);
+
+  String getName();
+
+  void setName(String name);
+
+  List<String> getAddress();
+
+  void setAddress(List<String> address);
+
+  Pet getMother();
+
+  Pet getFather();
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/interfaces/interfaceClassWithInterfaceFields/schema.graphql
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/interfaces/interfaceClassWithInterfaceFields/schema.graphql
@@ -1,0 +1,24 @@
+interface Pet {
+  id: ID!
+  name: String
+  address: [String!]!
+  mother: Pet!
+  father: Pet
+  parents: [Pet]
+}
+type Dog implements Pet {
+  id: ID!
+  name: String
+  address: [String!]!
+  mother: Dog!
+  father: Dog
+  parents: [Dog]
+}
+type Bird implements Pet {
+  id: ID!
+  name: String
+  address: [String!]!
+  mother: Bird!
+  father: Bird
+  parents: [Bird]
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/interfaces/interfaceClassWithInterfaceFieldsOfDifferentType/expected/DgsConstants.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/interfaces/interfaceClassWithInterfaceFieldsOfDifferentType/expected/DgsConstants.java
@@ -1,0 +1,35 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.interfaces.interfaceClassWithInterfaceFieldsOfDifferentType.expected;
+
+import java.lang.String;
+
+public class DgsConstants {
+  public static class VEGETARIAN {
+    public static final String TYPE_NAME = "Vegetarian";
+
+    public static final String Calories = "calories";
+
+    public static final String Vegetables = "vegetables";
+  }
+
+  public static class DOG {
+    public static final String TYPE_NAME = "Dog";
+
+    public static final String Name = "name";
+
+    public static final String Diet = "diet";
+  }
+
+  public static class PET {
+    public static final String TYPE_NAME = "Pet";
+
+    public static final String Name = "name";
+
+    public static final String Diet = "diet";
+  }
+
+  public static class DIET {
+    public static final String TYPE_NAME = "Diet";
+
+    public static final String Calories = "calories";
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/interfaces/interfaceClassWithInterfaceFieldsOfDifferentType/expected/types/Diet.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/interfaces/interfaceClassWithInterfaceFieldsOfDifferentType/expected/types/Diet.java
@@ -1,0 +1,17 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.interfaces.interfaceClassWithInterfaceFieldsOfDifferentType.expected.types;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import java.lang.String;
+
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NAME,
+    include = JsonTypeInfo.As.PROPERTY,
+    property = "__typename"
+)
+@JsonSubTypes(@JsonSubTypes.Type(value = Vegetarian.class, name = "Vegetarian"))
+public interface Diet {
+  String getCalories();
+
+  void setCalories(String calories);
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/interfaces/interfaceClassWithInterfaceFieldsOfDifferentType/expected/types/Dog.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/interfaces/interfaceClassWithInterfaceFieldsOfDifferentType/expected/types/Dog.java
@@ -1,0 +1,86 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.interfaces.interfaceClassWithInterfaceFieldsOfDifferentType.expected.types;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.util.Objects;
+
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NONE
+)
+public class Dog implements com.netflix.graphql.dgs.codegen.java.testcases.interfaces.interfaceClassWithInterfaceFieldsOfDifferentType.expected.types.Pet {
+  private String name;
+
+  private Vegetarian diet;
+
+  public Dog() {
+  }
+
+  public Dog(String name, Vegetarian diet) {
+    this.name = name;
+    this.diet = diet;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public Vegetarian getDiet() {
+    return diet;
+  }
+
+  public void setDiet(Vegetarian diet) {
+    this.diet = diet;
+  }
+
+  @Override
+  public String toString() {
+    return "Dog{name='" + name + "', diet='" + diet + "'}";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    Dog that = (Dog) o;
+    return Objects.equals(name, that.name) &&
+        Objects.equals(diet, that.diet);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, diet);
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private String name;
+
+    private Vegetarian diet;
+
+    public Dog build() {
+      Dog result = new Dog();
+      result.name = this.name;
+      result.diet = this.diet;
+      return result;
+    }
+
+    public Builder name(String name) {
+      this.name = name;
+      return this;
+    }
+
+    public Builder diet(Vegetarian diet) {
+      this.diet = diet;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/interfaces/interfaceClassWithInterfaceFieldsOfDifferentType/expected/types/Pet.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/interfaces/interfaceClassWithInterfaceFieldsOfDifferentType/expected/types/Pet.java
@@ -1,0 +1,19 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.interfaces.interfaceClassWithInterfaceFieldsOfDifferentType.expected.types;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import java.lang.String;
+
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NAME,
+    include = JsonTypeInfo.As.PROPERTY,
+    property = "__typename"
+)
+@JsonSubTypes(@JsonSubTypes.Type(value = Dog.class, name = "Dog"))
+public interface Pet {
+  String getName();
+
+  void setName(String name);
+
+  Diet getDiet();
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/interfaces/interfaceClassWithInterfaceFieldsOfDifferentType/expected/types/Vegetarian.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/interfaces/interfaceClassWithInterfaceFieldsOfDifferentType/expected/types/Vegetarian.java
@@ -1,0 +1,87 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.interfaces.interfaceClassWithInterfaceFieldsOfDifferentType.expected.types;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.util.List;
+import java.util.Objects;
+
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NONE
+)
+public class Vegetarian implements com.netflix.graphql.dgs.codegen.java.testcases.interfaces.interfaceClassWithInterfaceFieldsOfDifferentType.expected.types.Diet {
+  private String calories;
+
+  private List<String> vegetables;
+
+  public Vegetarian() {
+  }
+
+  public Vegetarian(String calories, List<String> vegetables) {
+    this.calories = calories;
+    this.vegetables = vegetables;
+  }
+
+  public String getCalories() {
+    return calories;
+  }
+
+  public void setCalories(String calories) {
+    this.calories = calories;
+  }
+
+  public List<String> getVegetables() {
+    return vegetables;
+  }
+
+  public void setVegetables(List<String> vegetables) {
+    this.vegetables = vegetables;
+  }
+
+  @Override
+  public String toString() {
+    return "Vegetarian{calories='" + calories + "', vegetables='" + vegetables + "'}";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    Vegetarian that = (Vegetarian) o;
+    return Objects.equals(calories, that.calories) &&
+        Objects.equals(vegetables, that.vegetables);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(calories, vegetables);
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private String calories;
+
+    private List<String> vegetables;
+
+    public Vegetarian build() {
+      Vegetarian result = new Vegetarian();
+      result.calories = this.calories;
+      result.vegetables = this.vegetables;
+      return result;
+    }
+
+    public Builder calories(String calories) {
+      this.calories = calories;
+      return this;
+    }
+
+    public Builder vegetables(List<String> vegetables) {
+      this.vegetables = vegetables;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/interfaces/interfaceClassWithInterfaceFieldsOfDifferentType/schema.graphql
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/interfaces/interfaceClassWithInterfaceFieldsOfDifferentType/schema.graphql
@@ -1,0 +1,18 @@
+interface Pet {
+  name: String
+  diet: Diet
+}
+
+interface Diet {
+  calories: String
+}
+
+type Vegetarian implements Diet {
+  calories: String
+  vegetables: [String]
+}
+
+type Dog implements Pet {
+  name: String
+  diet: Vegetarian
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/interfaces/interfaceClassWithNonNullableFields/expected/DgsConstants.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/interfaces/interfaceClassWithNonNullableFields/expected/DgsConstants.java
@@ -1,0 +1,31 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.interfaces.interfaceClassWithNonNullableFields.expected;
+
+import java.lang.String;
+
+public class DgsConstants {
+  public static final String QUERY_TYPE = "Query";
+
+  public static class QUERY {
+    public static final String TYPE_NAME = "Query";
+
+    public static final String People = "people";
+  }
+
+  public static class EMPLOYEE {
+    public static final String TYPE_NAME = "Employee";
+
+    public static final String Firstname = "firstname";
+
+    public static final String Lastname = "lastname";
+
+    public static final String Company = "company";
+  }
+
+  public static class PERSON {
+    public static final String TYPE_NAME = "Person";
+
+    public static final String Firstname = "firstname";
+
+    public static final String Lastname = "lastname";
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/interfaces/interfaceClassWithNonNullableFields/expected/client/EmployeeFragmentProjection.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/interfaces/interfaceClassWithNonNullableFields/expected/client/EmployeeFragmentProjection.java
@@ -1,0 +1,50 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.interfaces.interfaceClassWithNonNullableFields.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.BaseSubProjectionNode;
+import java.lang.Override;
+import java.lang.String;
+
+public class EmployeeFragmentProjection<PARENT extends BaseSubProjectionNode<?, ?>, ROOT extends BaseSubProjectionNode<?, ?>> extends BaseSubProjectionNode<PARENT, ROOT> {
+  {
+    getFields().put("__typename", null);
+  }
+
+  public EmployeeFragmentProjection(PARENT parent, ROOT root) {
+    super(parent, root, java.util.Optional.of("Employee"));
+  }
+
+  public EmployeeFragmentProjection<PARENT, ROOT> __typename() {
+    getFields().put("__typename", null);
+    return this;
+  }
+
+  public EmployeeFragmentProjection<PARENT, ROOT> firstname() {
+    getFields().put("firstname", null);
+    return this;
+  }
+
+  public EmployeeFragmentProjection<PARENT, ROOT> lastname() {
+    getFields().put("lastname", null);
+    return this;
+  }
+
+  public EmployeeFragmentProjection<PARENT, ROOT> company() {
+    getFields().put("company", null);
+    return this;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder builder = new StringBuilder();
+    builder.append("... on Employee {");
+    getFields().forEach((k, v) -> {
+        builder.append(" ").append(k);
+        if(v != null) {
+            builder.append(" ").append(v.toString());
+        }
+    });
+    builder.append("}");
+     
+    return builder.toString();
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/interfaces/interfaceClassWithNonNullableFields/expected/client/PeopleGraphQLQuery.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/interfaces/interfaceClassWithNonNullableFields/expected/client/PeopleGraphQLQuery.java
@@ -1,0 +1,50 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.interfaces.interfaceClassWithNonNullableFields.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.GraphQLQuery;
+import graphql.language.VariableDefinition;
+import java.lang.Override;
+import java.lang.String;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class PeopleGraphQLQuery extends GraphQLQuery {
+  public PeopleGraphQLQuery(String queryName) {
+    super("query", queryName);
+  }
+
+  public PeopleGraphQLQuery() {
+    super("query");
+  }
+
+  @Override
+  public String getOperationName() {
+    return "people";
+  }
+
+  public static Builder newRequest() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private Set<String> fieldsSet = new HashSet<>();
+
+    private final Map<String, String> variableReferences = new HashMap<>();
+
+    private final List<VariableDefinition> variableDefinitions = new ArrayList<>();
+
+    private String queryName;
+
+    public PeopleGraphQLQuery build() {
+      return new PeopleGraphQLQuery(queryName);                                     
+    }
+
+    public Builder queryName(String queryName) {
+      this.queryName = queryName;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/interfaces/interfaceClassWithNonNullableFields/expected/client/PeopleProjectionRoot.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/interfaces/interfaceClassWithNonNullableFields/expected/client/PeopleProjectionRoot.java
@@ -1,0 +1,31 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.interfaces.interfaceClassWithNonNullableFields.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.BaseSubProjectionNode;
+
+public class PeopleProjectionRoot<PARENT extends BaseSubProjectionNode<?, ?>, ROOT extends BaseSubProjectionNode<?, ?>> extends BaseSubProjectionNode<PARENT, ROOT> {
+  public PeopleProjectionRoot() {
+    super(null, null, java.util.Optional.of("Person"));
+  }
+
+  public PeopleProjectionRoot<PARENT, ROOT> __typename() {
+    getFields().put("__typename", null);
+    return this;
+  }
+
+  public PeopleProjectionRoot<PARENT, ROOT> firstname() {
+    getFields().put("firstname", null);
+    return this;
+  }
+
+  public PeopleProjectionRoot<PARENT, ROOT> lastname() {
+    getFields().put("lastname", null);
+    return this;
+  }
+
+  public EmployeeFragmentProjection<PeopleProjectionRoot<PARENT, ROOT>, PeopleProjectionRoot<PARENT, ROOT>> onEmployee(
+      ) {
+    EmployeeFragmentProjection<PeopleProjectionRoot<PARENT, ROOT>, PeopleProjectionRoot<PARENT, ROOT>> fragment = new EmployeeFragmentProjection<>(this, this);
+    getFragments().add(fragment);
+    return fragment;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/interfaces/interfaceClassWithNonNullableFields/expected/datafetchers/PeopleDatafetcher.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/interfaces/interfaceClassWithNonNullableFields/expected/datafetchers/PeopleDatafetcher.java
@@ -1,0 +1,18 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.interfaces.interfaceClassWithNonNullableFields.expected.datafetchers;
+
+import com.netflix.graphql.dgs.DgsComponent;
+import com.netflix.graphql.dgs.DgsData;
+import com.netflix.graphql.dgs.codegen.java.testcases.interfaces.interfaceClassWithNonNullableFields.expected.types.Person;
+import graphql.schema.DataFetchingEnvironment;
+import java.util.List;
+
+@DgsComponent
+public class PeopleDatafetcher {
+  @DgsData(
+      parentType = "Query",
+      field = "people"
+  )
+  public List<Person> getPeople(DataFetchingEnvironment dataFetchingEnvironment) {
+    return null;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/interfaces/interfaceClassWithNonNullableFields/expected/types/Employee.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/interfaces/interfaceClassWithNonNullableFields/expected/types/Employee.java
@@ -1,0 +1,106 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.interfaces.interfaceClassWithNonNullableFields.expected.types;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.util.Objects;
+
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NONE
+)
+public class Employee implements com.netflix.graphql.dgs.codegen.java.testcases.interfaces.interfaceClassWithNonNullableFields.expected.types.Person {
+  private String firstname;
+
+  private String lastname;
+
+  private String company;
+
+  public Employee() {
+  }
+
+  public Employee(String firstname, String lastname, String company) {
+    this.firstname = firstname;
+    this.lastname = lastname;
+    this.company = company;
+  }
+
+  public String getFirstname() {
+    return firstname;
+  }
+
+  public void setFirstname(String firstname) {
+    this.firstname = firstname;
+  }
+
+  public String getLastname() {
+    return lastname;
+  }
+
+  public void setLastname(String lastname) {
+    this.lastname = lastname;
+  }
+
+  public String getCompany() {
+    return company;
+  }
+
+  public void setCompany(String company) {
+    this.company = company;
+  }
+
+  @Override
+  public String toString() {
+    return "Employee{firstname='" + firstname + "', lastname='" + lastname + "', company='" + company + "'}";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    Employee that = (Employee) o;
+    return Objects.equals(firstname, that.firstname) &&
+        Objects.equals(lastname, that.lastname) &&
+        Objects.equals(company, that.company);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(firstname, lastname, company);
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private String firstname;
+
+    private String lastname;
+
+    private String company;
+
+    public Employee build() {
+      Employee result = new Employee();
+      result.firstname = this.firstname;
+      result.lastname = this.lastname;
+      result.company = this.company;
+      return result;
+    }
+
+    public Builder firstname(String firstname) {
+      this.firstname = firstname;
+      return this;
+    }
+
+    public Builder lastname(String lastname) {
+      this.lastname = lastname;
+      return this;
+    }
+
+    public Builder company(String company) {
+      this.company = company;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/interfaces/interfaceClassWithNonNullableFields/expected/types/Person.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/interfaces/interfaceClassWithNonNullableFields/expected/types/Person.java
@@ -1,0 +1,21 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.interfaces.interfaceClassWithNonNullableFields.expected.types;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import java.lang.String;
+
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NAME,
+    include = JsonTypeInfo.As.PROPERTY,
+    property = "__typename"
+)
+@JsonSubTypes(@JsonSubTypes.Type(value = Employee.class, name = "Employee"))
+public interface Person {
+  String getFirstname();
+
+  void setFirstname(String firstname);
+
+  String getLastname();
+
+  void setLastname(String lastname);
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/interfaces/interfaceClassWithNonNullableFields/schema.graphql
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/interfaces/interfaceClassWithNonNullableFields/schema.graphql
@@ -1,0 +1,14 @@
+type Query {
+  people: [Person]
+}
+
+interface Person {
+  firstname: String!
+  lastname: String
+}
+
+type Employee implements Person {
+  firstname: String!
+  lastname: String
+  company: String
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/interfaces/interfaceDocs/expected/DgsConstants.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/interfaces/interfaceDocs/expected/DgsConstants.java
@@ -1,0 +1,11 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.interfaces.interfaceDocs.expected;
+
+import java.lang.String;
+
+public class DgsConstants {
+  public static class TITLED {
+    public static final String TYPE_NAME = "Titled";
+
+    public static final String Title = "title";
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/interfaces/interfaceDocs/expected/types/Titled.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/interfaces/interfaceDocs/expected/types/Titled.java
@@ -1,0 +1,12 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.interfaces.interfaceDocs.expected.types;
+
+import java.lang.String;
+
+/**
+ * Anything with a title!
+ */
+public interface Titled {
+  String getTitle();
+
+  void setTitle(String title);
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/interfaces/interfaceDocs/schema.graphql
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/interfaces/interfaceDocs/schema.graphql
@@ -1,0 +1,6 @@
+"""
+Anything with a title!
+"""
+interface Titled {
+  title: String
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/interfaces/interfaceFieldsDocs/expected/DgsConstants.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/interfaces/interfaceFieldsDocs/expected/DgsConstants.java
@@ -1,0 +1,11 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.interfaces.interfaceFieldsDocs.expected;
+
+import java.lang.String;
+
+public class DgsConstants {
+  public static class TITLED {
+    public static final String TYPE_NAME = "Titled";
+
+    public static final String Title = "title";
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/interfaces/interfaceFieldsDocs/expected/types/Titled.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/interfaces/interfaceFieldsDocs/expected/types/Titled.java
@@ -1,0 +1,15 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.interfaces.interfaceFieldsDocs.expected.types;
+
+import java.lang.String;
+
+public interface Titled {
+  /**
+   * The original, non localized title.
+   */
+  String getTitle();
+
+  /**
+   * The original, non localized title.
+   */
+  void setTitle(String title);
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/interfaces/interfaceFieldsDocs/schema.graphql
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/interfaces/interfaceFieldsDocs/schema.graphql
@@ -1,0 +1,6 @@
+interface Titled {
+  """
+  The original, non localized title.
+  """
+  title: String
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/interfaces/interfaceWithInterfaceInheritance/expected/DgsConstants.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/interfaces/interfaceWithInterfaceInheritance/expected/DgsConstants.java
@@ -1,0 +1,33 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.interfaces.interfaceWithInterfaceInheritance.expected;
+
+import java.lang.String;
+
+public class DgsConstants {
+  public static final String QUERY_TYPE = "Query";
+
+  public static class QUERY {
+    public static final String TYPE_NAME = "Query";
+
+    public static final String Fruits = "fruits";
+  }
+
+  public static class SEED {
+    public static final String TYPE_NAME = "Seed";
+
+    public static final String Name = "name";
+  }
+
+  public static class FRUIT {
+    public static final String TYPE_NAME = "Fruit";
+
+    public static final String Seeds = "seeds";
+  }
+
+  public static class STONEFRUIT {
+    public static final String TYPE_NAME = "StoneFruit";
+
+    public static final String Seeds = "seeds";
+
+    public static final String Fuzzy = "fuzzy";
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/interfaces/interfaceWithInterfaceInheritance/expected/client/FruitsGraphQLQuery.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/interfaces/interfaceWithInterfaceInheritance/expected/client/FruitsGraphQLQuery.java
@@ -1,0 +1,50 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.interfaces.interfaceWithInterfaceInheritance.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.GraphQLQuery;
+import graphql.language.VariableDefinition;
+import java.lang.Override;
+import java.lang.String;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class FruitsGraphQLQuery extends GraphQLQuery {
+  public FruitsGraphQLQuery(String queryName) {
+    super("query", queryName);
+  }
+
+  public FruitsGraphQLQuery() {
+    super("query");
+  }
+
+  @Override
+  public String getOperationName() {
+    return "fruits";
+  }
+
+  public static Builder newRequest() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private Set<String> fieldsSet = new HashSet<>();
+
+    private final Map<String, String> variableReferences = new HashMap<>();
+
+    private final List<VariableDefinition> variableDefinitions = new ArrayList<>();
+
+    private String queryName;
+
+    public FruitsGraphQLQuery build() {
+      return new FruitsGraphQLQuery(queryName);                                     
+    }
+
+    public Builder queryName(String queryName) {
+      this.queryName = queryName;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/interfaces/interfaceWithInterfaceInheritance/expected/client/FruitsProjectionRoot.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/interfaces/interfaceWithInterfaceInheritance/expected/client/FruitsProjectionRoot.java
@@ -1,0 +1,21 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.interfaces.interfaceWithInterfaceInheritance.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.BaseSubProjectionNode;
+
+public class FruitsProjectionRoot<PARENT extends BaseSubProjectionNode<?, ?>, ROOT extends BaseSubProjectionNode<?, ?>> extends BaseSubProjectionNode<PARENT, ROOT> {
+  public FruitsProjectionRoot() {
+    super(null, null, java.util.Optional.of("Fruit"));
+  }
+
+  public FruitsProjectionRoot<PARENT, ROOT> __typename() {
+    getFields().put("__typename", null);
+    return this;
+  }
+
+  public SeedProjection<FruitsProjectionRoot<PARENT, ROOT>, FruitsProjectionRoot<PARENT, ROOT>> seeds(
+      ) {
+    SeedProjection<FruitsProjectionRoot<PARENT, ROOT>, FruitsProjectionRoot<PARENT, ROOT>> projection = new SeedProjection<>(this, this);    
+    getFields().put("seeds", projection);
+    return projection;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/interfaces/interfaceWithInterfaceInheritance/expected/client/SeedProjection.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/interfaces/interfaceWithInterfaceInheritance/expected/client/SeedProjection.java
@@ -1,0 +1,19 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.interfaces.interfaceWithInterfaceInheritance.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.BaseSubProjectionNode;
+
+public class SeedProjection<PARENT extends BaseSubProjectionNode<?, ?>, ROOT extends BaseSubProjectionNode<?, ?>> extends BaseSubProjectionNode<PARENT, ROOT> {
+  public SeedProjection(PARENT parent, ROOT root) {
+    super(parent, root, java.util.Optional.of("Seed"));
+  }
+
+  public SeedProjection<PARENT, ROOT> __typename() {
+    getFields().put("__typename", null);
+    return this;
+  }
+
+  public SeedProjection<PARENT, ROOT> name() {
+    getFields().put("name", null);
+    return this;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/interfaces/interfaceWithInterfaceInheritance/expected/datafetchers/FruitsDatafetcher.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/interfaces/interfaceWithInterfaceInheritance/expected/datafetchers/FruitsDatafetcher.java
@@ -1,0 +1,18 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.interfaces.interfaceWithInterfaceInheritance.expected.datafetchers;
+
+import com.netflix.graphql.dgs.DgsComponent;
+import com.netflix.graphql.dgs.DgsData;
+import com.netflix.graphql.dgs.codegen.java.testcases.interfaces.interfaceWithInterfaceInheritance.expected.types.Fruit;
+import graphql.schema.DataFetchingEnvironment;
+import java.util.List;
+
+@DgsComponent
+public class FruitsDatafetcher {
+  @DgsData(
+      parentType = "Query",
+      field = "fruits"
+  )
+  public List<Fruit> getFruits(DataFetchingEnvironment dataFetchingEnvironment) {
+    return null;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/interfaces/interfaceWithInterfaceInheritance/expected/types/Fruit.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/interfaces/interfaceWithInterfaceInheritance/expected/types/Fruit.java
@@ -1,0 +1,9 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.interfaces.interfaceWithInterfaceInheritance.expected.types;
+
+import java.util.List;
+
+public interface Fruit {
+  List<Seed> getSeeds();
+
+  void setSeeds(List<Seed> seeds);
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/interfaces/interfaceWithInterfaceInheritance/expected/types/Seed.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/interfaces/interfaceWithInterfaceInheritance/expected/types/Seed.java
@@ -1,0 +1,62 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.interfaces.interfaceWithInterfaceInheritance.expected.types;
+
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.util.Objects;
+
+public class Seed {
+  private String name;
+
+  public Seed() {
+  }
+
+  public Seed(String name) {
+    this.name = name;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  @Override
+  public String toString() {
+    return "Seed{name='" + name + "'}";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    Seed that = (Seed) o;
+    return Objects.equals(name, that.name);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name);
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private String name;
+
+    public Seed build() {
+      Seed result = new Seed();
+      result.name = this.name;
+      return result;
+    }
+
+    public Builder name(String name) {
+      this.name = name;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/interfaces/interfaceWithInterfaceInheritance/expected/types/StoneFruit.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/interfaces/interfaceWithInterfaceInheritance/expected/types/StoneFruit.java
@@ -1,0 +1,14 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.interfaces.interfaceWithInterfaceInheritance.expected.types;
+
+import java.lang.Boolean;
+import java.util.List;
+
+public interface StoneFruit extends Fruit {
+  List<Seed> getSeeds();
+
+  void setSeeds(List<Seed> seeds);
+
+  Boolean getFuzzy();
+
+  void setFuzzy(Boolean fuzzy);
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/interfaces/interfaceWithInterfaceInheritance/schema.graphql
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/interfaces/interfaceWithInterfaceInheritance/schema.graphql
@@ -1,0 +1,16 @@
+type Query {
+  fruits: [Fruit]
+}
+
+type Seed {
+  name: String
+}
+
+interface Fruit {
+  seeds: [Seed]
+}
+
+interface StoneFruit implements Fruit {
+  seeds: [Seed]
+  fuzzy: Boolean
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/interfaces/interfaceWithUnderscoreFields/expected/DgsConstants.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/interfaces/interfaceWithUnderscoreFields/expected/DgsConstants.java
@@ -1,0 +1,27 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.interfaces.interfaceWithUnderscoreFields.expected;
+
+import java.lang.String;
+
+public class DgsConstants {
+  public static final String QUERY_TYPE = "Query";
+
+  public static class QUERY {
+    public static final String TYPE_NAME = "Query";
+
+    public static final String Is = "is";
+  }
+
+  public static class T {
+    public static final String TYPE_NAME = "T";
+
+    public static final String _id = "_id";
+
+    public static final String Id = "id";
+  }
+
+  public static class I {
+    public static final String TYPE_NAME = "I";
+
+    public static final String _id = "_id";
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/interfaces/interfaceWithUnderscoreFields/expected/client/IsGraphQLQuery.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/interfaces/interfaceWithUnderscoreFields/expected/client/IsGraphQLQuery.java
@@ -1,0 +1,50 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.interfaces.interfaceWithUnderscoreFields.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.GraphQLQuery;
+import graphql.language.VariableDefinition;
+import java.lang.Override;
+import java.lang.String;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class IsGraphQLQuery extends GraphQLQuery {
+  public IsGraphQLQuery(String queryName) {
+    super("query", queryName);
+  }
+
+  public IsGraphQLQuery() {
+    super("query");
+  }
+
+  @Override
+  public String getOperationName() {
+    return "is";
+  }
+
+  public static Builder newRequest() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private Set<String> fieldsSet = new HashSet<>();
+
+    private final Map<String, String> variableReferences = new HashMap<>();
+
+    private final List<VariableDefinition> variableDefinitions = new ArrayList<>();
+
+    private String queryName;
+
+    public IsGraphQLQuery build() {
+      return new IsGraphQLQuery(queryName);                                     
+    }
+
+    public Builder queryName(String queryName) {
+      this.queryName = queryName;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/interfaces/interfaceWithUnderscoreFields/expected/client/IsProjectionRoot.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/interfaces/interfaceWithUnderscoreFields/expected/client/IsProjectionRoot.java
@@ -1,0 +1,25 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.interfaces.interfaceWithUnderscoreFields.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.BaseSubProjectionNode;
+
+public class IsProjectionRoot<PARENT extends BaseSubProjectionNode<?, ?>, ROOT extends BaseSubProjectionNode<?, ?>> extends BaseSubProjectionNode<PARENT, ROOT> {
+  public IsProjectionRoot() {
+    super(null, null, java.util.Optional.of("I"));
+  }
+
+  public IsProjectionRoot<PARENT, ROOT> __typename() {
+    getFields().put("__typename", null);
+    return this;
+  }
+
+  public IsProjectionRoot<PARENT, ROOT> _id() {
+    getFields().put("_id", null);
+    return this;
+  }
+
+  public TFragmentProjection<IsProjectionRoot<PARENT, ROOT>, IsProjectionRoot<PARENT, ROOT>> onT() {
+    TFragmentProjection<IsProjectionRoot<PARENT, ROOT>, IsProjectionRoot<PARENT, ROOT>> fragment = new TFragmentProjection<>(this, this);
+    getFragments().add(fragment);
+    return fragment;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/interfaces/interfaceWithUnderscoreFields/expected/client/TFragmentProjection.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/interfaces/interfaceWithUnderscoreFields/expected/client/TFragmentProjection.java
@@ -1,0 +1,45 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.interfaces.interfaceWithUnderscoreFields.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.BaseSubProjectionNode;
+import java.lang.Override;
+import java.lang.String;
+
+public class TFragmentProjection<PARENT extends BaseSubProjectionNode<?, ?>, ROOT extends BaseSubProjectionNode<?, ?>> extends BaseSubProjectionNode<PARENT, ROOT> {
+  {
+    getFields().put("__typename", null);
+  }
+
+  public TFragmentProjection(PARENT parent, ROOT root) {
+    super(parent, root, java.util.Optional.of("T"));
+  }
+
+  public TFragmentProjection<PARENT, ROOT> __typename() {
+    getFields().put("__typename", null);
+    return this;
+  }
+
+  public TFragmentProjection<PARENT, ROOT> _id() {
+    getFields().put("_id", null);
+    return this;
+  }
+
+  public TFragmentProjection<PARENT, ROOT> id() {
+    getFields().put("id", null);
+    return this;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder builder = new StringBuilder();
+    builder.append("... on T {");
+    getFields().forEach((k, v) -> {
+        builder.append(" ").append(k);
+        if(v != null) {
+            builder.append(" ").append(v.toString());
+        }
+    });
+    builder.append("}");
+     
+    return builder.toString();
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/interfaces/interfaceWithUnderscoreFields/expected/datafetchers/IsDatafetcher.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/interfaces/interfaceWithUnderscoreFields/expected/datafetchers/IsDatafetcher.java
@@ -1,0 +1,18 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.interfaces.interfaceWithUnderscoreFields.expected.datafetchers;
+
+import com.netflix.graphql.dgs.DgsComponent;
+import com.netflix.graphql.dgs.DgsData;
+import com.netflix.graphql.dgs.codegen.java.testcases.interfaces.interfaceWithUnderscoreFields.expected.types.I;
+import graphql.schema.DataFetchingEnvironment;
+import java.util.List;
+
+@DgsComponent
+public class IsDatafetcher {
+  @DgsData(
+      parentType = "Query",
+      field = "is"
+  )
+  public List<I> getIs(DataFetchingEnvironment dataFetchingEnvironment) {
+    return null;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/interfaces/interfaceWithUnderscoreFields/expected/types/I.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/interfaces/interfaceWithUnderscoreFields/expected/types/I.java
@@ -1,0 +1,17 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.interfaces.interfaceWithUnderscoreFields.expected.types;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import java.lang.String;
+
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NAME,
+    include = JsonTypeInfo.As.PROPERTY,
+    property = "__typename"
+)
+@JsonSubTypes(@JsonSubTypes.Type(value = T.class, name = "T"))
+public interface I {
+  String get_id();
+
+  void set_id(String _id);
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/interfaces/interfaceWithUnderscoreFields/expected/types/T.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/interfaces/interfaceWithUnderscoreFields/expected/types/T.java
@@ -1,0 +1,86 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.interfaces.interfaceWithUnderscoreFields.expected.types;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.util.Objects;
+
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NONE
+)
+public class T implements com.netflix.graphql.dgs.codegen.java.testcases.interfaces.interfaceWithUnderscoreFields.expected.types.I {
+  private String _id;
+
+  private String id;
+
+  public T() {
+  }
+
+  public T(String _id, String id) {
+    this._id = _id;
+    this.id = id;
+  }
+
+  public String get_id() {
+    return _id;
+  }
+
+  public void set_id(String _id) {
+    this._id = _id;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(String id) {
+    this.id = id;
+  }
+
+  @Override
+  public String toString() {
+    return "T{_id='" + _id + "', id='" + id + "'}";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    T that = (T) o;
+    return Objects.equals(_id, that._id) &&
+        Objects.equals(id, that.id);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_id, id);
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private String _id;
+
+    private String id;
+
+    public T build() {
+      T result = new T();
+      result._id = this._id;
+      result.id = this.id;
+      return result;
+    }
+
+    public Builder _id(String _id) {
+      this._id = _id;
+      return this;
+    }
+
+    public Builder id(String id) {
+      this.id = id;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/interfaces/interfaceWithUnderscoreFields/schema.graphql
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/interfaces/interfaceWithUnderscoreFields/schema.graphql
@@ -1,0 +1,12 @@
+type Query {
+  is: [I]
+}
+
+interface I {
+  _id: ID
+}
+
+type T implements I {
+  _id: ID
+  id: ID
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/misc/skipCodegenOnFields/expected/DgsConstants.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/misc/skipCodegenOnFields/expected/DgsConstants.java
@@ -1,0 +1,13 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.misc.skipCodegenOnFields.expected;
+
+import java.lang.String;
+
+public class DgsConstants {
+  public static class PERSON {
+    public static final String TYPE_NAME = "Person";
+
+    public static final String Name = "name";
+
+    public static final String Email = "email";
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/misc/skipCodegenOnFields/expected/types/Person.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/misc/skipCodegenOnFields/expected/types/Person.java
@@ -1,0 +1,62 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.misc.skipCodegenOnFields.expected.types;
+
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.util.Objects;
+
+public class Person {
+  private String name;
+
+  public Person() {
+  }
+
+  public Person(String name) {
+    this.name = name;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  @Override
+  public String toString() {
+    return "Person{name='" + name + "'}";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    Person that = (Person) o;
+    return Objects.equals(name, that.name);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name);
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private String name;
+
+    public Person build() {
+      Person result = new Person();
+      result.name = this.name;
+      return result;
+    }
+
+    public Builder name(String name) {
+      this.name = name;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/misc/skipCodegenOnFields/schema.graphql
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/misc/skipCodegenOnFields/schema.graphql
@@ -1,0 +1,4 @@
+type Person {
+  name: String
+  email: String @skipcodegen
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/misc/skipCodegenOnInterfaceFields/expected/DgsConstants.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/misc/skipCodegenOnInterfaceFields/expected/DgsConstants.java
@@ -1,0 +1,13 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.misc.skipCodegenOnInterfaceFields.expected;
+
+import java.lang.String;
+
+public class DgsConstants {
+  public static class PERSON {
+    public static final String TYPE_NAME = "Person";
+
+    public static final String Name = "name";
+
+    public static final String Email = "email";
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/misc/skipCodegenOnInterfaceFields/expected/types/Person.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/misc/skipCodegenOnInterfaceFields/expected/types/Person.java
@@ -1,0 +1,9 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.misc.skipCodegenOnInterfaceFields.expected.types;
+
+import java.lang.String;
+
+public interface Person {
+  String getName();
+
+  void setName(String name);
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/misc/skipCodegenOnInterfaceFields/schema.graphql
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/misc/skipCodegenOnInterfaceFields/schema.graphql
@@ -1,0 +1,4 @@
+interface Person {
+  name: String
+  email: String @skipcodegen
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/misc/skipCodegenOnTypes/expected/DgsConstants.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/misc/skipCodegenOnTypes/expected/DgsConstants.java
@@ -1,0 +1,17 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.misc.skipCodegenOnTypes.expected;
+
+import java.lang.String;
+
+public class DgsConstants {
+  public static class PERSON {
+    public static final String TYPE_NAME = "Person";
+
+    public static final String Name = "name";
+  }
+
+  public static class CAR {
+    public static final String TYPE_NAME = "Car";
+
+    public static final String Make = "make";
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/misc/skipCodegenOnTypes/expected/types/Person.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/misc/skipCodegenOnTypes/expected/types/Person.java
@@ -1,0 +1,62 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.misc.skipCodegenOnTypes.expected.types;
+
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.util.Objects;
+
+public class Person {
+  private String name;
+
+  public Person() {
+  }
+
+  public Person(String name) {
+    this.name = name;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  @Override
+  public String toString() {
+    return "Person{name='" + name + "'}";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    Person that = (Person) o;
+    return Objects.equals(name, that.name);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name);
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private String name;
+
+    public Person build() {
+      Person result = new Person();
+      result.name = this.name;
+      return result;
+    }
+
+    public Builder name(String name) {
+      this.name = name;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/misc/skipCodegenOnTypes/schema.graphql
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/misc/skipCodegenOnTypes/schema.graphql
@@ -1,0 +1,7 @@
+type Person {
+  name: String
+}
+
+type Car @skipcodegen {
+  make: String
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/misc/typesWithUnderscoreField/expected/DgsConstants.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/misc/typesWithUnderscoreField/expected/DgsConstants.java
@@ -1,0 +1,25 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.misc.typesWithUnderscoreField.expected;
+
+import java.lang.String;
+
+public class DgsConstants {
+  public static final String QUERY_TYPE = "Query";
+
+  public static class MYINTERFACEIMPL {
+    public static final String TYPE_NAME = "MyInterfaceImpl";
+
+    public static final String __ = "_";
+  }
+
+  public static class QUERY {
+    public static final String TYPE_NAME = "Query";
+
+    public static final String Impl = "impl";
+  }
+
+  public static class MYINTERFACE {
+    public static final String TYPE_NAME = "MyInterface";
+
+    public static final String __ = "_";
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/misc/typesWithUnderscoreField/expected/client/ImplGraphQLQuery.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/misc/typesWithUnderscoreField/expected/client/ImplGraphQLQuery.java
@@ -1,0 +1,50 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.misc.typesWithUnderscoreField.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.GraphQLQuery;
+import graphql.language.VariableDefinition;
+import java.lang.Override;
+import java.lang.String;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class ImplGraphQLQuery extends GraphQLQuery {
+  public ImplGraphQLQuery(String queryName) {
+    super("query", queryName);
+  }
+
+  public ImplGraphQLQuery() {
+    super("query");
+  }
+
+  @Override
+  public String getOperationName() {
+    return "impl";
+  }
+
+  public static Builder newRequest() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private Set<String> fieldsSet = new HashSet<>();
+
+    private final Map<String, String> variableReferences = new HashMap<>();
+
+    private final List<VariableDefinition> variableDefinitions = new ArrayList<>();
+
+    private String queryName;
+
+    public ImplGraphQLQuery build() {
+      return new ImplGraphQLQuery(queryName);                                     
+    }
+
+    public Builder queryName(String queryName) {
+      this.queryName = queryName;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/misc/typesWithUnderscoreField/expected/client/ImplProjectionRoot.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/misc/typesWithUnderscoreField/expected/client/ImplProjectionRoot.java
@@ -1,0 +1,19 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.misc.typesWithUnderscoreField.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.BaseSubProjectionNode;
+
+public class ImplProjectionRoot<PARENT extends BaseSubProjectionNode<?, ?>, ROOT extends BaseSubProjectionNode<?, ?>> extends BaseSubProjectionNode<PARENT, ROOT> {
+  public ImplProjectionRoot() {
+    super(null, null, java.util.Optional.of("MyInterfaceImpl"));
+  }
+
+  public ImplProjectionRoot<PARENT, ROOT> __typename() {
+    getFields().put("__typename", null);
+    return this;
+  }
+
+  public ImplProjectionRoot<PARENT, ROOT> __() {
+    getFields().put("_", null);
+    return this;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/misc/typesWithUnderscoreField/expected/datafetchers/ImplDatafetcher.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/misc/typesWithUnderscoreField/expected/datafetchers/ImplDatafetcher.java
@@ -1,0 +1,17 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.misc.typesWithUnderscoreField.expected.datafetchers;
+
+import com.netflix.graphql.dgs.DgsComponent;
+import com.netflix.graphql.dgs.DgsData;
+import com.netflix.graphql.dgs.codegen.java.testcases.misc.typesWithUnderscoreField.expected.types.MyInterfaceImpl;
+import graphql.schema.DataFetchingEnvironment;
+
+@DgsComponent
+public class ImplDatafetcher {
+  @DgsData(
+      parentType = "Query",
+      field = "impl"
+  )
+  public MyInterfaceImpl getImpl(DataFetchingEnvironment dataFetchingEnvironment) {
+    return null;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/misc/typesWithUnderscoreField/expected/types/MyInterface.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/misc/typesWithUnderscoreField/expected/types/MyInterface.java
@@ -1,0 +1,17 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.misc.typesWithUnderscoreField.expected.types;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import java.lang.String;
+
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NAME,
+    include = JsonTypeInfo.As.PROPERTY,
+    property = "__typename"
+)
+@JsonSubTypes(@JsonSubTypes.Type(value = MyInterfaceImpl.class, name = "MyInterfaceImpl"))
+public interface MyInterface {
+  String get_();
+
+  void set_(String __);
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/misc/typesWithUnderscoreField/expected/types/MyInterfaceImpl.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/misc/typesWithUnderscoreField/expected/types/MyInterfaceImpl.java
@@ -1,0 +1,66 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.misc.typesWithUnderscoreField.expected.types;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.util.Objects;
+
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NONE
+)
+public class MyInterfaceImpl implements com.netflix.graphql.dgs.codegen.java.testcases.misc.typesWithUnderscoreField.expected.types.MyInterface {
+  private String __;
+
+  public MyInterfaceImpl() {
+  }
+
+  public MyInterfaceImpl(String __) {
+    this.__ = __;
+  }
+
+  public String get_() {
+    return __;
+  }
+
+  public void set_(String __) {
+    this.__ = __;
+  }
+
+  @Override
+  public String toString() {
+    return "MyInterfaceImpl{_='" + __ + "'}";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    MyInterfaceImpl that = (MyInterfaceImpl) o;
+    return Objects.equals(__, that.__);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(__);
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private String __;
+
+    public MyInterfaceImpl build() {
+      MyInterfaceImpl result = new MyInterfaceImpl();
+      result.__ = this.__;
+      return result;
+    }
+
+    public Builder __(String __) {
+      this.__ = __;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/misc/typesWithUnderscoreField/schema.graphql
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/misc/typesWithUnderscoreField/schema.graphql
@@ -1,0 +1,11 @@
+interface MyInterface {
+    _: ID
+}
+
+type MyInterfaceImpl implements MyInterface {
+    _: ID
+}
+
+type Query {
+    impl: MyInterfaceImpl
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithEnum/expected/DgsConstants.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithEnum/expected/DgsConstants.java
@@ -1,0 +1,15 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.projections.projectionWithEnum.expected;
+
+import java.lang.String;
+
+public class DgsConstants {
+  public static final String QUERY_TYPE = "Query";
+
+  public static class QUERY {
+    public static final String TYPE_NAME = "Query";
+
+    public static final String E = "e";
+
+    public static final String Es = "es";
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithEnum/expected/client/EGraphQLQuery.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithEnum/expected/client/EGraphQLQuery.java
@@ -1,0 +1,50 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.projections.projectionWithEnum.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.GraphQLQuery;
+import graphql.language.VariableDefinition;
+import java.lang.Override;
+import java.lang.String;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class EGraphQLQuery extends GraphQLQuery {
+  public EGraphQLQuery(String queryName) {
+    super("query", queryName);
+  }
+
+  public EGraphQLQuery() {
+    super("query");
+  }
+
+  @Override
+  public String getOperationName() {
+    return "e";
+  }
+
+  public static Builder newRequest() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private Set<String> fieldsSet = new HashSet<>();
+
+    private final Map<String, String> variableReferences = new HashMap<>();
+
+    private final List<VariableDefinition> variableDefinitions = new ArrayList<>();
+
+    private String queryName;
+
+    public EGraphQLQuery build() {
+      return new EGraphQLQuery(queryName);                                     
+    }
+
+    public Builder queryName(String queryName) {
+      this.queryName = queryName;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithEnum/expected/client/EProjectionRoot.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithEnum/expected/client/EProjectionRoot.java
@@ -1,0 +1,14 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.projections.projectionWithEnum.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.BaseSubProjectionNode;
+
+public class EProjectionRoot<PARENT extends BaseSubProjectionNode<?, ?>, ROOT extends BaseSubProjectionNode<?, ?>> extends BaseSubProjectionNode<PARENT, ROOT> {
+  public EProjectionRoot() {
+    super(null, null, java.util.Optional.of("E"));
+  }
+
+  public EProjectionRoot<PARENT, ROOT> __typename() {
+    getFields().put("__typename", null);
+    return this;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithEnum/expected/client/EsGraphQLQuery.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithEnum/expected/client/EsGraphQLQuery.java
@@ -1,0 +1,50 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.projections.projectionWithEnum.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.GraphQLQuery;
+import graphql.language.VariableDefinition;
+import java.lang.Override;
+import java.lang.String;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class EsGraphQLQuery extends GraphQLQuery {
+  public EsGraphQLQuery(String queryName) {
+    super("query", queryName);
+  }
+
+  public EsGraphQLQuery() {
+    super("query");
+  }
+
+  @Override
+  public String getOperationName() {
+    return "es";
+  }
+
+  public static Builder newRequest() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private Set<String> fieldsSet = new HashSet<>();
+
+    private final Map<String, String> variableReferences = new HashMap<>();
+
+    private final List<VariableDefinition> variableDefinitions = new ArrayList<>();
+
+    private String queryName;
+
+    public EsGraphQLQuery build() {
+      return new EsGraphQLQuery(queryName);                                     
+    }
+
+    public Builder queryName(String queryName) {
+      this.queryName = queryName;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithEnum/expected/client/EsProjectionRoot.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithEnum/expected/client/EsProjectionRoot.java
@@ -1,0 +1,14 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.projections.projectionWithEnum.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.BaseSubProjectionNode;
+
+public class EsProjectionRoot<PARENT extends BaseSubProjectionNode<?, ?>, ROOT extends BaseSubProjectionNode<?, ?>> extends BaseSubProjectionNode<PARENT, ROOT> {
+  public EsProjectionRoot() {
+    super(null, null, java.util.Optional.of("E"));
+  }
+
+  public EsProjectionRoot<PARENT, ROOT> __typename() {
+    getFields().put("__typename", null);
+    return this;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithEnum/expected/datafetchers/EDatafetcher.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithEnum/expected/datafetchers/EDatafetcher.java
@@ -1,0 +1,17 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.projections.projectionWithEnum.expected.datafetchers;
+
+import com.netflix.graphql.dgs.DgsComponent;
+import com.netflix.graphql.dgs.DgsData;
+import com.netflix.graphql.dgs.codegen.java.testcases.projections.projectionWithEnum.expected.types.E;
+import graphql.schema.DataFetchingEnvironment;
+
+@DgsComponent
+public class EDatafetcher {
+  @DgsData(
+      parentType = "Query",
+      field = "e"
+  )
+  public E getE(DataFetchingEnvironment dataFetchingEnvironment) {
+    return null;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithEnum/expected/datafetchers/EsDatafetcher.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithEnum/expected/datafetchers/EsDatafetcher.java
@@ -1,0 +1,18 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.projections.projectionWithEnum.expected.datafetchers;
+
+import com.netflix.graphql.dgs.DgsComponent;
+import com.netflix.graphql.dgs.DgsData;
+import com.netflix.graphql.dgs.codegen.java.testcases.projections.projectionWithEnum.expected.types.E;
+import graphql.schema.DataFetchingEnvironment;
+import java.util.List;
+
+@DgsComponent
+public class EsDatafetcher {
+  @DgsData(
+      parentType = "Query",
+      field = "es"
+  )
+  public List<E> getEs(DataFetchingEnvironment dataFetchingEnvironment) {
+    return null;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithEnum/expected/types/E.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithEnum/expected/types/E.java
@@ -1,0 +1,5 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.projections.projectionWithEnum.expected.types;
+
+public enum E {
+  V
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithEnum/schema.graphql
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithEnum/schema.graphql
@@ -1,0 +1,8 @@
+type Query {
+  e: E
+  es: [E]
+}
+
+enum E {
+  V
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithNestedInputs/expected/DgsConstants.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithNestedInputs/expected/DgsConstants.java
@@ -1,0 +1,43 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.projections.projectionWithNestedInputs.expected;
+
+import java.lang.String;
+
+public class DgsConstants {
+  public static final String QUERY_TYPE = "Query";
+
+  public static class QUERY {
+    public static final String TYPE_NAME = "Query";
+
+    public static final String Q1 = "q1";
+
+    public static final String Q2 = "q2";
+
+    public static class Q1_INPUT_ARGUMENT {
+      public static final String Arg1 = "arg1";
+
+      public static final String Arg2 = "arg2";
+    }
+
+    public static class Q2_INPUT_ARGUMENT {
+      public static final String Arg1 = "arg1";
+
+      public static final String Arg2 = "arg2";
+    }
+  }
+
+  public static class I1 {
+    public static final String TYPE_NAME = "I1";
+
+    public static final String Arg1 = "arg1";
+
+    public static final String Arg2 = "arg2";
+  }
+
+  public static class I2 {
+    public static final String TYPE_NAME = "I2";
+
+    public static final String Arg1 = "arg1";
+
+    public static final String Arg2 = "arg2";
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithNestedInputs/expected/client/Q1GraphQLQuery.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithNestedInputs/expected/client/Q1GraphQLQuery.java
@@ -1,0 +1,104 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.projections.projectionWithNestedInputs.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.GraphQLQuery;
+import com.netflix.graphql.dgs.codegen.java.testcases.projections.projectionWithNestedInputs.expected.types.I2;
+import graphql.language.VariableDefinition;
+import java.lang.Override;
+import java.lang.String;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class Q1GraphQLQuery extends GraphQLQuery {
+  public Q1GraphQLQuery(String arg1, I2 arg2, String queryName, Set<String> fieldsSet) {
+    super("query", queryName);
+    if (arg1 != null || fieldsSet.contains("arg1")) {
+        getInput().put("arg1", arg1);
+    }if (arg2 != null || fieldsSet.contains("arg2")) {
+        getInput().put("arg2", arg2);
+    }
+  }
+
+  public Q1GraphQLQuery(String arg1, I2 arg2, String queryName, Set<String> fieldsSet,
+      Map<String, String> variableReferences, List<VariableDefinition> variableDefinitions) {
+    super("query", queryName);
+    if (arg1 != null || fieldsSet.contains("arg1")) {
+        getInput().put("arg1", arg1);
+    }if (arg2 != null || fieldsSet.contains("arg2")) {
+        getInput().put("arg2", arg2);
+    }
+    if(variableDefinitions != null) {
+       getVariableDefinitions().addAll(variableDefinitions);
+    }
+
+    if(variableReferences != null) {
+       getVariableReferences().putAll(variableReferences);
+    }                      
+  }
+
+  public Q1GraphQLQuery() {
+    super("query");
+  }
+
+  @Override
+  public String getOperationName() {
+    return "q1";
+  }
+
+  public static Builder newRequest() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private Set<String> fieldsSet = new HashSet<>();
+
+    private final Map<String, String> variableReferences = new HashMap<>();
+
+    private final List<VariableDefinition> variableDefinitions = new ArrayList<>();
+
+    private String arg1;
+
+    private I2 arg2;
+
+    private String queryName;
+
+    public Q1GraphQLQuery build() {
+      return new Q1GraphQLQuery(arg1, arg2, queryName, fieldsSet, variableReferences, variableDefinitions);
+               
+    }
+
+    public Builder arg1(String arg1) {
+      this.arg1 = arg1;
+      this.fieldsSet.add("arg1");
+      return this;
+    }
+
+    public Builder arg1Reference(String variableRef) {
+      this.variableReferences.put("arg1", variableRef);
+      this.variableDefinitions.add(graphql.language.VariableDefinition.newVariableDefinition(variableRef, new graphql.language.TypeName("String")).build());
+      this.fieldsSet.add("arg1");
+      return this;
+    }
+
+    public Builder arg2(I2 arg2) {
+      this.arg2 = arg2;
+      this.fieldsSet.add("arg2");
+      return this;
+    }
+
+    public Builder arg2Reference(String variableRef) {
+      this.variableReferences.put("arg2", variableRef);
+      this.variableDefinitions.add(graphql.language.VariableDefinition.newVariableDefinition(variableRef, new graphql.language.TypeName("I2")).build());
+      this.fieldsSet.add("arg2");
+      return this;
+    }
+
+    public Builder queryName(String queryName) {
+      this.queryName = queryName;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithNestedInputs/expected/client/Q2GraphQLQuery.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithNestedInputs/expected/client/Q2GraphQLQuery.java
@@ -1,0 +1,104 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.projections.projectionWithNestedInputs.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.GraphQLQuery;
+import com.netflix.graphql.dgs.codegen.java.testcases.projections.projectionWithNestedInputs.expected.types.I1;
+import graphql.language.VariableDefinition;
+import java.lang.Override;
+import java.lang.String;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class Q2GraphQLQuery extends GraphQLQuery {
+  public Q2GraphQLQuery(I1 arg1, String arg2, String queryName, Set<String> fieldsSet) {
+    super("query", queryName);
+    if (arg1 != null || fieldsSet.contains("arg1")) {
+        getInput().put("arg1", arg1);
+    }if (arg2 != null || fieldsSet.contains("arg2")) {
+        getInput().put("arg2", arg2);
+    }
+  }
+
+  public Q2GraphQLQuery(I1 arg1, String arg2, String queryName, Set<String> fieldsSet,
+      Map<String, String> variableReferences, List<VariableDefinition> variableDefinitions) {
+    super("query", queryName);
+    if (arg1 != null || fieldsSet.contains("arg1")) {
+        getInput().put("arg1", arg1);
+    }if (arg2 != null || fieldsSet.contains("arg2")) {
+        getInput().put("arg2", arg2);
+    }
+    if(variableDefinitions != null) {
+       getVariableDefinitions().addAll(variableDefinitions);
+    }
+
+    if(variableReferences != null) {
+       getVariableReferences().putAll(variableReferences);
+    }                      
+  }
+
+  public Q2GraphQLQuery() {
+    super("query");
+  }
+
+  @Override
+  public String getOperationName() {
+    return "q2";
+  }
+
+  public static Builder newRequest() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private Set<String> fieldsSet = new HashSet<>();
+
+    private final Map<String, String> variableReferences = new HashMap<>();
+
+    private final List<VariableDefinition> variableDefinitions = new ArrayList<>();
+
+    private I1 arg1;
+
+    private String arg2;
+
+    private String queryName;
+
+    public Q2GraphQLQuery build() {
+      return new Q2GraphQLQuery(arg1, arg2, queryName, fieldsSet, variableReferences, variableDefinitions);
+               
+    }
+
+    public Builder arg1(I1 arg1) {
+      this.arg1 = arg1;
+      this.fieldsSet.add("arg1");
+      return this;
+    }
+
+    public Builder arg1Reference(String variableRef) {
+      this.variableReferences.put("arg1", variableRef);
+      this.variableDefinitions.add(graphql.language.VariableDefinition.newVariableDefinition(variableRef, new graphql.language.TypeName("I1")).build());
+      this.fieldsSet.add("arg1");
+      return this;
+    }
+
+    public Builder arg2(String arg2) {
+      this.arg2 = arg2;
+      this.fieldsSet.add("arg2");
+      return this;
+    }
+
+    public Builder arg2Reference(String variableRef) {
+      this.variableReferences.put("arg2", variableRef);
+      this.variableDefinitions.add(graphql.language.VariableDefinition.newVariableDefinition(variableRef, new graphql.language.TypeName("String")).build());
+      this.fieldsSet.add("arg2");
+      return this;
+    }
+
+    public Builder queryName(String queryName) {
+      this.queryName = queryName;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithNestedInputs/expected/datafetchers/Q1Datafetcher.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithNestedInputs/expected/datafetchers/Q1Datafetcher.java
@@ -1,0 +1,17 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.projections.projectionWithNestedInputs.expected.datafetchers;
+
+import com.netflix.graphql.dgs.DgsComponent;
+import com.netflix.graphql.dgs.DgsData;
+import graphql.schema.DataFetchingEnvironment;
+import java.lang.String;
+
+@DgsComponent
+public class Q1Datafetcher {
+  @DgsData(
+      parentType = "Query",
+      field = "q1"
+  )
+  public String getQ1(DataFetchingEnvironment dataFetchingEnvironment) {
+    return "";
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithNestedInputs/expected/datafetchers/Q2Datafetcher.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithNestedInputs/expected/datafetchers/Q2Datafetcher.java
@@ -1,0 +1,17 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.projections.projectionWithNestedInputs.expected.datafetchers;
+
+import com.netflix.graphql.dgs.DgsComponent;
+import com.netflix.graphql.dgs.DgsData;
+import graphql.schema.DataFetchingEnvironment;
+import java.lang.String;
+
+@DgsComponent
+public class Q2Datafetcher {
+  @DgsData(
+      parentType = "Query",
+      field = "q2"
+  )
+  public String getQ2(DataFetchingEnvironment dataFetchingEnvironment) {
+    return "";
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithNestedInputs/expected/types/I1.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithNestedInputs/expected/types/I1.java
@@ -1,0 +1,82 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.projections.projectionWithNestedInputs.expected.types;
+
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.util.Objects;
+
+public class I1 {
+  private I1 arg1;
+
+  private I2 arg2;
+
+  public I1() {
+  }
+
+  public I1(I1 arg1, I2 arg2) {
+    this.arg1 = arg1;
+    this.arg2 = arg2;
+  }
+
+  public I1 getArg1() {
+    return arg1;
+  }
+
+  public void setArg1(I1 arg1) {
+    this.arg1 = arg1;
+  }
+
+  public I2 getArg2() {
+    return arg2;
+  }
+
+  public void setArg2(I2 arg2) {
+    this.arg2 = arg2;
+  }
+
+  @Override
+  public String toString() {
+    return "I1{arg1='" + arg1 + "', arg2='" + arg2 + "'}";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    I1 that = (I1) o;
+    return Objects.equals(arg1, that.arg1) &&
+        Objects.equals(arg2, that.arg2);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(arg1, arg2);
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private I1 arg1;
+
+    private I2 arg2;
+
+    public I1 build() {
+      I1 result = new I1();
+      result.arg1 = this.arg1;
+      result.arg2 = this.arg2;
+      return result;
+    }
+
+    public Builder arg1(I1 arg1) {
+      this.arg1 = arg1;
+      return this;
+    }
+
+    public Builder arg2(I2 arg2) {
+      this.arg2 = arg2;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithNestedInputs/expected/types/I2.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithNestedInputs/expected/types/I2.java
@@ -1,0 +1,82 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.projections.projectionWithNestedInputs.expected.types;
+
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.util.Objects;
+
+public class I2 {
+  private String arg1;
+
+  private String arg2;
+
+  public I2() {
+  }
+
+  public I2(String arg1, String arg2) {
+    this.arg1 = arg1;
+    this.arg2 = arg2;
+  }
+
+  public String getArg1() {
+    return arg1;
+  }
+
+  public void setArg1(String arg1) {
+    this.arg1 = arg1;
+  }
+
+  public String getArg2() {
+    return arg2;
+  }
+
+  public void setArg2(String arg2) {
+    this.arg2 = arg2;
+  }
+
+  @Override
+  public String toString() {
+    return "I2{arg1='" + arg1 + "', arg2='" + arg2 + "'}";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    I2 that = (I2) o;
+    return Objects.equals(arg1, that.arg1) &&
+        Objects.equals(arg2, that.arg2);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(arg1, arg2);
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private String arg1;
+
+    private String arg2;
+
+    public I2 build() {
+      I2 result = new I2();
+      result.arg1 = this.arg1;
+      result.arg2 = this.arg2;
+      return result;
+    }
+
+    public Builder arg1(String arg1) {
+      this.arg1 = arg1;
+      return this;
+    }
+
+    public Builder arg2(String arg2) {
+      this.arg2 = arg2;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithNestedInputs/schema.graphql
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithNestedInputs/schema.graphql
@@ -1,0 +1,16 @@
+# note that it's important for this test that all of the argument names are the same
+
+type Query {
+  q1(arg1: String, arg2: I2): String
+  q2(arg1: I1, arg2: String): String
+}
+
+input I1 {
+  arg1: I1
+  arg2: I2
+}
+
+input I2 {
+  arg1: String
+  arg2: String
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithNestedInputs/test/ProjectionWithNestedInputsQueryTest.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithNestedInputs/test/ProjectionWithNestedInputsQueryTest.java
@@ -1,0 +1,68 @@
+/*
+ *
+ *  Copyright 2020 Netflix, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package com.netflix.graphql.dgs.codegen.java.testcases.projections.projectionWithNestedInputs.test;
+
+import com.netflix.graphql.dgs.client.codegen.GraphQLQueryRequest;
+import com.netflix.graphql.dgs.codegen.java.testcases.projections.projectionWithNestedInputs.expected.client.Q1GraphQLQuery;
+import com.netflix.graphql.dgs.codegen.java.testcases.projections.projectionWithNestedInputs.expected.client.Q2GraphQLQuery;
+import com.netflix.graphql.dgs.codegen.java.testcases.projections.projectionWithNestedInputs.expected.types.I1;
+import com.netflix.graphql.dgs.codegen.java.testcases.projections.projectionWithNestedInputs.expected.types.I2;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ProjectionWithNestedInputsQueryTest {
+
+    @Test
+    void testWipeSameNameDifferentClass() {
+        var query = Q1GraphQLQuery.newRequest()
+                .queryName("TestQuery")
+                .arg2(I2.newBuilder()
+                        .arg2("")
+                        .build())
+                .build();
+
+        var request = new GraphQLQueryRequest(query);
+
+        assertThat(request.serialize())
+                .isEqualTo("""
+                        query TestQuery {
+                          q1(arg2: {arg2 : ""})
+                        }""");
+    }
+
+    @Test
+    void testWipeSameNameSameClass() {
+        var query = Q2GraphQLQuery.newRequest()
+                .queryName("TestQuery")
+                .arg1(I1.newBuilder()
+                        .arg1(new I1())
+                        .build())
+                .build();
+
+        var request = new GraphQLQueryRequest(query);
+
+        assertThat(request.serialize())
+                .isEqualTo("""
+                        query TestQuery {
+                          q2(arg1: {arg1 : {}})
+                        }""");
+    }
+
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithPrimitiveAndArgs/expected/DgsConstants.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithPrimitiveAndArgs/expected/DgsConstants.java
@@ -1,0 +1,27 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.projections.projectionWithPrimitiveAndArgs.expected;
+
+import java.lang.String;
+
+public class DgsConstants {
+  public static final String QUERY_TYPE = "Query";
+
+  public static class QUERY {
+    public static final String TYPE_NAME = "Query";
+
+    public static final String String = "string";
+
+    public static class STRING_INPUT_ARGUMENT {
+      public static final String A1 = "a1";
+
+      public static final String A2 = "a2";
+
+      public static final String A3 = "a3";
+    }
+  }
+
+  public static class I {
+    public static final String TYPE_NAME = "I";
+
+    public static final String Arg = "arg";
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithPrimitiveAndArgs/expected/client/StringGraphQLQuery.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithPrimitiveAndArgs/expected/client/StringGraphQLQuery.java
@@ -1,0 +1,123 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.projections.projectionWithPrimitiveAndArgs.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.GraphQLQuery;
+import com.netflix.graphql.dgs.codegen.java.testcases.projections.projectionWithPrimitiveAndArgs.expected.types.I;
+import graphql.language.VariableDefinition;
+import java.lang.Override;
+import java.lang.String;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class StringGraphQLQuery extends GraphQLQuery {
+  public StringGraphQLQuery(String a1, String a2, I a3, String queryName, Set<String> fieldsSet) {
+    super("query", queryName);
+    if (a1 != null || fieldsSet.contains("a1")) {
+        getInput().put("a1", a1);
+    }if (a2 != null || fieldsSet.contains("a2")) {
+        getInput().put("a2", a2);
+    }if (a3 != null || fieldsSet.contains("a3")) {
+        getInput().put("a3", a3);
+    }
+  }
+
+  public StringGraphQLQuery(String a1, String a2, I a3, String queryName, Set<String> fieldsSet,
+      Map<String, String> variableReferences, List<VariableDefinition> variableDefinitions) {
+    super("query", queryName);
+    if (a1 != null || fieldsSet.contains("a1")) {
+        getInput().put("a1", a1);
+    }if (a2 != null || fieldsSet.contains("a2")) {
+        getInput().put("a2", a2);
+    }if (a3 != null || fieldsSet.contains("a3")) {
+        getInput().put("a3", a3);
+    }
+    if(variableDefinitions != null) {
+       getVariableDefinitions().addAll(variableDefinitions);
+    }
+
+    if(variableReferences != null) {
+       getVariableReferences().putAll(variableReferences);
+    }                      
+  }
+
+  public StringGraphQLQuery() {
+    super("query");
+  }
+
+  @Override
+  public String getOperationName() {
+    return "string";
+  }
+
+  public static Builder newRequest() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private Set<String> fieldsSet = new HashSet<>();
+
+    private final Map<String, String> variableReferences = new HashMap<>();
+
+    private final List<VariableDefinition> variableDefinitions = new ArrayList<>();
+
+    private String a1;
+
+    private String a2;
+
+    private I a3;
+
+    private String queryName;
+
+    public StringGraphQLQuery build() {
+      return new StringGraphQLQuery(a1, a2, a3, queryName, fieldsSet, variableReferences, variableDefinitions);
+               
+    }
+
+    public Builder a1(String a1) {
+      this.a1 = a1;
+      this.fieldsSet.add("a1");
+      return this;
+    }
+
+    public Builder a1Reference(String variableRef) {
+      this.variableReferences.put("a1", variableRef);
+      this.variableDefinitions.add(graphql.language.VariableDefinition.newVariableDefinition(variableRef, new graphql.language.TypeName("String")).build());
+      this.fieldsSet.add("a1");
+      return this;
+    }
+
+    public Builder a2(String a2) {
+      this.a2 = a2;
+      this.fieldsSet.add("a2");
+      return this;
+    }
+
+    public Builder a2Reference(String variableRef) {
+      this.variableReferences.put("a2", variableRef);
+      this.variableDefinitions.add(graphql.language.VariableDefinition.newVariableDefinition(variableRef, new graphql.language.NonNullType(new graphql.language.TypeName("String"))).build());
+      this.fieldsSet.add("a2");
+      return this;
+    }
+
+    public Builder a3(I a3) {
+      this.a3 = a3;
+      this.fieldsSet.add("a3");
+      return this;
+    }
+
+    public Builder a3Reference(String variableRef) {
+      this.variableReferences.put("a3", variableRef);
+      this.variableDefinitions.add(graphql.language.VariableDefinition.newVariableDefinition(variableRef, new graphql.language.TypeName("I")).build());
+      this.fieldsSet.add("a3");
+      return this;
+    }
+
+    public Builder queryName(String queryName) {
+      this.queryName = queryName;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithPrimitiveAndArgs/expected/datafetchers/StringDatafetcher.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithPrimitiveAndArgs/expected/datafetchers/StringDatafetcher.java
@@ -1,0 +1,17 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.projections.projectionWithPrimitiveAndArgs.expected.datafetchers;
+
+import com.netflix.graphql.dgs.DgsComponent;
+import com.netflix.graphql.dgs.DgsData;
+import graphql.schema.DataFetchingEnvironment;
+import java.lang.String;
+
+@DgsComponent
+public class StringDatafetcher {
+  @DgsData(
+      parentType = "Query",
+      field = "string"
+  )
+  public String getString(DataFetchingEnvironment dataFetchingEnvironment) {
+    return "";
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithPrimitiveAndArgs/expected/types/I.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithPrimitiveAndArgs/expected/types/I.java
@@ -1,0 +1,62 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.projections.projectionWithPrimitiveAndArgs.expected.types;
+
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.util.Objects;
+
+public class I {
+  private String arg;
+
+  public I() {
+  }
+
+  public I(String arg) {
+    this.arg = arg;
+  }
+
+  public String getArg() {
+    return arg;
+  }
+
+  public void setArg(String arg) {
+    this.arg = arg;
+  }
+
+  @Override
+  public String toString() {
+    return "I{arg='" + arg + "'}";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    I that = (I) o;
+    return Objects.equals(arg, that.arg);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(arg);
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private String arg;
+
+    public I build() {
+      I result = new I();
+      result.arg = this.arg;
+      return result;
+    }
+
+    public Builder arg(String arg) {
+      this.arg = arg;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithPrimitiveAndArgs/schema.graphql
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithPrimitiveAndArgs/schema.graphql
@@ -1,0 +1,7 @@
+type Query {
+  string(a1: String, a2: String!, a3: I): String
+}
+
+input I {
+  arg: String
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithPrimitives/expected/DgsConstants.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithPrimitives/expected/DgsConstants.java
@@ -1,0 +1,15 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.projections.projectionWithPrimitives.expected;
+
+import java.lang.String;
+
+public class DgsConstants {
+  public static final String QUERY_TYPE = "Query";
+
+  public static class QUERY {
+    public static final String TYPE_NAME = "Query";
+
+    public static final String String = "string";
+
+    public static final String Strings = "strings";
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithPrimitives/expected/client/StringGraphQLQuery.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithPrimitives/expected/client/StringGraphQLQuery.java
@@ -1,0 +1,50 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.projections.projectionWithPrimitives.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.GraphQLQuery;
+import graphql.language.VariableDefinition;
+import java.lang.Override;
+import java.lang.String;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class StringGraphQLQuery extends GraphQLQuery {
+  public StringGraphQLQuery(String queryName) {
+    super("query", queryName);
+  }
+
+  public StringGraphQLQuery() {
+    super("query");
+  }
+
+  @Override
+  public String getOperationName() {
+    return "string";
+  }
+
+  public static Builder newRequest() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private Set<String> fieldsSet = new HashSet<>();
+
+    private final Map<String, String> variableReferences = new HashMap<>();
+
+    private final List<VariableDefinition> variableDefinitions = new ArrayList<>();
+
+    private String queryName;
+
+    public StringGraphQLQuery build() {
+      return new StringGraphQLQuery(queryName);                                     
+    }
+
+    public Builder queryName(String queryName) {
+      this.queryName = queryName;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithPrimitives/expected/client/StringsGraphQLQuery.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithPrimitives/expected/client/StringsGraphQLQuery.java
@@ -1,0 +1,50 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.projections.projectionWithPrimitives.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.GraphQLQuery;
+import graphql.language.VariableDefinition;
+import java.lang.Override;
+import java.lang.String;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class StringsGraphQLQuery extends GraphQLQuery {
+  public StringsGraphQLQuery(String queryName) {
+    super("query", queryName);
+  }
+
+  public StringsGraphQLQuery() {
+    super("query");
+  }
+
+  @Override
+  public String getOperationName() {
+    return "strings";
+  }
+
+  public static Builder newRequest() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private Set<String> fieldsSet = new HashSet<>();
+
+    private final Map<String, String> variableReferences = new HashMap<>();
+
+    private final List<VariableDefinition> variableDefinitions = new ArrayList<>();
+
+    private String queryName;
+
+    public StringsGraphQLQuery build() {
+      return new StringsGraphQLQuery(queryName);                                     
+    }
+
+    public Builder queryName(String queryName) {
+      this.queryName = queryName;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithPrimitives/expected/datafetchers/StringDatafetcher.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithPrimitives/expected/datafetchers/StringDatafetcher.java
@@ -1,0 +1,17 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.projections.projectionWithPrimitives.expected.datafetchers;
+
+import com.netflix.graphql.dgs.DgsComponent;
+import com.netflix.graphql.dgs.DgsData;
+import graphql.schema.DataFetchingEnvironment;
+import java.lang.String;
+
+@DgsComponent
+public class StringDatafetcher {
+  @DgsData(
+      parentType = "Query",
+      field = "string"
+  )
+  public String getString(DataFetchingEnvironment dataFetchingEnvironment) {
+    return "";
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithPrimitives/expected/datafetchers/StringsDatafetcher.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithPrimitives/expected/datafetchers/StringsDatafetcher.java
@@ -1,0 +1,18 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.projections.projectionWithPrimitives.expected.datafetchers;
+
+import com.netflix.graphql.dgs.DgsComponent;
+import com.netflix.graphql.dgs.DgsData;
+import graphql.schema.DataFetchingEnvironment;
+import java.lang.String;
+import java.util.List;
+
+@DgsComponent
+public class StringsDatafetcher {
+  @DgsData(
+      parentType = "Query",
+      field = "strings"
+  )
+  public List<String> getStrings(DataFetchingEnvironment dataFetchingEnvironment) {
+    return null;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithPrimitives/schema.graphql
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithPrimitives/schema.graphql
@@ -1,0 +1,4 @@
+type Query {
+  string: String
+  strings: [String]
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithType/expected/DgsConstants.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithType/expected/DgsConstants.java
@@ -1,0 +1,29 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.projections.projectionWithType.expected;
+
+import java.lang.String;
+
+public class DgsConstants {
+  public static final String QUERY_TYPE = "Query";
+
+  public static class QUERY {
+    public static final String TYPE_NAME = "Query";
+
+    public static final String Person = "person";
+
+    public static final String People = "people";
+  }
+
+  public static class EMPLOYEE {
+    public static final String TYPE_NAME = "Employee";
+
+    public static final String Firstname = "firstname";
+
+    public static final String Company = "company";
+  }
+
+  public static class PERSON {
+    public static final String TYPE_NAME = "Person";
+
+    public static final String Firstname = "firstname";
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithType/expected/client/EmployeeFragmentProjection.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithType/expected/client/EmployeeFragmentProjection.java
@@ -1,0 +1,45 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.projections.projectionWithType.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.BaseSubProjectionNode;
+import java.lang.Override;
+import java.lang.String;
+
+public class EmployeeFragmentProjection<PARENT extends BaseSubProjectionNode<?, ?>, ROOT extends BaseSubProjectionNode<?, ?>> extends BaseSubProjectionNode<PARENT, ROOT> {
+  {
+    getFields().put("__typename", null);
+  }
+
+  public EmployeeFragmentProjection(PARENT parent, ROOT root) {
+    super(parent, root, java.util.Optional.of("Employee"));
+  }
+
+  public EmployeeFragmentProjection<PARENT, ROOT> __typename() {
+    getFields().put("__typename", null);
+    return this;
+  }
+
+  public EmployeeFragmentProjection<PARENT, ROOT> firstname() {
+    getFields().put("firstname", null);
+    return this;
+  }
+
+  public EmployeeFragmentProjection<PARENT, ROOT> company() {
+    getFields().put("company", null);
+    return this;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder builder = new StringBuilder();
+    builder.append("... on Employee {");
+    getFields().forEach((k, v) -> {
+        builder.append(" ").append(k);
+        if(v != null) {
+            builder.append(" ").append(v.toString());
+        }
+    });
+    builder.append("}");
+     
+    return builder.toString();
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithType/expected/client/PeopleGraphQLQuery.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithType/expected/client/PeopleGraphQLQuery.java
@@ -1,0 +1,50 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.projections.projectionWithType.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.GraphQLQuery;
+import graphql.language.VariableDefinition;
+import java.lang.Override;
+import java.lang.String;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class PeopleGraphQLQuery extends GraphQLQuery {
+  public PeopleGraphQLQuery(String queryName) {
+    super("query", queryName);
+  }
+
+  public PeopleGraphQLQuery() {
+    super("query");
+  }
+
+  @Override
+  public String getOperationName() {
+    return "people";
+  }
+
+  public static Builder newRequest() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private Set<String> fieldsSet = new HashSet<>();
+
+    private final Map<String, String> variableReferences = new HashMap<>();
+
+    private final List<VariableDefinition> variableDefinitions = new ArrayList<>();
+
+    private String queryName;
+
+    public PeopleGraphQLQuery build() {
+      return new PeopleGraphQLQuery(queryName);                                     
+    }
+
+    public Builder queryName(String queryName) {
+      this.queryName = queryName;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithType/expected/client/PeopleProjectionRoot.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithType/expected/client/PeopleProjectionRoot.java
@@ -1,0 +1,26 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.projections.projectionWithType.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.BaseSubProjectionNode;
+
+public class PeopleProjectionRoot<PARENT extends BaseSubProjectionNode<?, ?>, ROOT extends BaseSubProjectionNode<?, ?>> extends BaseSubProjectionNode<PARENT, ROOT> {
+  public PeopleProjectionRoot() {
+    super(null, null, java.util.Optional.of("Person"));
+  }
+
+  public PeopleProjectionRoot<PARENT, ROOT> __typename() {
+    getFields().put("__typename", null);
+    return this;
+  }
+
+  public PeopleProjectionRoot<PARENT, ROOT> firstname() {
+    getFields().put("firstname", null);
+    return this;
+  }
+
+  public EmployeeFragmentProjection<PeopleProjectionRoot<PARENT, ROOT>, PeopleProjectionRoot<PARENT, ROOT>> onEmployee(
+      ) {
+    EmployeeFragmentProjection<PeopleProjectionRoot<PARENT, ROOT>, PeopleProjectionRoot<PARENT, ROOT>> fragment = new EmployeeFragmentProjection<>(this, this);
+    getFragments().add(fragment);
+    return fragment;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithType/expected/client/PersonGraphQLQuery.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithType/expected/client/PersonGraphQLQuery.java
@@ -1,0 +1,50 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.projections.projectionWithType.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.GraphQLQuery;
+import graphql.language.VariableDefinition;
+import java.lang.Override;
+import java.lang.String;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class PersonGraphQLQuery extends GraphQLQuery {
+  public PersonGraphQLQuery(String queryName) {
+    super("query", queryName);
+  }
+
+  public PersonGraphQLQuery() {
+    super("query");
+  }
+
+  @Override
+  public String getOperationName() {
+    return "person";
+  }
+
+  public static Builder newRequest() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private Set<String> fieldsSet = new HashSet<>();
+
+    private final Map<String, String> variableReferences = new HashMap<>();
+
+    private final List<VariableDefinition> variableDefinitions = new ArrayList<>();
+
+    private String queryName;
+
+    public PersonGraphQLQuery build() {
+      return new PersonGraphQLQuery(queryName);                                     
+    }
+
+    public Builder queryName(String queryName) {
+      this.queryName = queryName;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithType/expected/client/PersonProjectionRoot.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithType/expected/client/PersonProjectionRoot.java
@@ -1,0 +1,26 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.projections.projectionWithType.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.BaseSubProjectionNode;
+
+public class PersonProjectionRoot<PARENT extends BaseSubProjectionNode<?, ?>, ROOT extends BaseSubProjectionNode<?, ?>> extends BaseSubProjectionNode<PARENT, ROOT> {
+  public PersonProjectionRoot() {
+    super(null, null, java.util.Optional.of("Person"));
+  }
+
+  public PersonProjectionRoot<PARENT, ROOT> __typename() {
+    getFields().put("__typename", null);
+    return this;
+  }
+
+  public PersonProjectionRoot<PARENT, ROOT> firstname() {
+    getFields().put("firstname", null);
+    return this;
+  }
+
+  public EmployeeFragmentProjection<PersonProjectionRoot<PARENT, ROOT>, PersonProjectionRoot<PARENT, ROOT>> onEmployee(
+      ) {
+    EmployeeFragmentProjection<PersonProjectionRoot<PARENT, ROOT>, PersonProjectionRoot<PARENT, ROOT>> fragment = new EmployeeFragmentProjection<>(this, this);
+    getFragments().add(fragment);
+    return fragment;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithType/expected/datafetchers/PeopleDatafetcher.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithType/expected/datafetchers/PeopleDatafetcher.java
@@ -1,0 +1,18 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.projections.projectionWithType.expected.datafetchers;
+
+import com.netflix.graphql.dgs.DgsComponent;
+import com.netflix.graphql.dgs.DgsData;
+import com.netflix.graphql.dgs.codegen.java.testcases.projections.projectionWithType.expected.types.Person;
+import graphql.schema.DataFetchingEnvironment;
+import java.util.List;
+
+@DgsComponent
+public class PeopleDatafetcher {
+  @DgsData(
+      parentType = "Query",
+      field = "people"
+  )
+  public List<Person> getPeople(DataFetchingEnvironment dataFetchingEnvironment) {
+    return null;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithType/expected/datafetchers/PersonDatafetcher.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithType/expected/datafetchers/PersonDatafetcher.java
@@ -1,0 +1,17 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.projections.projectionWithType.expected.datafetchers;
+
+import com.netflix.graphql.dgs.DgsComponent;
+import com.netflix.graphql.dgs.DgsData;
+import com.netflix.graphql.dgs.codegen.java.testcases.projections.projectionWithType.expected.types.Person;
+import graphql.schema.DataFetchingEnvironment;
+
+@DgsComponent
+public class PersonDatafetcher {
+  @DgsData(
+      parentType = "Query",
+      field = "person"
+  )
+  public Person getPerson(DataFetchingEnvironment dataFetchingEnvironment) {
+    return null;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithType/expected/types/Employee.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithType/expected/types/Employee.java
@@ -1,0 +1,86 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.projections.projectionWithType.expected.types;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.util.Objects;
+
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NONE
+)
+public class Employee implements com.netflix.graphql.dgs.codegen.java.testcases.projections.projectionWithType.expected.types.Person {
+  private String firstname;
+
+  private String company;
+
+  public Employee() {
+  }
+
+  public Employee(String firstname, String company) {
+    this.firstname = firstname;
+    this.company = company;
+  }
+
+  public String getFirstname() {
+    return firstname;
+  }
+
+  public void setFirstname(String firstname) {
+    this.firstname = firstname;
+  }
+
+  public String getCompany() {
+    return company;
+  }
+
+  public void setCompany(String company) {
+    this.company = company;
+  }
+
+  @Override
+  public String toString() {
+    return "Employee{firstname='" + firstname + "', company='" + company + "'}";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    Employee that = (Employee) o;
+    return Objects.equals(firstname, that.firstname) &&
+        Objects.equals(company, that.company);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(firstname, company);
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private String firstname;
+
+    private String company;
+
+    public Employee build() {
+      Employee result = new Employee();
+      result.firstname = this.firstname;
+      result.company = this.company;
+      return result;
+    }
+
+    public Builder firstname(String firstname) {
+      this.firstname = firstname;
+      return this;
+    }
+
+    public Builder company(String company) {
+      this.company = company;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithType/expected/types/Person.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithType/expected/types/Person.java
@@ -1,0 +1,17 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.projections.projectionWithType.expected.types;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import java.lang.String;
+
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NAME,
+    include = JsonTypeInfo.As.PROPERTY,
+    property = "__typename"
+)
+@JsonSubTypes(@JsonSubTypes.Type(value = Employee.class, name = "Employee"))
+public interface Person {
+  String getFirstname();
+
+  void setFirstname(String firstname);
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithType/schema.graphql
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithType/schema.graphql
@@ -1,0 +1,13 @@
+type Query {
+  person: Person
+  people: [Person]
+}
+
+interface Person {
+  firstname: String
+}
+
+type Employee implements Person {
+  firstname: String
+  company: String
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithTypeAndArgs/expected/DgsConstants.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithTypeAndArgs/expected/DgsConstants.java
@@ -1,0 +1,41 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.projections.projectionWithTypeAndArgs.expected;
+
+import java.lang.String;
+
+public class DgsConstants {
+  public static final String QUERY_TYPE = "Query";
+
+  public static class QUERY {
+    public static final String TYPE_NAME = "Query";
+
+    public static final String Person = "person";
+
+    public static class PERSON_INPUT_ARGUMENT {
+      public static final String A1 = "a1";
+
+      public static final String A2 = "a2";
+
+      public static final String A3 = "a3";
+    }
+  }
+
+  public static class EMPLOYEE {
+    public static final String TYPE_NAME = "Employee";
+
+    public static final String Firstname = "firstname";
+
+    public static final String Company = "company";
+  }
+
+  public static class I {
+    public static final String TYPE_NAME = "I";
+
+    public static final String Arg = "arg";
+  }
+
+  public static class PERSON {
+    public static final String TYPE_NAME = "Person";
+
+    public static final String Firstname = "firstname";
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithTypeAndArgs/expected/client/EmployeeFragmentProjection.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithTypeAndArgs/expected/client/EmployeeFragmentProjection.java
@@ -1,0 +1,45 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.projections.projectionWithTypeAndArgs.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.BaseSubProjectionNode;
+import java.lang.Override;
+import java.lang.String;
+
+public class EmployeeFragmentProjection<PARENT extends BaseSubProjectionNode<?, ?>, ROOT extends BaseSubProjectionNode<?, ?>> extends BaseSubProjectionNode<PARENT, ROOT> {
+  {
+    getFields().put("__typename", null);
+  }
+
+  public EmployeeFragmentProjection(PARENT parent, ROOT root) {
+    super(parent, root, java.util.Optional.of("Employee"));
+  }
+
+  public EmployeeFragmentProjection<PARENT, ROOT> __typename() {
+    getFields().put("__typename", null);
+    return this;
+  }
+
+  public EmployeeFragmentProjection<PARENT, ROOT> firstname() {
+    getFields().put("firstname", null);
+    return this;
+  }
+
+  public EmployeeFragmentProjection<PARENT, ROOT> company() {
+    getFields().put("company", null);
+    return this;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder builder = new StringBuilder();
+    builder.append("... on Employee {");
+    getFields().forEach((k, v) -> {
+        builder.append(" ").append(k);
+        if(v != null) {
+            builder.append(" ").append(v.toString());
+        }
+    });
+    builder.append("}");
+     
+    return builder.toString();
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithTypeAndArgs/expected/client/PersonGraphQLQuery.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithTypeAndArgs/expected/client/PersonGraphQLQuery.java
@@ -1,0 +1,123 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.projections.projectionWithTypeAndArgs.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.GraphQLQuery;
+import com.netflix.graphql.dgs.codegen.java.testcases.projections.projectionWithTypeAndArgs.expected.types.I;
+import graphql.language.VariableDefinition;
+import java.lang.Override;
+import java.lang.String;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class PersonGraphQLQuery extends GraphQLQuery {
+  public PersonGraphQLQuery(String a1, String a2, I a3, String queryName, Set<String> fieldsSet) {
+    super("query", queryName);
+    if (a1 != null || fieldsSet.contains("a1")) {
+        getInput().put("a1", a1);
+    }if (a2 != null || fieldsSet.contains("a2")) {
+        getInput().put("a2", a2);
+    }if (a3 != null || fieldsSet.contains("a3")) {
+        getInput().put("a3", a3);
+    }
+  }
+
+  public PersonGraphQLQuery(String a1, String a2, I a3, String queryName, Set<String> fieldsSet,
+      Map<String, String> variableReferences, List<VariableDefinition> variableDefinitions) {
+    super("query", queryName);
+    if (a1 != null || fieldsSet.contains("a1")) {
+        getInput().put("a1", a1);
+    }if (a2 != null || fieldsSet.contains("a2")) {
+        getInput().put("a2", a2);
+    }if (a3 != null || fieldsSet.contains("a3")) {
+        getInput().put("a3", a3);
+    }
+    if(variableDefinitions != null) {
+       getVariableDefinitions().addAll(variableDefinitions);
+    }
+
+    if(variableReferences != null) {
+       getVariableReferences().putAll(variableReferences);
+    }                      
+  }
+
+  public PersonGraphQLQuery() {
+    super("query");
+  }
+
+  @Override
+  public String getOperationName() {
+    return "person";
+  }
+
+  public static Builder newRequest() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private Set<String> fieldsSet = new HashSet<>();
+
+    private final Map<String, String> variableReferences = new HashMap<>();
+
+    private final List<VariableDefinition> variableDefinitions = new ArrayList<>();
+
+    private String a1;
+
+    private String a2;
+
+    private I a3;
+
+    private String queryName;
+
+    public PersonGraphQLQuery build() {
+      return new PersonGraphQLQuery(a1, a2, a3, queryName, fieldsSet, variableReferences, variableDefinitions);
+               
+    }
+
+    public Builder a1(String a1) {
+      this.a1 = a1;
+      this.fieldsSet.add("a1");
+      return this;
+    }
+
+    public Builder a1Reference(String variableRef) {
+      this.variableReferences.put("a1", variableRef);
+      this.variableDefinitions.add(graphql.language.VariableDefinition.newVariableDefinition(variableRef, new graphql.language.TypeName("String")).build());
+      this.fieldsSet.add("a1");
+      return this;
+    }
+
+    public Builder a2(String a2) {
+      this.a2 = a2;
+      this.fieldsSet.add("a2");
+      return this;
+    }
+
+    public Builder a2Reference(String variableRef) {
+      this.variableReferences.put("a2", variableRef);
+      this.variableDefinitions.add(graphql.language.VariableDefinition.newVariableDefinition(variableRef, new graphql.language.NonNullType(new graphql.language.TypeName("String"))).build());
+      this.fieldsSet.add("a2");
+      return this;
+    }
+
+    public Builder a3(I a3) {
+      this.a3 = a3;
+      this.fieldsSet.add("a3");
+      return this;
+    }
+
+    public Builder a3Reference(String variableRef) {
+      this.variableReferences.put("a3", variableRef);
+      this.variableDefinitions.add(graphql.language.VariableDefinition.newVariableDefinition(variableRef, new graphql.language.TypeName("I")).build());
+      this.fieldsSet.add("a3");
+      return this;
+    }
+
+    public Builder queryName(String queryName) {
+      this.queryName = queryName;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithTypeAndArgs/expected/client/PersonProjectionRoot.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithTypeAndArgs/expected/client/PersonProjectionRoot.java
@@ -1,0 +1,26 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.projections.projectionWithTypeAndArgs.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.BaseSubProjectionNode;
+
+public class PersonProjectionRoot<PARENT extends BaseSubProjectionNode<?, ?>, ROOT extends BaseSubProjectionNode<?, ?>> extends BaseSubProjectionNode<PARENT, ROOT> {
+  public PersonProjectionRoot() {
+    super(null, null, java.util.Optional.of("Person"));
+  }
+
+  public PersonProjectionRoot<PARENT, ROOT> __typename() {
+    getFields().put("__typename", null);
+    return this;
+  }
+
+  public PersonProjectionRoot<PARENT, ROOT> firstname() {
+    getFields().put("firstname", null);
+    return this;
+  }
+
+  public EmployeeFragmentProjection<PersonProjectionRoot<PARENT, ROOT>, PersonProjectionRoot<PARENT, ROOT>> onEmployee(
+      ) {
+    EmployeeFragmentProjection<PersonProjectionRoot<PARENT, ROOT>, PersonProjectionRoot<PARENT, ROOT>> fragment = new EmployeeFragmentProjection<>(this, this);
+    getFragments().add(fragment);
+    return fragment;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithTypeAndArgs/expected/datafetchers/PersonDatafetcher.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithTypeAndArgs/expected/datafetchers/PersonDatafetcher.java
@@ -1,0 +1,17 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.projections.projectionWithTypeAndArgs.expected.datafetchers;
+
+import com.netflix.graphql.dgs.DgsComponent;
+import com.netflix.graphql.dgs.DgsData;
+import com.netflix.graphql.dgs.codegen.java.testcases.projections.projectionWithTypeAndArgs.expected.types.Person;
+import graphql.schema.DataFetchingEnvironment;
+
+@DgsComponent
+public class PersonDatafetcher {
+  @DgsData(
+      parentType = "Query",
+      field = "person"
+  )
+  public Person getPerson(DataFetchingEnvironment dataFetchingEnvironment) {
+    return null;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithTypeAndArgs/expected/types/Employee.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithTypeAndArgs/expected/types/Employee.java
@@ -1,0 +1,86 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.projections.projectionWithTypeAndArgs.expected.types;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.util.Objects;
+
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NONE
+)
+public class Employee implements com.netflix.graphql.dgs.codegen.java.testcases.projections.projectionWithTypeAndArgs.expected.types.Person {
+  private String firstname;
+
+  private String company;
+
+  public Employee() {
+  }
+
+  public Employee(String firstname, String company) {
+    this.firstname = firstname;
+    this.company = company;
+  }
+
+  public String getFirstname() {
+    return firstname;
+  }
+
+  public void setFirstname(String firstname) {
+    this.firstname = firstname;
+  }
+
+  public String getCompany() {
+    return company;
+  }
+
+  public void setCompany(String company) {
+    this.company = company;
+  }
+
+  @Override
+  public String toString() {
+    return "Employee{firstname='" + firstname + "', company='" + company + "'}";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    Employee that = (Employee) o;
+    return Objects.equals(firstname, that.firstname) &&
+        Objects.equals(company, that.company);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(firstname, company);
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private String firstname;
+
+    private String company;
+
+    public Employee build() {
+      Employee result = new Employee();
+      result.firstname = this.firstname;
+      result.company = this.company;
+      return result;
+    }
+
+    public Builder firstname(String firstname) {
+      this.firstname = firstname;
+      return this;
+    }
+
+    public Builder company(String company) {
+      this.company = company;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithTypeAndArgs/expected/types/I.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithTypeAndArgs/expected/types/I.java
@@ -1,0 +1,62 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.projections.projectionWithTypeAndArgs.expected.types;
+
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.util.Objects;
+
+public class I {
+  private String arg;
+
+  public I() {
+  }
+
+  public I(String arg) {
+    this.arg = arg;
+  }
+
+  public String getArg() {
+    return arg;
+  }
+
+  public void setArg(String arg) {
+    this.arg = arg;
+  }
+
+  @Override
+  public String toString() {
+    return "I{arg='" + arg + "'}";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    I that = (I) o;
+    return Objects.equals(arg, that.arg);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(arg);
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private String arg;
+
+    public I build() {
+      I result = new I();
+      result.arg = this.arg;
+      return result;
+    }
+
+    public Builder arg(String arg) {
+      this.arg = arg;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithTypeAndArgs/expected/types/Person.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithTypeAndArgs/expected/types/Person.java
@@ -1,0 +1,17 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.projections.projectionWithTypeAndArgs.expected.types;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import java.lang.String;
+
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NAME,
+    include = JsonTypeInfo.As.PROPERTY,
+    property = "__typename"
+)
+@JsonSubTypes(@JsonSubTypes.Type(value = Employee.class, name = "Employee"))
+public interface Person {
+  String getFirstname();
+
+  void setFirstname(String firstname);
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithTypeAndArgs/schema.graphql
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithTypeAndArgs/schema.graphql
@@ -1,0 +1,16 @@
+type Query {
+  person(a1: String, a2: String!, a3: I): Person
+}
+
+interface Person {
+  firstname: String
+}
+
+type Employee implements Person {
+  firstname: String
+  company: String
+}
+
+input I {
+  arg: String
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithTypeAndArgs/test/ProjectionWithTypeAndArgsQueryTest.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithTypeAndArgs/test/ProjectionWithTypeAndArgsQueryTest.java
@@ -1,0 +1,112 @@
+/*
+ *
+ *  Copyright 2020 Netflix, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package com.netflix.graphql.dgs.codegen.java.testcases.projections.projectionWithTypeAndArgs.test;
+
+import com.netflix.graphql.dgs.client.codegen.GraphQLMultiQueryRequest;
+import com.netflix.graphql.dgs.client.codegen.GraphQLQueryRequest;
+import com.netflix.graphql.dgs.codegen.java.testcases.projections.projectionWithTypeAndArgs.expected.client.PersonGraphQLQuery;
+import com.netflix.graphql.dgs.codegen.java.testcases.projections.projectionWithTypeAndArgs.expected.client.PersonProjectionRoot;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ProjectionWithTypeAndArgsQueryTest {
+
+    @Test
+    void testQueryWithFragment() {
+        var query = PersonGraphQLQuery.newRequest()
+                .queryName("TestQuery")
+                .a2("name")
+                .build();
+
+        var projection = new PersonProjectionRoot<>()
+                .firstname()
+                .onEmployee().company();
+
+        var request = new GraphQLQueryRequest(query, projection);
+
+        assertThat(request.serialize())
+                .isEqualTo("""
+                        query TestQuery {
+                          person(a2: "name") {
+                            firstname
+                            ... on Employee {
+                              __typename
+                              company
+                            }
+                          }
+                        }""");
+    }
+
+    @Test
+    void testQueryWithUnnamedArgs() {
+        var query = new PersonGraphQLQuery("a1", "a2", null, "TestQuery", Set.of());
+
+        var projection = new PersonProjectionRoot<>()
+                .firstname();
+
+        var request = new GraphQLQueryRequest(query, projection);
+
+        assertThat(request.serialize())
+                .isEqualTo("""
+                        query TestQuery {
+                          person(a1: "a1", a2: "a2") {
+                            firstname
+                          }
+                        }""");
+    }
+
+    @Test
+    void testQueryWithAlias() {
+        var query1 = PersonGraphQLQuery.newRequest()
+                .queryName("TestQuery1")
+                .a2("person1")
+                .build();
+        query1.setQueryAlias("person1");
+
+        var query2 = PersonGraphQLQuery.newRequest()
+                .queryName("TestQuery2")
+                .a2("person2")
+                .build();
+        query2.setQueryAlias("person2");
+
+        var projection = new PersonProjectionRoot<>()
+                .firstname();
+
+        var request = new GraphQLMultiQueryRequest(List.of(
+                new GraphQLQueryRequest(query1, projection),
+                new GraphQLQueryRequest(query2, projection)
+        ));
+
+        assertThat(request.serialize())
+                .isEqualTo("""
+                        query TestQuery1 {
+                          person1: person(a2: "person1") {
+                            firstname
+                          }
+                          person2: person(a2: "person2") {
+                            firstname
+                          }
+                        }""");
+    }
+
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithUnion/expected/DgsConstants.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithUnion/expected/DgsConstants.java
@@ -1,0 +1,29 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.projections.projectionWithUnion.expected;
+
+import java.lang.String;
+
+public class DgsConstants {
+  public static final String QUERY_TYPE = "Query";
+
+  public static class QUERY {
+    public static final String TYPE_NAME = "Query";
+
+    public static final String U = "u";
+
+    public static final String Us = "us";
+  }
+
+  public static class EMPLOYEE {
+    public static final String TYPE_NAME = "Employee";
+
+    public static final String Firstname = "firstname";
+
+    public static final String Company = "company";
+  }
+
+  public static class PERSON {
+    public static final String TYPE_NAME = "Person";
+
+    public static final String Firstname = "firstname";
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithUnion/expected/client/EmployeeFragmentProjection.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithUnion/expected/client/EmployeeFragmentProjection.java
@@ -1,0 +1,45 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.projections.projectionWithUnion.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.BaseSubProjectionNode;
+import java.lang.Override;
+import java.lang.String;
+
+public class EmployeeFragmentProjection<PARENT extends BaseSubProjectionNode<?, ?>, ROOT extends BaseSubProjectionNode<?, ?>> extends BaseSubProjectionNode<PARENT, ROOT> {
+  {
+    getFields().put("__typename", null);
+  }
+
+  public EmployeeFragmentProjection(PARENT parent, ROOT root) {
+    super(parent, root, java.util.Optional.of("Employee"));
+  }
+
+  public EmployeeFragmentProjection<PARENT, ROOT> __typename() {
+    getFields().put("__typename", null);
+    return this;
+  }
+
+  public EmployeeFragmentProjection<PARENT, ROOT> firstname() {
+    getFields().put("firstname", null);
+    return this;
+  }
+
+  public EmployeeFragmentProjection<PARENT, ROOT> company() {
+    getFields().put("company", null);
+    return this;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder builder = new StringBuilder();
+    builder.append("... on Employee {");
+    getFields().forEach((k, v) -> {
+        builder.append(" ").append(k);
+        if(v != null) {
+            builder.append(" ").append(v.toString());
+        }
+    });
+    builder.append("}");
+     
+    return builder.toString();
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithUnion/expected/client/UGraphQLQuery.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithUnion/expected/client/UGraphQLQuery.java
@@ -1,0 +1,50 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.projections.projectionWithUnion.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.GraphQLQuery;
+import graphql.language.VariableDefinition;
+import java.lang.Override;
+import java.lang.String;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class UGraphQLQuery extends GraphQLQuery {
+  public UGraphQLQuery(String queryName) {
+    super("query", queryName);
+  }
+
+  public UGraphQLQuery() {
+    super("query");
+  }
+
+  @Override
+  public String getOperationName() {
+    return "u";
+  }
+
+  public static Builder newRequest() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private Set<String> fieldsSet = new HashSet<>();
+
+    private final Map<String, String> variableReferences = new HashMap<>();
+
+    private final List<VariableDefinition> variableDefinitions = new ArrayList<>();
+
+    private String queryName;
+
+    public UGraphQLQuery build() {
+      return new UGraphQLQuery(queryName);                                     
+    }
+
+    public Builder queryName(String queryName) {
+      this.queryName = queryName;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithUnion/expected/client/UProjectionRoot.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithUnion/expected/client/UProjectionRoot.java
@@ -1,0 +1,21 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.projections.projectionWithUnion.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.BaseSubProjectionNode;
+
+public class UProjectionRoot<PARENT extends BaseSubProjectionNode<?, ?>, ROOT extends BaseSubProjectionNode<?, ?>> extends BaseSubProjectionNode<PARENT, ROOT> {
+  public UProjectionRoot() {
+    super(null, null, java.util.Optional.of("U"));
+  }
+
+  public UProjectionRoot<PARENT, ROOT> __typename() {
+    getFields().put("__typename", null);
+    return this;
+  }
+
+  public EmployeeFragmentProjection<UProjectionRoot<PARENT, ROOT>, UProjectionRoot<PARENT, ROOT>> onEmployee(
+      ) {
+    EmployeeFragmentProjection<UProjectionRoot<PARENT, ROOT>, UProjectionRoot<PARENT, ROOT>> fragment = new EmployeeFragmentProjection<>(this, this);
+    getFragments().add(fragment);
+    return fragment;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithUnion/expected/client/UsGraphQLQuery.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithUnion/expected/client/UsGraphQLQuery.java
@@ -1,0 +1,50 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.projections.projectionWithUnion.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.GraphQLQuery;
+import graphql.language.VariableDefinition;
+import java.lang.Override;
+import java.lang.String;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class UsGraphQLQuery extends GraphQLQuery {
+  public UsGraphQLQuery(String queryName) {
+    super("query", queryName);
+  }
+
+  public UsGraphQLQuery() {
+    super("query");
+  }
+
+  @Override
+  public String getOperationName() {
+    return "us";
+  }
+
+  public static Builder newRequest() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private Set<String> fieldsSet = new HashSet<>();
+
+    private final Map<String, String> variableReferences = new HashMap<>();
+
+    private final List<VariableDefinition> variableDefinitions = new ArrayList<>();
+
+    private String queryName;
+
+    public UsGraphQLQuery build() {
+      return new UsGraphQLQuery(queryName);                                     
+    }
+
+    public Builder queryName(String queryName) {
+      this.queryName = queryName;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithUnion/expected/client/UsProjectionRoot.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithUnion/expected/client/UsProjectionRoot.java
@@ -1,0 +1,21 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.projections.projectionWithUnion.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.BaseSubProjectionNode;
+
+public class UsProjectionRoot<PARENT extends BaseSubProjectionNode<?, ?>, ROOT extends BaseSubProjectionNode<?, ?>> extends BaseSubProjectionNode<PARENT, ROOT> {
+  public UsProjectionRoot() {
+    super(null, null, java.util.Optional.of("U"));
+  }
+
+  public UsProjectionRoot<PARENT, ROOT> __typename() {
+    getFields().put("__typename", null);
+    return this;
+  }
+
+  public EmployeeFragmentProjection<UsProjectionRoot<PARENT, ROOT>, UsProjectionRoot<PARENT, ROOT>> onEmployee(
+      ) {
+    EmployeeFragmentProjection<UsProjectionRoot<PARENT, ROOT>, UsProjectionRoot<PARENT, ROOT>> fragment = new EmployeeFragmentProjection<>(this, this);
+    getFragments().add(fragment);
+    return fragment;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithUnion/expected/datafetchers/UDatafetcher.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithUnion/expected/datafetchers/UDatafetcher.java
@@ -1,0 +1,17 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.projections.projectionWithUnion.expected.datafetchers;
+
+import com.netflix.graphql.dgs.DgsComponent;
+import com.netflix.graphql.dgs.DgsData;
+import com.netflix.graphql.dgs.codegen.java.testcases.projections.projectionWithUnion.expected.types.U;
+import graphql.schema.DataFetchingEnvironment;
+
+@DgsComponent
+public class UDatafetcher {
+  @DgsData(
+      parentType = "Query",
+      field = "u"
+  )
+  public U getU(DataFetchingEnvironment dataFetchingEnvironment) {
+    return null;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithUnion/expected/datafetchers/UsDatafetcher.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithUnion/expected/datafetchers/UsDatafetcher.java
@@ -1,0 +1,18 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.projections.projectionWithUnion.expected.datafetchers;
+
+import com.netflix.graphql.dgs.DgsComponent;
+import com.netflix.graphql.dgs.DgsData;
+import com.netflix.graphql.dgs.codegen.java.testcases.projections.projectionWithUnion.expected.types.U;
+import graphql.schema.DataFetchingEnvironment;
+import java.util.List;
+
+@DgsComponent
+public class UsDatafetcher {
+  @DgsData(
+      parentType = "Query",
+      field = "us"
+  )
+  public List<U> getUs(DataFetchingEnvironment dataFetchingEnvironment) {
+    return null;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithUnion/expected/types/Employee.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithUnion/expected/types/Employee.java
@@ -1,0 +1,86 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.projections.projectionWithUnion.expected.types;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.util.Objects;
+
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NONE
+)
+public class Employee implements U, com.netflix.graphql.dgs.codegen.java.testcases.projections.projectionWithUnion.expected.types.Person {
+  private String firstname;
+
+  private String company;
+
+  public Employee() {
+  }
+
+  public Employee(String firstname, String company) {
+    this.firstname = firstname;
+    this.company = company;
+  }
+
+  public String getFirstname() {
+    return firstname;
+  }
+
+  public void setFirstname(String firstname) {
+    this.firstname = firstname;
+  }
+
+  public String getCompany() {
+    return company;
+  }
+
+  public void setCompany(String company) {
+    this.company = company;
+  }
+
+  @Override
+  public String toString() {
+    return "Employee{firstname='" + firstname + "', company='" + company + "'}";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    Employee that = (Employee) o;
+    return Objects.equals(firstname, that.firstname) &&
+        Objects.equals(company, that.company);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(firstname, company);
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private String firstname;
+
+    private String company;
+
+    public Employee build() {
+      Employee result = new Employee();
+      result.firstname = this.firstname;
+      result.company = this.company;
+      return result;
+    }
+
+    public Builder firstname(String firstname) {
+      this.firstname = firstname;
+      return this;
+    }
+
+    public Builder company(String company) {
+      this.company = company;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithUnion/expected/types/Person.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithUnion/expected/types/Person.java
@@ -1,0 +1,17 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.projections.projectionWithUnion.expected.types;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import java.lang.String;
+
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NAME,
+    include = JsonTypeInfo.As.PROPERTY,
+    property = "__typename"
+)
+@JsonSubTypes(@JsonSubTypes.Type(value = Employee.class, name = "Employee"))
+public interface Person {
+  String getFirstname();
+
+  void setFirstname(String firstname);
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithUnion/expected/types/U.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithUnion/expected/types/U.java
@@ -1,0 +1,13 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.projections.projectionWithUnion.expected.types;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NAME,
+    include = JsonTypeInfo.As.PROPERTY,
+    property = "__typename"
+)
+@JsonSubTypes(@JsonSubTypes.Type(value = Employee.class, name = "Employee"))
+public interface U {
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithUnion/schema.graphql
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/projections/projectionWithUnion/schema.graphql
@@ -1,0 +1,15 @@
+type Query {
+  u: U
+  us: [U]
+}
+
+interface Person {
+  firstname: String
+}
+
+type Employee implements Person {
+  firstname: String
+  company: String
+}
+
+union U = Employee

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/unions/union/expected/DgsConstants.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/unions/union/expected/DgsConstants.java
@@ -1,0 +1,25 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.unions.union.expected;
+
+import java.lang.String;
+
+public class DgsConstants {
+  public static final String QUERY_TYPE = "Query";
+
+  public static class QUERY {
+    public static final String TYPE_NAME = "Query";
+
+    public static final String Search = "search";
+  }
+
+  public static class MOVIE {
+    public static final String TYPE_NAME = "Movie";
+
+    public static final String Title = "title";
+  }
+
+  public static class ACTOR {
+    public static final String TYPE_NAME = "Actor";
+
+    public static final String Name = "name";
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/unions/union/expected/client/ActorFragmentProjection.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/unions/union/expected/client/ActorFragmentProjection.java
@@ -1,0 +1,40 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.unions.union.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.BaseSubProjectionNode;
+import java.lang.Override;
+import java.lang.String;
+
+public class ActorFragmentProjection<PARENT extends BaseSubProjectionNode<?, ?>, ROOT extends BaseSubProjectionNode<?, ?>> extends BaseSubProjectionNode<PARENT, ROOT> {
+  {
+    getFields().put("__typename", null);
+  }
+
+  public ActorFragmentProjection(PARENT parent, ROOT root) {
+    super(parent, root, java.util.Optional.of("Actor"));
+  }
+
+  public ActorFragmentProjection<PARENT, ROOT> __typename() {
+    getFields().put("__typename", null);
+    return this;
+  }
+
+  public ActorFragmentProjection<PARENT, ROOT> name() {
+    getFields().put("name", null);
+    return this;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder builder = new StringBuilder();
+    builder.append("... on Actor {");
+    getFields().forEach((k, v) -> {
+        builder.append(" ").append(k);
+        if(v != null) {
+            builder.append(" ").append(v.toString());
+        }
+    });
+    builder.append("}");
+     
+    return builder.toString();
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/unions/union/expected/client/MovieFragmentProjection.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/unions/union/expected/client/MovieFragmentProjection.java
@@ -1,0 +1,40 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.unions.union.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.BaseSubProjectionNode;
+import java.lang.Override;
+import java.lang.String;
+
+public class MovieFragmentProjection<PARENT extends BaseSubProjectionNode<?, ?>, ROOT extends BaseSubProjectionNode<?, ?>> extends BaseSubProjectionNode<PARENT, ROOT> {
+  {
+    getFields().put("__typename", null);
+  }
+
+  public MovieFragmentProjection(PARENT parent, ROOT root) {
+    super(parent, root, java.util.Optional.of("Movie"));
+  }
+
+  public MovieFragmentProjection<PARENT, ROOT> __typename() {
+    getFields().put("__typename", null);
+    return this;
+  }
+
+  public MovieFragmentProjection<PARENT, ROOT> title() {
+    getFields().put("title", null);
+    return this;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder builder = new StringBuilder();
+    builder.append("... on Movie {");
+    getFields().forEach((k, v) -> {
+        builder.append(" ").append(k);
+        if(v != null) {
+            builder.append(" ").append(v.toString());
+        }
+    });
+    builder.append("}");
+     
+    return builder.toString();
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/unions/union/expected/client/SearchGraphQLQuery.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/unions/union/expected/client/SearchGraphQLQuery.java
@@ -1,0 +1,50 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.unions.union.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.GraphQLQuery;
+import graphql.language.VariableDefinition;
+import java.lang.Override;
+import java.lang.String;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class SearchGraphQLQuery extends GraphQLQuery {
+  public SearchGraphQLQuery(String queryName) {
+    super("query", queryName);
+  }
+
+  public SearchGraphQLQuery() {
+    super("query");
+  }
+
+  @Override
+  public String getOperationName() {
+    return "search";
+  }
+
+  public static Builder newRequest() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private Set<String> fieldsSet = new HashSet<>();
+
+    private final Map<String, String> variableReferences = new HashMap<>();
+
+    private final List<VariableDefinition> variableDefinitions = new ArrayList<>();
+
+    private String queryName;
+
+    public SearchGraphQLQuery build() {
+      return new SearchGraphQLQuery(queryName);                                     
+    }
+
+    public Builder queryName(String queryName) {
+      this.queryName = queryName;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/unions/union/expected/client/SearchProjectionRoot.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/unions/union/expected/client/SearchProjectionRoot.java
@@ -1,0 +1,28 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.unions.union.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.BaseSubProjectionNode;
+
+public class SearchProjectionRoot<PARENT extends BaseSubProjectionNode<?, ?>, ROOT extends BaseSubProjectionNode<?, ?>> extends BaseSubProjectionNode<PARENT, ROOT> {
+  public SearchProjectionRoot() {
+    super(null, null, java.util.Optional.of("SearchResult"));
+  }
+
+  public SearchProjectionRoot<PARENT, ROOT> __typename() {
+    getFields().put("__typename", null);
+    return this;
+  }
+
+  public MovieFragmentProjection<SearchProjectionRoot<PARENT, ROOT>, SearchProjectionRoot<PARENT, ROOT>> onMovie(
+      ) {
+    MovieFragmentProjection<SearchProjectionRoot<PARENT, ROOT>, SearchProjectionRoot<PARENT, ROOT>> fragment = new MovieFragmentProjection<>(this, this);
+    getFragments().add(fragment);
+    return fragment;
+  }
+
+  public ActorFragmentProjection<SearchProjectionRoot<PARENT, ROOT>, SearchProjectionRoot<PARENT, ROOT>> onActor(
+      ) {
+    ActorFragmentProjection<SearchProjectionRoot<PARENT, ROOT>, SearchProjectionRoot<PARENT, ROOT>> fragment = new ActorFragmentProjection<>(this, this);
+    getFragments().add(fragment);
+    return fragment;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/unions/union/expected/datafetchers/SearchDatafetcher.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/unions/union/expected/datafetchers/SearchDatafetcher.java
@@ -1,0 +1,18 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.unions.union.expected.datafetchers;
+
+import com.netflix.graphql.dgs.DgsComponent;
+import com.netflix.graphql.dgs.DgsData;
+import com.netflix.graphql.dgs.codegen.java.testcases.unions.union.expected.types.SearchResult;
+import graphql.schema.DataFetchingEnvironment;
+import java.util.List;
+
+@DgsComponent
+public class SearchDatafetcher {
+  @DgsData(
+      parentType = "Query",
+      field = "search"
+  )
+  public List<SearchResult> getSearch(DataFetchingEnvironment dataFetchingEnvironment) {
+    return null;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/unions/union/expected/types/Actor.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/unions/union/expected/types/Actor.java
@@ -1,0 +1,66 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.unions.union.expected.types;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.util.Objects;
+
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NONE
+)
+public class Actor implements SearchResult {
+  private String name;
+
+  public Actor() {
+  }
+
+  public Actor(String name) {
+    this.name = name;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  @Override
+  public String toString() {
+    return "Actor{name='" + name + "'}";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    Actor that = (Actor) o;
+    return Objects.equals(name, that.name);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name);
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private String name;
+
+    public Actor build() {
+      Actor result = new Actor();
+      result.name = this.name;
+      return result;
+    }
+
+    public Builder name(String name) {
+      this.name = name;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/unions/union/expected/types/Movie.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/unions/union/expected/types/Movie.java
@@ -1,0 +1,66 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.unions.union.expected.types;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.util.Objects;
+
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NONE
+)
+public class Movie implements SearchResult {
+  private String title;
+
+  public Movie() {
+  }
+
+  public Movie(String title) {
+    this.title = title;
+  }
+
+  public String getTitle() {
+    return title;
+  }
+
+  public void setTitle(String title) {
+    this.title = title;
+  }
+
+  @Override
+  public String toString() {
+    return "Movie{title='" + title + "'}";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    Movie that = (Movie) o;
+    return Objects.equals(title, that.title);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(title);
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private String title;
+
+    public Movie build() {
+      Movie result = new Movie();
+      result.title = this.title;
+      return result;
+    }
+
+    public Builder title(String title) {
+      this.title = title;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/unions/union/expected/types/SearchResult.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/unions/union/expected/types/SearchResult.java
@@ -1,0 +1,16 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.unions.union.expected.types;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NAME,
+    include = JsonTypeInfo.As.PROPERTY,
+    property = "__typename"
+)
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = Movie.class, name = "Movie"),
+    @JsonSubTypes.Type(value = Actor.class, name = "Actor")
+})
+public interface SearchResult {
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/unions/union/schema.graphql
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/unions/union/schema.graphql
@@ -1,0 +1,13 @@
+type Query {
+  search: [SearchResult]
+}
+
+union SearchResult = Movie | Actor
+
+type Movie {
+  title: String
+}
+
+type Actor {
+  name: String
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/unions/unionTypesWithoutInterfaceCanDeserialize/expected/DgsConstants.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/unions/unionTypesWithoutInterfaceCanDeserialize/expected/DgsConstants.java
@@ -1,0 +1,43 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.unions.unionTypesWithoutInterfaceCanDeserialize.expected;
+
+import java.lang.String;
+
+public class DgsConstants {
+  public static final String QUERY_TYPE = "Query";
+
+  public static class QUERY {
+    public static final String TYPE_NAME = "Query";
+
+    public static final String Search = "search";
+
+    public static class SEARCH_INPUT_ARGUMENT {
+      public static final String Text = "text";
+    }
+  }
+
+  public static class HUMAN {
+    public static final String TYPE_NAME = "Human";
+
+    public static final String Id = "id";
+
+    public static final String Name = "name";
+
+    public static final String TotalCredits = "totalCredits";
+  }
+
+  public static class DROID {
+    public static final String TYPE_NAME = "Droid";
+
+    public static final String Id = "id";
+
+    public static final String Name = "name";
+
+    public static final String PrimaryFunction = "primaryFunction";
+  }
+
+  public static class SEARCHRESULTPAGE {
+    public static final String TYPE_NAME = "SearchResultPage";
+
+    public static final String Items = "items";
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/unions/unionTypesWithoutInterfaceCanDeserialize/expected/client/DroidFragmentProjection.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/unions/unionTypesWithoutInterfaceCanDeserialize/expected/client/DroidFragmentProjection.java
@@ -1,0 +1,50 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.unions.unionTypesWithoutInterfaceCanDeserialize.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.BaseSubProjectionNode;
+import java.lang.Override;
+import java.lang.String;
+
+public class DroidFragmentProjection<PARENT extends BaseSubProjectionNode<?, ?>, ROOT extends BaseSubProjectionNode<?, ?>> extends BaseSubProjectionNode<PARENT, ROOT> {
+  {
+    getFields().put("__typename", null);
+  }
+
+  public DroidFragmentProjection(PARENT parent, ROOT root) {
+    super(parent, root, java.util.Optional.of("Droid"));
+  }
+
+  public DroidFragmentProjection<PARENT, ROOT> __typename() {
+    getFields().put("__typename", null);
+    return this;
+  }
+
+  public DroidFragmentProjection<PARENT, ROOT> id() {
+    getFields().put("id", null);
+    return this;
+  }
+
+  public DroidFragmentProjection<PARENT, ROOT> name() {
+    getFields().put("name", null);
+    return this;
+  }
+
+  public DroidFragmentProjection<PARENT, ROOT> primaryFunction() {
+    getFields().put("primaryFunction", null);
+    return this;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder builder = new StringBuilder();
+    builder.append("... on Droid {");
+    getFields().forEach((k, v) -> {
+        builder.append(" ").append(k);
+        if(v != null) {
+            builder.append(" ").append(v.toString());
+        }
+    });
+    builder.append("}");
+     
+    return builder.toString();
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/unions/unionTypesWithoutInterfaceCanDeserialize/expected/client/HumanFragmentProjection.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/unions/unionTypesWithoutInterfaceCanDeserialize/expected/client/HumanFragmentProjection.java
@@ -1,0 +1,50 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.unions.unionTypesWithoutInterfaceCanDeserialize.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.BaseSubProjectionNode;
+import java.lang.Override;
+import java.lang.String;
+
+public class HumanFragmentProjection<PARENT extends BaseSubProjectionNode<?, ?>, ROOT extends BaseSubProjectionNode<?, ?>> extends BaseSubProjectionNode<PARENT, ROOT> {
+  {
+    getFields().put("__typename", null);
+  }
+
+  public HumanFragmentProjection(PARENT parent, ROOT root) {
+    super(parent, root, java.util.Optional.of("Human"));
+  }
+
+  public HumanFragmentProjection<PARENT, ROOT> __typename() {
+    getFields().put("__typename", null);
+    return this;
+  }
+
+  public HumanFragmentProjection<PARENT, ROOT> id() {
+    getFields().put("id", null);
+    return this;
+  }
+
+  public HumanFragmentProjection<PARENT, ROOT> name() {
+    getFields().put("name", null);
+    return this;
+  }
+
+  public HumanFragmentProjection<PARENT, ROOT> totalCredits() {
+    getFields().put("totalCredits", null);
+    return this;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder builder = new StringBuilder();
+    builder.append("... on Human {");
+    getFields().forEach((k, v) -> {
+        builder.append(" ").append(k);
+        if(v != null) {
+            builder.append(" ").append(v.toString());
+        }
+    });
+    builder.append("}");
+     
+    return builder.toString();
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/unions/unionTypesWithoutInterfaceCanDeserialize/expected/client/SearchGraphQLQuery.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/unions/unionTypesWithoutInterfaceCanDeserialize/expected/client/SearchGraphQLQuery.java
@@ -1,0 +1,84 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.unions.unionTypesWithoutInterfaceCanDeserialize.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.GraphQLQuery;
+import graphql.language.VariableDefinition;
+import java.lang.Override;
+import java.lang.String;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class SearchGraphQLQuery extends GraphQLQuery {
+  public SearchGraphQLQuery(String text, String queryName, Set<String> fieldsSet) {
+    super("query", queryName);
+    if (text != null || fieldsSet.contains("text")) {
+        getInput().put("text", text);
+    }
+  }
+
+  public SearchGraphQLQuery(String text, String queryName, Set<String> fieldsSet,
+      Map<String, String> variableReferences, List<VariableDefinition> variableDefinitions) {
+    super("query", queryName);
+    if (text != null || fieldsSet.contains("text")) {
+        getInput().put("text", text);
+    }
+    if(variableDefinitions != null) {
+       getVariableDefinitions().addAll(variableDefinitions);
+    }
+
+    if(variableReferences != null) {
+       getVariableReferences().putAll(variableReferences);
+    }                      
+  }
+
+  public SearchGraphQLQuery() {
+    super("query");
+  }
+
+  @Override
+  public String getOperationName() {
+    return "search";
+  }
+
+  public static Builder newRequest() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private Set<String> fieldsSet = new HashSet<>();
+
+    private final Map<String, String> variableReferences = new HashMap<>();
+
+    private final List<VariableDefinition> variableDefinitions = new ArrayList<>();
+
+    private String text;
+
+    private String queryName;
+
+    public SearchGraphQLQuery build() {
+      return new SearchGraphQLQuery(text, queryName, fieldsSet, variableReferences, variableDefinitions);
+               
+    }
+
+    public Builder text(String text) {
+      this.text = text;
+      this.fieldsSet.add("text");
+      return this;
+    }
+
+    public Builder textReference(String variableRef) {
+      this.variableReferences.put("text", variableRef);
+      this.variableDefinitions.add(graphql.language.VariableDefinition.newVariableDefinition(variableRef, new graphql.language.NonNullType(new graphql.language.TypeName("String"))).build());
+      this.fieldsSet.add("text");
+      return this;
+    }
+
+    public Builder queryName(String queryName) {
+      this.queryName = queryName;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/unions/unionTypesWithoutInterfaceCanDeserialize/expected/client/SearchProjectionRoot.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/unions/unionTypesWithoutInterfaceCanDeserialize/expected/client/SearchProjectionRoot.java
@@ -1,0 +1,21 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.unions.unionTypesWithoutInterfaceCanDeserialize.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.BaseSubProjectionNode;
+
+public class SearchProjectionRoot<PARENT extends BaseSubProjectionNode<?, ?>, ROOT extends BaseSubProjectionNode<?, ?>> extends BaseSubProjectionNode<PARENT, ROOT> {
+  public SearchProjectionRoot() {
+    super(null, null, java.util.Optional.of("SearchResultPage"));
+  }
+
+  public SearchProjectionRoot<PARENT, ROOT> __typename() {
+    getFields().put("__typename", null);
+    return this;
+  }
+
+  public SearchResultProjection<SearchProjectionRoot<PARENT, ROOT>, SearchProjectionRoot<PARENT, ROOT>> items(
+      ) {
+    SearchResultProjection<SearchProjectionRoot<PARENT, ROOT>, SearchProjectionRoot<PARENT, ROOT>> projection = new SearchResultProjection<>(this, this);    
+    getFields().put("items", projection);
+    return projection;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/unions/unionTypesWithoutInterfaceCanDeserialize/expected/client/SearchResultProjection.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/unions/unionTypesWithoutInterfaceCanDeserialize/expected/client/SearchResultProjection.java
@@ -1,0 +1,26 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.unions.unionTypesWithoutInterfaceCanDeserialize.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.BaseSubProjectionNode;
+
+public class SearchResultProjection<PARENT extends BaseSubProjectionNode<?, ?>, ROOT extends BaseSubProjectionNode<?, ?>> extends BaseSubProjectionNode<PARENT, ROOT> {
+  public SearchResultProjection(PARENT parent, ROOT root) {
+    super(parent, root, java.util.Optional.of("SearchResult"));
+  }
+
+  public SearchResultProjection<PARENT, ROOT> __typename() {
+    getFields().put("__typename", null);
+    return this;
+  }
+
+  public HumanFragmentProjection<SearchResultProjection<PARENT, ROOT>, ROOT> onHuman() {
+    HumanFragmentProjection<SearchResultProjection<PARENT, ROOT>, ROOT> fragment = new HumanFragmentProjection<>(this, getRoot());
+    getFragments().add(fragment);
+    return fragment;
+  }
+
+  public DroidFragmentProjection<SearchResultProjection<PARENT, ROOT>, ROOT> onDroid() {
+    DroidFragmentProjection<SearchResultProjection<PARENT, ROOT>, ROOT> fragment = new DroidFragmentProjection<>(this, getRoot());
+    getFragments().add(fragment);
+    return fragment;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/unions/unionTypesWithoutInterfaceCanDeserialize/expected/datafetchers/SearchDatafetcher.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/unions/unionTypesWithoutInterfaceCanDeserialize/expected/datafetchers/SearchDatafetcher.java
@@ -1,0 +1,17 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.unions.unionTypesWithoutInterfaceCanDeserialize.expected.datafetchers;
+
+import com.netflix.graphql.dgs.DgsComponent;
+import com.netflix.graphql.dgs.DgsData;
+import com.netflix.graphql.dgs.codegen.java.testcases.unions.unionTypesWithoutInterfaceCanDeserialize.expected.types.SearchResultPage;
+import graphql.schema.DataFetchingEnvironment;
+
+@DgsComponent
+public class SearchDatafetcher {
+  @DgsData(
+      parentType = "Query",
+      field = "search"
+  )
+  public SearchResultPage getSearch(DataFetchingEnvironment dataFetchingEnvironment) {
+    return null;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/unions/unionTypesWithoutInterfaceCanDeserialize/expected/types/Droid.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/unions/unionTypesWithoutInterfaceCanDeserialize/expected/types/Droid.java
@@ -1,0 +1,106 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.unions.unionTypesWithoutInterfaceCanDeserialize.expected.types;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.util.Objects;
+
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NONE
+)
+public class Droid implements SearchResult {
+  private String id;
+
+  private String name;
+
+  private String primaryFunction;
+
+  public Droid() {
+  }
+
+  public Droid(String id, String name, String primaryFunction) {
+    this.id = id;
+    this.name = name;
+    this.primaryFunction = primaryFunction;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(String id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public String getPrimaryFunction() {
+    return primaryFunction;
+  }
+
+  public void setPrimaryFunction(String primaryFunction) {
+    this.primaryFunction = primaryFunction;
+  }
+
+  @Override
+  public String toString() {
+    return "Droid{id='" + id + "', name='" + name + "', primaryFunction='" + primaryFunction + "'}";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    Droid that = (Droid) o;
+    return Objects.equals(id, that.id) &&
+        Objects.equals(name, that.name) &&
+        Objects.equals(primaryFunction, that.primaryFunction);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, name, primaryFunction);
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private String id;
+
+    private String name;
+
+    private String primaryFunction;
+
+    public Droid build() {
+      Droid result = new Droid();
+      result.id = this.id;
+      result.name = this.name;
+      result.primaryFunction = this.primaryFunction;
+      return result;
+    }
+
+    public Builder id(String id) {
+      this.id = id;
+      return this;
+    }
+
+    public Builder name(String name) {
+      this.name = name;
+      return this;
+    }
+
+    public Builder primaryFunction(String primaryFunction) {
+      this.primaryFunction = primaryFunction;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/unions/unionTypesWithoutInterfaceCanDeserialize/expected/types/Human.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/unions/unionTypesWithoutInterfaceCanDeserialize/expected/types/Human.java
@@ -1,0 +1,107 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.unions.unionTypesWithoutInterfaceCanDeserialize.expected.types;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import java.lang.Integer;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.util.Objects;
+
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NONE
+)
+public class Human implements SearchResult {
+  private String id;
+
+  private String name;
+
+  private Integer totalCredits;
+
+  public Human() {
+  }
+
+  public Human(String id, String name, Integer totalCredits) {
+    this.id = id;
+    this.name = name;
+    this.totalCredits = totalCredits;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(String id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public Integer getTotalCredits() {
+    return totalCredits;
+  }
+
+  public void setTotalCredits(Integer totalCredits) {
+    this.totalCredits = totalCredits;
+  }
+
+  @Override
+  public String toString() {
+    return "Human{id='" + id + "', name='" + name + "', totalCredits='" + totalCredits + "'}";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    Human that = (Human) o;
+    return Objects.equals(id, that.id) &&
+        Objects.equals(name, that.name) &&
+        Objects.equals(totalCredits, that.totalCredits);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, name, totalCredits);
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private String id;
+
+    private String name;
+
+    private Integer totalCredits;
+
+    public Human build() {
+      Human result = new Human();
+      result.id = this.id;
+      result.name = this.name;
+      result.totalCredits = this.totalCredits;
+      return result;
+    }
+
+    public Builder id(String id) {
+      this.id = id;
+      return this;
+    }
+
+    public Builder name(String name) {
+      this.name = name;
+      return this;
+    }
+
+    public Builder totalCredits(Integer totalCredits) {
+      this.totalCredits = totalCredits;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/unions/unionTypesWithoutInterfaceCanDeserialize/expected/types/SearchResult.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/unions/unionTypesWithoutInterfaceCanDeserialize/expected/types/SearchResult.java
@@ -1,0 +1,16 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.unions.unionTypesWithoutInterfaceCanDeserialize.expected.types;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NAME,
+    include = JsonTypeInfo.As.PROPERTY,
+    property = "__typename"
+)
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = Human.class, name = "Human"),
+    @JsonSubTypes.Type(value = Droid.class, name = "Droid")
+})
+public interface SearchResult {
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/unions/unionTypesWithoutInterfaceCanDeserialize/expected/types/SearchResultPage.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/unions/unionTypesWithoutInterfaceCanDeserialize/expected/types/SearchResultPage.java
@@ -1,0 +1,63 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.unions.unionTypesWithoutInterfaceCanDeserialize.expected.types;
+
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.util.List;
+import java.util.Objects;
+
+public class SearchResultPage {
+  private List<SearchResult> items;
+
+  public SearchResultPage() {
+  }
+
+  public SearchResultPage(List<SearchResult> items) {
+    this.items = items;
+  }
+
+  public List<SearchResult> getItems() {
+    return items;
+  }
+
+  public void setItems(List<SearchResult> items) {
+    this.items = items;
+  }
+
+  @Override
+  public String toString() {
+    return "SearchResultPage{items='" + items + "'}";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    SearchResultPage that = (SearchResultPage) o;
+    return Objects.equals(items, that.items);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(items);
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private List<SearchResult> items;
+
+    public SearchResultPage build() {
+      SearchResultPage result = new SearchResultPage();
+      result.items = this.items;
+      return result;
+    }
+
+    public Builder items(List<SearchResult> items) {
+      this.items = items;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/unions/unionTypesWithoutInterfaceCanDeserialize/schema.graphql
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/unions/unionTypesWithoutInterfaceCanDeserialize/schema.graphql
@@ -1,0 +1,21 @@
+type Query {
+  search(text: String!): SearchResultPage
+}
+
+type Human {
+  id: ID!
+  name: String!
+  totalCredits: Int
+}
+
+type Droid {
+  id: ID!
+  name: String!
+  primaryFunction: String
+}
+
+union SearchResult = Human | Droid
+
+type SearchResultPage {
+  items: [SearchResult]
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/unions/unionWithExtendedType/expected/DgsConstants.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/unions/unionWithExtendedType/expected/DgsConstants.java
@@ -1,0 +1,31 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.unions.unionWithExtendedType.expected;
+
+import java.lang.String;
+
+public class DgsConstants {
+  public static final String QUERY_TYPE = "Query";
+
+  public static class QUERY {
+    public static final String TYPE_NAME = "Query";
+
+    public static final String Search = "search";
+  }
+
+  public static class MOVIE {
+    public static final String TYPE_NAME = "Movie";
+
+    public static final String Title = "title";
+  }
+
+  public static class ACTOR {
+    public static final String TYPE_NAME = "Actor";
+
+    public static final String Name = "name";
+  }
+
+  public static class RATING {
+    public static final String TYPE_NAME = "Rating";
+
+    public static final String Stars = "stars";
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/unions/unionWithExtendedType/expected/client/ActorFragmentProjection.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/unions/unionWithExtendedType/expected/client/ActorFragmentProjection.java
@@ -1,0 +1,40 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.unions.unionWithExtendedType.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.BaseSubProjectionNode;
+import java.lang.Override;
+import java.lang.String;
+
+public class ActorFragmentProjection<PARENT extends BaseSubProjectionNode<?, ?>, ROOT extends BaseSubProjectionNode<?, ?>> extends BaseSubProjectionNode<PARENT, ROOT> {
+  {
+    getFields().put("__typename", null);
+  }
+
+  public ActorFragmentProjection(PARENT parent, ROOT root) {
+    super(parent, root, java.util.Optional.of("Actor"));
+  }
+
+  public ActorFragmentProjection<PARENT, ROOT> __typename() {
+    getFields().put("__typename", null);
+    return this;
+  }
+
+  public ActorFragmentProjection<PARENT, ROOT> name() {
+    getFields().put("name", null);
+    return this;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder builder = new StringBuilder();
+    builder.append("... on Actor {");
+    getFields().forEach((k, v) -> {
+        builder.append(" ").append(k);
+        if(v != null) {
+            builder.append(" ").append(v.toString());
+        }
+    });
+    builder.append("}");
+     
+    return builder.toString();
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/unions/unionWithExtendedType/expected/client/MovieFragmentProjection.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/unions/unionWithExtendedType/expected/client/MovieFragmentProjection.java
@@ -1,0 +1,40 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.unions.unionWithExtendedType.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.BaseSubProjectionNode;
+import java.lang.Override;
+import java.lang.String;
+
+public class MovieFragmentProjection<PARENT extends BaseSubProjectionNode<?, ?>, ROOT extends BaseSubProjectionNode<?, ?>> extends BaseSubProjectionNode<PARENT, ROOT> {
+  {
+    getFields().put("__typename", null);
+  }
+
+  public MovieFragmentProjection(PARENT parent, ROOT root) {
+    super(parent, root, java.util.Optional.of("Movie"));
+  }
+
+  public MovieFragmentProjection<PARENT, ROOT> __typename() {
+    getFields().put("__typename", null);
+    return this;
+  }
+
+  public MovieFragmentProjection<PARENT, ROOT> title() {
+    getFields().put("title", null);
+    return this;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder builder = new StringBuilder();
+    builder.append("... on Movie {");
+    getFields().forEach((k, v) -> {
+        builder.append(" ").append(k);
+        if(v != null) {
+            builder.append(" ").append(v.toString());
+        }
+    });
+    builder.append("}");
+     
+    return builder.toString();
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/unions/unionWithExtendedType/expected/client/SearchGraphQLQuery.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/unions/unionWithExtendedType/expected/client/SearchGraphQLQuery.java
@@ -1,0 +1,50 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.unions.unionWithExtendedType.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.GraphQLQuery;
+import graphql.language.VariableDefinition;
+import java.lang.Override;
+import java.lang.String;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class SearchGraphQLQuery extends GraphQLQuery {
+  public SearchGraphQLQuery(String queryName) {
+    super("query", queryName);
+  }
+
+  public SearchGraphQLQuery() {
+    super("query");
+  }
+
+  @Override
+  public String getOperationName() {
+    return "search";
+  }
+
+  public static Builder newRequest() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private Set<String> fieldsSet = new HashSet<>();
+
+    private final Map<String, String> variableReferences = new HashMap<>();
+
+    private final List<VariableDefinition> variableDefinitions = new ArrayList<>();
+
+    private String queryName;
+
+    public SearchGraphQLQuery build() {
+      return new SearchGraphQLQuery(queryName);                                     
+    }
+
+    public Builder queryName(String queryName) {
+      this.queryName = queryName;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/unions/unionWithExtendedType/expected/client/SearchProjectionRoot.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/unions/unionWithExtendedType/expected/client/SearchProjectionRoot.java
@@ -1,0 +1,28 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.unions.unionWithExtendedType.expected.client;
+
+import com.netflix.graphql.dgs.client.codegen.BaseSubProjectionNode;
+
+public class SearchProjectionRoot<PARENT extends BaseSubProjectionNode<?, ?>, ROOT extends BaseSubProjectionNode<?, ?>> extends BaseSubProjectionNode<PARENT, ROOT> {
+  public SearchProjectionRoot() {
+    super(null, null, java.util.Optional.of("SearchResult"));
+  }
+
+  public SearchProjectionRoot<PARENT, ROOT> __typename() {
+    getFields().put("__typename", null);
+    return this;
+  }
+
+  public MovieFragmentProjection<SearchProjectionRoot<PARENT, ROOT>, SearchProjectionRoot<PARENT, ROOT>> onMovie(
+      ) {
+    MovieFragmentProjection<SearchProjectionRoot<PARENT, ROOT>, SearchProjectionRoot<PARENT, ROOT>> fragment = new MovieFragmentProjection<>(this, this);
+    getFragments().add(fragment);
+    return fragment;
+  }
+
+  public ActorFragmentProjection<SearchProjectionRoot<PARENT, ROOT>, SearchProjectionRoot<PARENT, ROOT>> onActor(
+      ) {
+    ActorFragmentProjection<SearchProjectionRoot<PARENT, ROOT>, SearchProjectionRoot<PARENT, ROOT>> fragment = new ActorFragmentProjection<>(this, this);
+    getFragments().add(fragment);
+    return fragment;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/unions/unionWithExtendedType/expected/datafetchers/SearchDatafetcher.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/unions/unionWithExtendedType/expected/datafetchers/SearchDatafetcher.java
@@ -1,0 +1,18 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.unions.unionWithExtendedType.expected.datafetchers;
+
+import com.netflix.graphql.dgs.DgsComponent;
+import com.netflix.graphql.dgs.DgsData;
+import com.netflix.graphql.dgs.codegen.java.testcases.unions.unionWithExtendedType.expected.types.SearchResult;
+import graphql.schema.DataFetchingEnvironment;
+import java.util.List;
+
+@DgsComponent
+public class SearchDatafetcher {
+  @DgsData(
+      parentType = "Query",
+      field = "search"
+  )
+  public List<SearchResult> getSearch(DataFetchingEnvironment dataFetchingEnvironment) {
+    return null;
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/unions/unionWithExtendedType/expected/types/Actor.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/unions/unionWithExtendedType/expected/types/Actor.java
@@ -1,0 +1,66 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.unions.unionWithExtendedType.expected.types;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.util.Objects;
+
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NONE
+)
+public class Actor implements SearchResult {
+  private String name;
+
+  public Actor() {
+  }
+
+  public Actor(String name) {
+    this.name = name;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  @Override
+  public String toString() {
+    return "Actor{name='" + name + "'}";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    Actor that = (Actor) o;
+    return Objects.equals(name, that.name);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name);
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private String name;
+
+    public Actor build() {
+      Actor result = new Actor();
+      result.name = this.name;
+      return result;
+    }
+
+    public Builder name(String name) {
+      this.name = name;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/unions/unionWithExtendedType/expected/types/Movie.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/unions/unionWithExtendedType/expected/types/Movie.java
@@ -1,0 +1,66 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.unions.unionWithExtendedType.expected.types;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.util.Objects;
+
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NONE
+)
+public class Movie implements SearchResult {
+  private String title;
+
+  public Movie() {
+  }
+
+  public Movie(String title) {
+    this.title = title;
+  }
+
+  public String getTitle() {
+    return title;
+  }
+
+  public void setTitle(String title) {
+    this.title = title;
+  }
+
+  @Override
+  public String toString() {
+    return "Movie{title='" + title + "'}";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    Movie that = (Movie) o;
+    return Objects.equals(title, that.title);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(title);
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private String title;
+
+    public Movie build() {
+      Movie result = new Movie();
+      result.title = this.title;
+      return result;
+    }
+
+    public Builder title(String title) {
+      this.title = title;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/unions/unionWithExtendedType/expected/types/Rating.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/unions/unionWithExtendedType/expected/types/Rating.java
@@ -1,0 +1,67 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.unions.unionWithExtendedType.expected.types;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import java.lang.Integer;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.util.Objects;
+
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NONE
+)
+public class Rating implements SearchResult {
+  private Integer stars;
+
+  public Rating() {
+  }
+
+  public Rating(Integer stars) {
+    this.stars = stars;
+  }
+
+  public Integer getStars() {
+    return stars;
+  }
+
+  public void setStars(Integer stars) {
+    this.stars = stars;
+  }
+
+  @Override
+  public String toString() {
+    return "Rating{stars='" + stars + "'}";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    Rating that = (Rating) o;
+    return Objects.equals(stars, that.stars);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(stars);
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private Integer stars;
+
+    public Rating build() {
+      Rating result = new Rating();
+      result.stars = this.stars;
+      return result;
+    }
+
+    public Builder stars(Integer stars) {
+      this.stars = stars;
+      return this;
+    }
+  }
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/unions/unionWithExtendedType/expected/types/SearchResult.java
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/unions/unionWithExtendedType/expected/types/SearchResult.java
@@ -1,0 +1,17 @@
+package com.netflix.graphql.dgs.codegen.java.testcases.unions.unionWithExtendedType.expected.types;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NAME,
+    include = JsonTypeInfo.As.PROPERTY,
+    property = "__typename"
+)
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = Movie.class, name = "Movie"),
+    @JsonSubTypes.Type(value = Actor.class, name = "Actor"),
+    @JsonSubTypes.Type(value = Rating.class, name = "Rating")
+})
+public interface SearchResult {
+}

--- a/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/unions/unionWithExtendedType/schema.graphql
+++ b/graphql-dgs-codegen-core/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/unions/unionWithExtendedType/schema.graphql
@@ -1,0 +1,19 @@
+type Query {
+  search: [SearchResult]
+}
+
+union SearchResult = Movie | Actor
+
+type Movie {
+  title: String
+}
+
+type Actor {
+  name: String
+}
+
+type Rating {
+  stars: Int
+}
+
+extend union SearchResult = Rating

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/JavaCodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/JavaCodeGenTest.kt
@@ -1,0 +1,269 @@
+/*
+ *
+ *  Copyright 2020 Netflix, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package com.netflix.graphql.dgs.codegen
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.fail
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.util.stream.Collectors
+import kotlin.io.path.createDirectories
+import kotlin.io.path.exists
+import kotlin.io.path.listDirectoryEntries
+import kotlin.io.path.readText
+
+class JavaCodeGenTest {
+    // set this to true to update all expected outputs instead of running tests
+    private val updateExpected = false
+
+    @ParameterizedTest
+    @MethodSource("constantsTestCases")
+    fun testCodeGen_constants(testCaseName: String) {
+        val testPackage = "constants"
+        val codeGenConfig = getBaseCodeGenConfig(testPackage, testCaseName)
+        runTest(testPackage, testCaseName, codeGenConfig)
+    }
+
+    @ParameterizedTest
+    @MethodSource("dataClassesTestCases")
+    fun testCodeGen_dataClasses(testCaseName: String) {
+        val testPackage = "dataclasses"
+        val codeGenConfig = getBaseCodeGenConfig(testPackage, testCaseName)
+        codeGenConfig.typeMapping =
+            when (testCaseName) {
+                "dataClassWithMappedTypes" ->
+                    mapOf(
+                        "Long" to "java.lang.Long",
+                        "DateTime" to "java.time.OffsetDateTime",
+                        "PageInfo" to "graphql.relay.PageInfo",
+                        "EntityConnection" to
+                            "graphql.relay.SimpleListConnection<com.netflix.graphql.dgs.codegen.java.testcases.dataclasses.dataClassWithMappedTypes.expected.types.EntityEdge>",
+                    )
+                "dataClassWithMappedInterfaces" ->
+                    mapOf(
+                        "Node" to "com.netflix.graphql.dgs.codegen.java.fixtures.Node",
+                    )
+                else -> emptyMap()
+            }
+
+        runTest(testPackage, testCaseName, codeGenConfig)
+    }
+
+    @ParameterizedTest
+    @MethodSource("enumsTestCases")
+    fun testCodeGen_enums(testCaseName: String) {
+        val testPackage = "enums"
+        val codeGenConfig = getBaseCodeGenConfig(testPackage, testCaseName)
+        runTest(testPackage, testCaseName, codeGenConfig)
+    }
+
+    @ParameterizedTest
+    @MethodSource("inputsTestCases")
+    fun testCodeGen_inputs(testCaseName: String) {
+        val testPackage = "inputs"
+        val codeGenConfig = getBaseCodeGenConfig(testPackage, testCaseName)
+        codeGenConfig.typeMapping =
+            when (testCaseName) {
+                "inputWithDefaultBigDecimal" ->
+                    mapOf(
+                        "Decimal" to "java.math.BigDecimal",
+                    )
+                "inputWithDefaultCurrency" ->
+                    mapOf(
+                        "Currency" to "java.util.Currency",
+                    )
+                else -> emptyMap()
+            }
+
+        runTest(testPackage, testCaseName, codeGenConfig)
+    }
+
+    @ParameterizedTest
+    @MethodSource("interfacesTestCases")
+    fun testCodeGen_interfaces(testCaseName: String) {
+        val testPackage = "interfaces"
+        val codeGenConfig = getBaseCodeGenConfig(testPackage, testCaseName)
+        runTest(testPackage, testCaseName, codeGenConfig)
+    }
+
+    @ParameterizedTest
+    @MethodSource("miscTestCases")
+    fun testCodeGen_misc(testCaseName: String) {
+        val testPackage = "misc"
+        val codeGenConfig = getBaseCodeGenConfig(testPackage, testCaseName)
+        runTest(testPackage, testCaseName, codeGenConfig)
+    }
+
+    @ParameterizedTest
+    @MethodSource("projectionsTestCases")
+    fun testCodeGen_projections(testCaseName: String) {
+        val testPackage = "projections"
+        val codeGenConfig = getBaseCodeGenConfig(testPackage, testCaseName)
+        runTest(testPackage, testCaseName, codeGenConfig)
+    }
+
+    @ParameterizedTest
+    @MethodSource("unionsTestCases")
+    fun testCodeGen_unions(testCaseName: String) {
+        val testPackage = "unions"
+        val codeGenConfig = getBaseCodeGenConfig(testPackage, testCaseName)
+        runTest(testPackage, testCaseName, codeGenConfig)
+    }
+
+    @Test
+    fun `assert updateExpected is false`() {
+        assertThat(updateExpected).isFalse()
+    }
+
+    private fun runTest(
+        testPackage: String,
+        testCaseName: String,
+        codeGenConfig: CodeGenConfig,
+    ) {
+        val codeGenResult = CodeGen(codeGenConfig).generate()
+
+        val generatedFilePathAndContentPairs =
+            codeGenResult
+                .javaSources()
+                .map {
+                    val generatedFilePath =
+                        "${it.packageName()}.${it.typeSpec().name()}"
+                            .replace(".", "/")
+                            .plus(".java")
+
+                    generatedFilePath to it.toString()
+                }
+
+        // fail if any file was defined twice
+        generatedFilePathAndContentPairs
+            .groupingBy { it.first }
+            .eachCount()
+            .filterValues { it > 1 }
+            .keys
+            .forEach { fail("Generated duplicate file: $it") }
+
+        val expectedFileContentByPath =
+            listAllFiles("$testPackage/$testCaseName/expected")
+                .associate {
+                    val relativePath = getTestsSourceTreeAbsolutePath().relativize(it).toString()
+                    relativePath to it.readText()
+                }
+
+        // fail if any file was expected that's not generated
+        expectedFileContentByPath
+            .keys
+            .subtract(generatedFilePathAndContentPairs.map { it.first }.toSet())
+            .forEach { fail("Missing expected file: $it") }
+
+        generatedFilePathAndContentPairs.forEach { (generatedFilePath, generatedContent) ->
+            if (updateExpected) {
+                writeExpected(generatedFilePath, generatedContent)
+            } else {
+                val expectedContent = expectedFileContentByPath[generatedFilePath]
+                assertThat(generatedContent).isEqualTo(expectedContent)
+            }
+        }
+
+        assertCompilesJava(codeGenResult)
+    }
+
+    companion object {
+        @JvmStatic
+        fun listTestsToRunForPackage(testPackageName: String): List<String> =
+            getAbsolutePath(testPackageName)
+                .listDirectoryEntries()
+                .map { it.getName(it.nameCount.dec()).toString() }
+                .sorted()
+
+        @JvmStatic
+        fun constantsTestCases(): List<String> = listTestsToRunForPackage("constants")
+
+        @JvmStatic
+        fun dataClassesTestCases(): List<String> = listTestsToRunForPackage("dataclasses")
+
+        @JvmStatic
+        fun enumsTestCases(): List<String> = listTestsToRunForPackage("enums")
+
+        @JvmStatic
+        fun inputsTestCases(): List<String> = listTestsToRunForPackage("inputs")
+
+        @JvmStatic
+        fun interfacesTestCases(): List<String> = listTestsToRunForPackage("interfaces")
+
+        @JvmStatic
+        fun miscTestCases(): List<String> = listTestsToRunForPackage("misc")
+
+        @JvmStatic
+        fun projectionsTestCases(): List<String> = listTestsToRunForPackage("projections")
+
+        @JvmStatic
+        fun unionsTestCases(): List<String> = listTestsToRunForPackage("unions")
+
+        private fun getBaseCodeGenConfig(
+            testPackage: String,
+            testCaseName: String,
+        ): CodeGenConfig {
+            val schema = readFileContent("$testPackage/$testCaseName/schema.graphql")
+            return CodeGenConfig(
+                schemas = setOf(schema),
+                packageName = "com.netflix.graphql.dgs.codegen.java.testcases.$testPackage.$testCaseName.expected",
+                language = Language.JAVA,
+                generateClientApi = true,
+            )
+        }
+
+        private fun getAbsolutePath(suffix: String): Path {
+            val projectDirAbsolutePath = Paths.get("").toAbsolutePath().toString()
+            return Paths.get(projectDirAbsolutePath, "/src/integTest/java/com/netflix/graphql/dgs/codegen/java/testcases/$suffix")
+        }
+
+        private fun getTestsSourceTreeAbsolutePath(): Path {
+            val projectDirAbsolutePath = Paths.get("").toAbsolutePath().toString()
+            return Paths.get(projectDirAbsolutePath, "/src/integTest/java")
+        }
+
+        private fun listAllFiles(suffix: String): List<Path> {
+            val path = getAbsolutePath(suffix)
+            if (!path.exists()) return emptyList()
+            return Files
+                .walk(path)
+                .filter { Files.isRegularFile(it) }
+                .collect(Collectors.toList())
+        }
+
+        private fun readFileContent(fileName: String): String = getAbsolutePath(fileName).readText()
+
+        private fun writeExpected(
+            fileName: String,
+            content: String,
+        ) {
+            val path = getTestsSourceTreeAbsolutePath().resolve(fileName)
+
+            if (!path.exists()) {
+                path.parent.createDirectories()
+            }
+
+            path.toFile().writeText(content)
+        }
+    }
+}

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ClientApiGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ClientApiGenerator.kt
@@ -551,8 +551,9 @@ class ClientApiGenerator(
                 |getInputArguments().computeIfAbsent("${fieldDefinition.name}", k -> new ${'$'}T<>());                      
                 |${
                         fieldDefinition.inputValueDefinitions.joinToString("\n") { input ->
+                            val sanitizedName = javaReservedKeywordSanitizer.sanitize(input.name)
                             """
-                     |InputArgument ${input.name}Arg = new InputArgument("${input.name}", ${input.name}, false, null);
+                     |InputArgument ${input.name}Arg = new InputArgument("${input.name}", $sanitizedName, false, null);
                      |getInputArguments().get("${fieldDefinition.name}").add(${input.name}Arg);
                             """.trimMargin()
                         }
@@ -934,8 +935,9 @@ class ClientApiGenerator(
                                 |getInputArguments().computeIfAbsent("${it.name}", k -> new ${'$'}T<>());
                                 |${
                                         it.inputValueDefinitions.joinToString("\n") { input ->
+                                            val sanitizedName = javaReservedKeywordSanitizer.sanitize(input.name)
                                             """
-                                     |InputArgument ${input.name}Arg = new InputArgument("${input.name}", ${input.name}, false, null);
+                                     |InputArgument ${input.name}Arg = new InputArgument("${input.name}", $sanitizedName, false, null);
                                      |getInputArguments().get("${it.name}").add(${input.name}Arg);
                                             """.trimMargin()
                                         }}


### PR DESCRIPTION
Use the same approach as for `Kotlin2CodeGenTest` with a few differences:
- Test cases are grouped by topic/area, so that it is easier to run just the required subset of related test cases.
- Test case for underscore fields, which was inlined into `Kotlin2CodeGenTest`, is added as a separate test case into the `misc` package.

Use `com.netflix.graphql.dgs.codegen.java` package for the test cases to avoid any accidental name clashes with the classes from the integration test suite for Kotlin code generator.

Refactor the parametrized test logic, so that it works with the paths relative to the test sources root directory, rather than relying only on the parent package/directory.

<del>Resolve the issue with the client API generation for the cases when a reserved keyword is used as an input field name. Sanitize the input variable name, so that the generated Java code can be compiled.</del> -- this was resolved by #911.