### PR TITLE
Handle NullValue in input field default value code generation

### DIFF
--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/DataTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/DataTypeGenerator.kt
@@ -41,6 +41,7 @@ import graphql.language.InputObjectTypeExtensionDefinition
 import graphql.language.IntValue
 import graphql.language.InterfaceTypeDefinition
 import graphql.language.NonNullType
+import graphql.language.NullValue
 import graphql.language.ObjectTypeDefinition
 import graphql.language.ObjectTypeExtensionDefinition
 import graphql.language.ObjectValue
@@ -316,6 +317,7 @@ class InputTypeGenerator(
                 }
             }
 
+            is NullValue -> CodeBlock.of("null")
             else -> CodeBlock.of("\$L", value)
         }
 

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/shared/GenerateKotlinCode.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/shared/GenerateKotlinCode.kt
@@ -87,6 +87,7 @@ fun generateKotlinCode(
                 )
             }
 
+            is NullValue -> CodeBlock.of("null")
             else -> CodeBlock.of("%L", value)
         }
 

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
@@ -2190,6 +2190,33 @@ class CodeGenTest {
     }
 
     @Test
+    fun generateInputWithDefaultNullValue() {
+        val schema =
+            """
+            input QuantityRuleInput {
+                maximum: Int = null
+                minimum: Int!
+            }
+            """.trimIndent()
+
+        val (dataTypes) = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = BASE_PACKAGE_NAME)).generate()
+        assertThat(dataTypes).hasSize(1)
+
+        val data = dataTypes[0]
+        assertThat(data.packageName()).isEqualTo(TYPES_PACKAGE_NAME)
+
+        val type = data.typeSpec()
+        assertThat(type.name()).isEqualTo("QuantityRuleInput")
+
+        val fields = type.fieldSpecs()
+        val maximumField = fields.find { it.name() == "maximum" }
+        assertThat(maximumField).isNotNull
+        assertThat(maximumField!!.initializer().toString()).isEqualTo("null")
+
+        assertCompilesJava(dataTypes)
+    }
+
+    @Test
     fun generateExtendedInputTypes() {
         val schema =
             """

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
@@ -1760,6 +1760,48 @@ class KotlinCodeGenTest {
     }
 
     @Test
+    fun generateInputWithDefaultNullValue() {
+        val schema =
+            """
+            input QuantityRuleInput {
+                maximum: Int = null
+                minimum: Int!
+            }
+            """.trimIndent()
+
+        val codeGenResult =
+            CodeGen(
+                CodeGenConfig(
+                    schemas = setOf(schema),
+                    packageName = BASE_PACKAGE_NAME,
+                    language = Language.KOTLIN,
+                ),
+            ).generate()
+        val dataTypes = codeGenResult.kotlinDataTypes
+        assertThat(dataTypes).hasSize(1)
+
+        val data = dataTypes[0]
+        assertThat(data.packageName).isEqualTo(TYPES_PACKAGE_NAME)
+
+        val members = data.members
+        assertThat(members).hasSize(1)
+
+        val type = members[0] as TypeSpec
+        assertThat(type.name).isEqualTo("QuantityRuleInput")
+
+        val ctorSpec = type.primaryConstructor
+        assertThat(ctorSpec).isNotNull
+        assertThat(ctorSpec!!.parameters).hasSize(2)
+
+        val maximumParam = ctorSpec.parameters.find { it.name == "maximum" }
+        assertThat(maximumParam).isNotNull
+        assertThat(maximumParam!!.defaultValue).isNotNull
+        assertThat(maximumParam.defaultValue.toString()).isEqualTo("null")
+
+        assertCompilesKotlin(dataTypes)
+    }
+
+    @Test
     fun generateInputWithEmptyDefaultValueForArray() {
         val schema =
             """


### PR DESCRIPTION
 ## Summary                                                                                                                                                                                  
  - Fix `NullValue{}` being generated instead of `null` when a GraphQL input field has `= null` as its default value                                                                          
  - Handle `NullValue` in both Java and Kotlin code generators, alongside the existing `EnumValue`, `BooleanValue`, `IntValue`, etc. cases                                                    
  - Same root cause as the `EnumValue` bug fixed in PR #33 — the `else` branch called `.toString()` on the AST node                                                                           
                                                                                                                                                                                              
  ## Test plan                                                                                                                                                                                
  - [x] Added `generateInputWithDefaultNullValue` test for Java codegen (`CodeGenTest.kt`)                                                                                                    
  - [x] Added `generateInputWithDefaultNullValue` test for Kotlin codegen (`KotlinCodeGenTest.kt`)                                                                                            
  - [x] Both tests verify the generated code compiles (`assertCompilesJava` / `assertCompilesKotlin`)                                                                                         
  - [x] All existing default value tests continue to pass                                                                                                                                     
                                                                                                                                                                                              
  Fixes #770         