### PR TITLE
Remove @JsonCreator annotation from Kotlin types

### DIFF
--- a/graphql-dgs-codegen-core/build.gradle
+++ b/graphql-dgs-codegen-core/build.gradle
@@ -41,6 +41,8 @@ dependencies {
     testImplementation 'com.google.guava:guava:33.4.+'
     testImplementation 'com.google.testing.compile:compile-testing:0.+'
     testImplementation 'org.jetbrains.kotlin:kotlin-compiler'
+
+    integTestImplementation 'com.fasterxml.jackson.module:jackson-module-kotlin'
 }
 
 application {

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/constantsForInputTypes/expected/types/PersonFilter.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/constantsForInputTypes/expected/types/PersonFilter.kt
@@ -1,6 +1,5 @@
 package com.netflix.graphql.dgs.codegen.cases.constantsForInputTypes.expected.types
 
-import com.fasterxml.jackson.`annotation`.JsonCreator
 import com.fasterxml.jackson.`annotation`.JsonProperty
 import com.netflix.graphql.dgs.codegen.GraphQLInput
 import kotlin.Any
@@ -8,7 +7,7 @@ import kotlin.Pair
 import kotlin.String
 import kotlin.collections.List
 
-public data class PersonFilter @JsonCreator constructor(
+public data class PersonFilter(
   @JsonProperty("email")
   public val email: String? = default<PersonFilter, String?>("email", null),
 ) : GraphQLInput() {

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/constantsWithExtendedInputTypes/expected/types/PersonFilter.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/constantsWithExtendedInputTypes/expected/types/PersonFilter.kt
@@ -1,6 +1,5 @@
 package com.netflix.graphql.dgs.codegen.cases.constantsWithExtendedInputTypes.expected.types
 
-import com.fasterxml.jackson.`annotation`.JsonCreator
 import com.fasterxml.jackson.`annotation`.JsonProperty
 import com.netflix.graphql.dgs.codegen.GraphQLInput
 import kotlin.Any
@@ -9,7 +8,7 @@ import kotlin.Pair
 import kotlin.String
 import kotlin.collections.List
 
-public data class PersonFilter @JsonCreator constructor(
+public data class PersonFilter(
   @JsonProperty("email")
   public val email: String? = default<PersonFilter, String?>("email", null),
   @JsonProperty("birthYear")

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassDocs/expected/types/MovieFilter.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassDocs/expected/types/MovieFilter.kt
@@ -1,6 +1,5 @@
 package com.netflix.graphql.dgs.codegen.cases.dataClassDocs.expected.types
 
-import com.fasterxml.jackson.`annotation`.JsonCreator
 import com.fasterxml.jackson.`annotation`.JsonProperty
 import com.netflix.graphql.dgs.codegen.GraphQLInput
 import kotlin.Any
@@ -13,7 +12,7 @@ import kotlin.collections.List
  *
  * It takes a title and such.
  */
-public data class MovieFilter @JsonCreator constructor(
+public data class MovieFilter(
   @JsonProperty("titleFilter")
   public val titleFilter: String? = default<MovieFilter, String?>("titleFilter", null),
 ) : GraphQLInput() {

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassFieldDocs/expected/types/MovieFilter.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/dataClassFieldDocs/expected/types/MovieFilter.kt
@@ -1,6 +1,5 @@
 package com.netflix.graphql.dgs.codegen.cases.dataClassFieldDocs.expected.types
 
-import com.fasterxml.jackson.`annotation`.JsonCreator
 import com.fasterxml.jackson.`annotation`.JsonProperty
 import com.netflix.graphql.dgs.codegen.GraphQLInput
 import kotlin.Any
@@ -8,7 +7,7 @@ import kotlin.Pair
 import kotlin.String
 import kotlin.collections.List
 
-public data class MovieFilter @JsonCreator constructor(
+public data class MovieFilter(
   @JsonProperty("titleFilter")
   public val titleFilter: String? = default<MovieFilter, String?>("titleFilter", null),
 ) : GraphQLInput() {

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/input/expected/types/MovieFilter.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/input/expected/types/MovieFilter.kt
@@ -1,6 +1,5 @@
 package com.netflix.graphql.dgs.codegen.cases.input.expected.types
 
-import com.fasterxml.jackson.`annotation`.JsonCreator
 import com.fasterxml.jackson.`annotation`.JsonProperty
 import com.netflix.graphql.dgs.codegen.GraphQLInput
 import kotlin.Any
@@ -8,7 +7,7 @@ import kotlin.Pair
 import kotlin.String
 import kotlin.collections.List
 
-public data class MovieFilter @JsonCreator constructor(
+public data class MovieFilter(
   @JsonProperty("genre")
   public val genre: String? = default<MovieFilter, String?>("genre", null),
 ) : GraphQLInput() {

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/inputWithDefaultBigDecimal/expected/types/OrderFilter.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/inputWithDefaultBigDecimal/expected/types/OrderFilter.kt
@@ -1,6 +1,5 @@
 package com.netflix.graphql.dgs.codegen.cases.inputWithDefaultBigDecimal.expected.types
 
-import com.fasterxml.jackson.`annotation`.JsonCreator
 import com.fasterxml.jackson.`annotation`.JsonProperty
 import com.netflix.graphql.dgs.codegen.GraphQLInput
 import java.math.BigDecimal
@@ -9,7 +8,7 @@ import kotlin.Pair
 import kotlin.String
 import kotlin.collections.List
 
-public data class OrderFilter @JsonCreator constructor(
+public data class OrderFilter(
   @JsonProperty("min")
   public val min: BigDecimal = default<OrderFilter, BigDecimal>("min", java.math.BigDecimal("1.1")),
   @JsonProperty("avg")

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/inputWithDefaultCurrency/expected/types/OrderFilter.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/inputWithDefaultCurrency/expected/types/OrderFilter.kt
@@ -1,6 +1,5 @@
 package com.netflix.graphql.dgs.codegen.cases.inputWithDefaultCurrency.expected.types
 
-import com.fasterxml.jackson.`annotation`.JsonCreator
 import com.fasterxml.jackson.`annotation`.JsonProperty
 import com.netflix.graphql.dgs.codegen.GraphQLInput
 import java.util.Currency
@@ -9,7 +8,7 @@ import kotlin.Pair
 import kotlin.String
 import kotlin.collections.List
 
-public data class OrderFilter @JsonCreator constructor(
+public data class OrderFilter(
   @JsonProperty("value")
   public val `value`: Currency = default<OrderFilter, Currency>("value",
       java.util.Currency.getInstance("USD")),

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/inputWithDefaultEnumValueForArray/expected/types/SomeType.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/inputWithDefaultEnumValueForArray/expected/types/SomeType.kt
@@ -1,6 +1,5 @@
 package com.netflix.graphql.dgs.codegen.cases.inputWithDefaultEnumValueForArray.expected.types
 
-import com.fasterxml.jackson.`annotation`.JsonCreator
 import com.fasterxml.jackson.`annotation`.JsonProperty
 import com.netflix.graphql.dgs.codegen.GraphQLInput
 import kotlin.Any
@@ -8,7 +7,7 @@ import kotlin.Pair
 import kotlin.String
 import kotlin.collections.List
 
-public data class SomeType @JsonCreator constructor(
+public data class SomeType(
   @JsonProperty("colors")
   public val colors: List<Color?>? = default<SomeType, List<Color?>?>("colors",
       listOf(com.netflix.graphql.dgs.codegen.cases.inputWithDefaultEnumValueForArray.expected.types.Color.red)),

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/inputWithDefaultIntValueForArray/expected/types/SomeType.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/inputWithDefaultIntValueForArray/expected/types/SomeType.kt
@@ -1,6 +1,5 @@
 package com.netflix.graphql.dgs.codegen.cases.inputWithDefaultIntValueForArray.expected.types
 
-import com.fasterxml.jackson.`annotation`.JsonCreator
 import com.fasterxml.jackson.`annotation`.JsonProperty
 import com.netflix.graphql.dgs.codegen.GraphQLInput
 import kotlin.Any
@@ -9,7 +8,7 @@ import kotlin.Pair
 import kotlin.String
 import kotlin.collections.List
 
-public data class SomeType @JsonCreator constructor(
+public data class SomeType(
   @JsonProperty("numbers")
   public val numbers: List<Int?>? = default<SomeType, List<Int?>?>("numbers", listOf(1, 2, 3)),
 ) : GraphQLInput() {

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/inputWithDefaultStringValueForArray/expected/types/SomeType.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/inputWithDefaultStringValueForArray/expected/types/SomeType.kt
@@ -1,6 +1,5 @@
 package com.netflix.graphql.dgs.codegen.cases.inputWithDefaultStringValueForArray.expected.types
 
-import com.fasterxml.jackson.`annotation`.JsonCreator
 import com.fasterxml.jackson.`annotation`.JsonProperty
 import com.netflix.graphql.dgs.codegen.GraphQLInput
 import kotlin.Any
@@ -8,7 +7,7 @@ import kotlin.Pair
 import kotlin.String
 import kotlin.collections.List
 
-public data class SomeType @JsonCreator constructor(
+public data class SomeType(
   @JsonProperty("names")
   public val names: List<String?>? = default<SomeType, List<String?>?>("names", listOf("A", "B")),
 ) : GraphQLInput() {

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/inputWithDefaultValueForArray/expected/types/SomeType.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/inputWithDefaultValueForArray/expected/types/SomeType.kt
@@ -1,6 +1,5 @@
 package com.netflix.graphql.dgs.codegen.cases.inputWithDefaultValueForArray.expected.types
 
-import com.fasterxml.jackson.`annotation`.JsonCreator
 import com.fasterxml.jackson.`annotation`.JsonProperty
 import com.netflix.graphql.dgs.codegen.GraphQLInput
 import kotlin.Any
@@ -8,7 +7,7 @@ import kotlin.Pair
 import kotlin.String
 import kotlin.collections.List
 
-public data class SomeType @JsonCreator constructor(
+public data class SomeType(
   @JsonProperty("names")
   public val names: List<String?>? = default<SomeType, List<String?>?>("names", emptyList()),
 ) : GraphQLInput() {

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/inputWithDefaultValueForEnum/expected/types/ColorFilter.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/inputWithDefaultValueForEnum/expected/types/ColorFilter.kt
@@ -1,6 +1,5 @@
 package com.netflix.graphql.dgs.codegen.cases.inputWithDefaultValueForEnum.expected.types
 
-import com.fasterxml.jackson.`annotation`.JsonCreator
 import com.fasterxml.jackson.`annotation`.JsonProperty
 import com.netflix.graphql.dgs.codegen.GraphQLInput
 import kotlin.Any
@@ -8,7 +7,7 @@ import kotlin.Pair
 import kotlin.String
 import kotlin.collections.List
 
-public data class ColorFilter @JsonCreator constructor(
+public data class ColorFilter(
   @JsonProperty("color")
   public val color: Color? = default<ColorFilter, Color?>("color",
       com.netflix.graphql.dgs.codegen.cases.inputWithDefaultValueForEnum.expected.types.Color.red),

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/inputWithDefaultValueForNonNullableFields/expected/types/Car.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/inputWithDefaultValueForNonNullableFields/expected/types/Car.kt
@@ -1,6 +1,5 @@
 package com.netflix.graphql.dgs.codegen.cases.inputWithDefaultValueForNonNullableFields.expected.types
 
-import com.fasterxml.jackson.`annotation`.JsonCreator
 import com.fasterxml.jackson.`annotation`.JsonProperty
 import com.netflix.graphql.dgs.codegen.GraphQLInput
 import kotlin.Any
@@ -8,7 +7,7 @@ import kotlin.Pair
 import kotlin.String
 import kotlin.collections.List
 
-public data class Car @JsonCreator constructor(
+public data class Car(
   @JsonProperty("brand")
   public val brand: String = default<Car, String>("brand", "BMW"),
 ) : GraphQLInput() {

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/inputWithDefaultValueForNonNullableFields/expected/types/Person.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/inputWithDefaultValueForNonNullableFields/expected/types/Person.kt
@@ -1,6 +1,5 @@
 package com.netflix.graphql.dgs.codegen.cases.inputWithDefaultValueForNonNullableFields.expected.types
 
-import com.fasterxml.jackson.`annotation`.JsonCreator
 import com.fasterxml.jackson.`annotation`.JsonProperty
 import com.netflix.graphql.dgs.codegen.GraphQLInput
 import kotlin.Any
@@ -10,7 +9,7 @@ import kotlin.Pair
 import kotlin.String
 import kotlin.collections.List
 
-public data class Person @JsonCreator constructor(
+public data class Person(
   @JsonProperty("name")
   public val name: String = default<Person, String>("name", "Damian"),
   @JsonProperty("age")

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/inputWithDefaultValueForObject/expected/types/Car.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/inputWithDefaultValueForObject/expected/types/Car.kt
@@ -1,6 +1,5 @@
 package com.netflix.graphql.dgs.codegen.cases.inputWithDefaultValueForObject.expected.types
 
-import com.fasterxml.jackson.`annotation`.JsonCreator
 import com.fasterxml.jackson.`annotation`.JsonProperty
 import com.netflix.graphql.dgs.codegen.GraphQLInput
 import kotlin.Any
@@ -8,7 +7,7 @@ import kotlin.Pair
 import kotlin.String
 import kotlin.collections.List
 
-public data class Car @JsonCreator constructor(
+public data class Car(
   @JsonProperty("brand")
   public val brand: String = default<Car, String>("brand", "BMW"),
 ) : GraphQLInput() {

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/inputWithDefaultValueForObject/expected/types/MovieFilter.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/inputWithDefaultValueForObject/expected/types/MovieFilter.kt
@@ -1,6 +1,5 @@
 package com.netflix.graphql.dgs.codegen.cases.inputWithDefaultValueForObject.expected.types
 
-import com.fasterxml.jackson.`annotation`.JsonCreator
 import com.fasterxml.jackson.`annotation`.JsonProperty
 import com.netflix.graphql.dgs.codegen.GraphQLInput
 import kotlin.Any
@@ -8,7 +7,7 @@ import kotlin.Pair
 import kotlin.String
 import kotlin.collections.List
 
-public data class MovieFilter @JsonCreator constructor(
+public data class MovieFilter(
   @JsonProperty("director")
   public val director: Person? = default<MovieFilter, Person?>("director",
       com.netflix.graphql.dgs.codegen.cases.inputWithDefaultValueForObject.expected.types.Person(name

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/inputWithDefaultValueForObject/expected/types/Person.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/inputWithDefaultValueForObject/expected/types/Person.kt
@@ -1,6 +1,5 @@
 package com.netflix.graphql.dgs.codegen.cases.inputWithDefaultValueForObject.expected.types
 
-import com.fasterxml.jackson.`annotation`.JsonCreator
 import com.fasterxml.jackson.`annotation`.JsonProperty
 import com.netflix.graphql.dgs.codegen.GraphQLInput
 import kotlin.Any
@@ -9,7 +8,7 @@ import kotlin.Pair
 import kotlin.String
 import kotlin.collections.List
 
-public data class Person @JsonCreator constructor(
+public data class Person(
   @JsonProperty("name")
   public val name: String? = default<Person, String?>("name", "John"),
   @JsonProperty("age")

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/inputWithExtendedType/expected/types/MovieFilter.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/inputWithExtendedType/expected/types/MovieFilter.kt
@@ -1,6 +1,5 @@
 package com.netflix.graphql.dgs.codegen.cases.inputWithExtendedType.expected.types
 
-import com.fasterxml.jackson.`annotation`.JsonCreator
 import com.fasterxml.jackson.`annotation`.JsonProperty
 import com.netflix.graphql.dgs.codegen.GraphQLInput
 import kotlin.Any
@@ -9,7 +8,7 @@ import kotlin.Pair
 import kotlin.String
 import kotlin.collections.List
 
-public data class MovieFilter @JsonCreator constructor(
+public data class MovieFilter(
   @JsonProperty("genre")
   public val genre: String? = default<MovieFilter, String?>("genre", null),
   @JsonProperty("releaseYear")

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/inputWithReservedWord/expected/types/SampleInput.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/inputWithReservedWord/expected/types/SampleInput.kt
@@ -1,6 +1,5 @@
 package com.netflix.graphql.dgs.codegen.cases.inputWithReservedWord.expected.types
 
-import com.fasterxml.jackson.`annotation`.JsonCreator
 import com.fasterxml.jackson.`annotation`.JsonProperty
 import com.netflix.graphql.dgs.codegen.GraphQLInput
 import kotlin.Any
@@ -8,7 +7,7 @@ import kotlin.Pair
 import kotlin.String
 import kotlin.collections.List
 
-public data class SampleInput @JsonCreator constructor(
+public data class SampleInput(
   @JsonProperty("return")
   public val `return`: String,
 ) : GraphQLInput() {

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/projectionWithNestedInputs/expected/types/I1.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/projectionWithNestedInputs/expected/types/I1.kt
@@ -1,6 +1,5 @@
 package com.netflix.graphql.dgs.codegen.cases.projectionWithNestedInputs.expected.types
 
-import com.fasterxml.jackson.`annotation`.JsonCreator
 import com.fasterxml.jackson.`annotation`.JsonProperty
 import com.netflix.graphql.dgs.codegen.GraphQLInput
 import kotlin.Any
@@ -8,7 +7,7 @@ import kotlin.Pair
 import kotlin.String
 import kotlin.collections.List
 
-public data class I1 @JsonCreator constructor(
+public data class I1(
   @JsonProperty("arg1")
   public val arg1: I1? = default<I1, I1?>("arg1", null),
   @JsonProperty("arg2")

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/projectionWithNestedInputs/expected/types/I2.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/projectionWithNestedInputs/expected/types/I2.kt
@@ -1,6 +1,5 @@
 package com.netflix.graphql.dgs.codegen.cases.projectionWithNestedInputs.expected.types
 
-import com.fasterxml.jackson.`annotation`.JsonCreator
 import com.fasterxml.jackson.`annotation`.JsonProperty
 import com.netflix.graphql.dgs.codegen.GraphQLInput
 import kotlin.Any
@@ -8,7 +7,7 @@ import kotlin.Pair
 import kotlin.String
 import kotlin.collections.List
 
-public data class I2 @JsonCreator constructor(
+public data class I2(
   @JsonProperty("arg1")
   public val arg1: String? = default<I2, String?>("arg1", null),
   @JsonProperty("arg2")

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/projectionWithPrimitiveAndArgs/expected/types/I.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/projectionWithPrimitiveAndArgs/expected/types/I.kt
@@ -1,6 +1,5 @@
 package com.netflix.graphql.dgs.codegen.cases.projectionWithPrimitiveAndArgs.expected.types
 
-import com.fasterxml.jackson.`annotation`.JsonCreator
 import com.fasterxml.jackson.`annotation`.JsonProperty
 import com.netflix.graphql.dgs.codegen.GraphQLInput
 import kotlin.Any
@@ -8,7 +7,7 @@ import kotlin.Pair
 import kotlin.String
 import kotlin.collections.List
 
-public data class I @JsonCreator constructor(
+public data class I(
   @JsonProperty("arg")
   public val arg: String? = default<I, String?>("arg", null),
 ) : GraphQLInput() {

--- a/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/projectionWithTypeAndArgs/expected/types/I.kt
+++ b/graphql-dgs-codegen-core/src/integTest/kotlin/com/netflix/graphql/dgs/codegen/cases/projectionWithTypeAndArgs/expected/types/I.kt
@@ -1,6 +1,5 @@
 package com.netflix.graphql.dgs.codegen.cases.projectionWithTypeAndArgs.expected.types
 
-import com.fasterxml.jackson.`annotation`.JsonCreator
 import com.fasterxml.jackson.`annotation`.JsonProperty
 import com.netflix.graphql.dgs.codegen.GraphQLInput
 import kotlin.Any
@@ -8,7 +7,7 @@ import kotlin.Pair
 import kotlin.String
 import kotlin.collections.List
 
-public data class I @JsonCreator constructor(
+public data class I(
   @JsonProperty("arg")
   public val arg: String? = default<I, String?>("arg", null),
 ) : GraphQLInput() {

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin2/GenerateKotlin2InputTypes.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin2/GenerateKotlin2InputTypes.kt
@@ -18,7 +18,6 @@
 
 package com.netflix.graphql.dgs.codegen.generators.kotlin2
 
-import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.netflix.graphql.dgs.codegen.CodeGenConfig
 import com.netflix.graphql.dgs.codegen.GraphQLInput
@@ -89,7 +88,6 @@ fun generateKotlin2InputTypes(
                     .primaryConstructor(
                         FunSpec
                             .constructorBuilder()
-                            .addAnnotation(JsonCreator::class)
                             .addParameters(
                                 fields.map { field ->
                                     val type = type(field)


### PR DESCRIPTION
Jackson 2.21 introduced stricter detection for constructors and now [flags](https://github.com/FasterXML/jackson-databind/blob/3db1dbbdde8f9340af62d2feaf63e44ab9c7f0f6/src/main/java/tools/jackson/databind/introspect/POJOPropertiesCollector.java#L672) the generated Kotlin 0-arg constructor as being annotated with `@JsonCreator` in addition to the constructor defined in the data class, leading to a `Conflicting property-based creators` `JsonMappingException` when the object mapper is used at runtime.

This PR removes the `@JsonCreator` annotation entirely from generated Kotlin data classes. `@JsonProperty` is kept for each field to maintain the mapping from JSON field to parameters. With this change, Jackson uses the explicitly defined [non-0-arg constructor](https://github.com/FasterXML/jackson-databind/blob/3db1dbbdde8f9340af62d2feaf63e44ab9c7f0f6/src/main/java/tools/jackson/databind/introspect/POJOPropertiesCollector.java#L638) as the creator and avoids the conflicting creators exception.