### PR TITLE
chore: Mark editorconfig as root

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,5 @@
+root = true
+
 [{*.kt,*.kts}]
 ij_kotlin_code_style_defaults = KOTLIN_OFFICIAL
 ktlint_standard_no-wildcard-imports = disabled


### PR DESCRIPTION
Without it, most IDEs and linters will traverse up the filetree and look for other `.editorconfig` files and merge the settings.

This can lead to `formatKotlin` behaving differently on some computers.
