### PR TITLE
Add generic params to scalar fields with inputs in sub projections

### DIFF
--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ClientApiGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ClientApiGenerator.kt
@@ -927,7 +927,7 @@ class ClientApiGenerator(
                         val methodWithInputArgumentsBuilder =
                             MethodSpec
                                 .methodBuilder(javaReservedKeywordSanitizer.sanitize(it.name))
-                                .returns(ClassName.get(getPackageName(), javaType.build().name()))
+                                .returns(TypeVariableName.get("$clazzName<PARENT, ROOT>"))
                                 .addCode(
                                     """
                                 |getFields().put("${it.name}", null);


### PR DESCRIPTION
Closes #886

Adds generic parameters to method signature of projection methods for fields with inputs to preserve type safety and maintain consistency with other generated projection methods.