### PR TITLE
Update release drafter template and config

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,4 +1,16 @@
+categories:
+  - title: "⭐ Improvements"
+    labels:
+      - "enhancement"
+  - title: "🐞 Bug Fixes"
+    labels:
+      - "bug"
+  - title: "🔨 Dependency Upgrades"
+    labels:
+      - "dependencies"
+      - "gradle-wrapper"
+
 template: |
-  ## What’s Changed
+  ## What's Changed
 
   $CHANGES

--- a/.github/workflows/releasedraft.yml
+++ b/.github/workflows/releasedraft.yml
@@ -6,9 +6,6 @@ on:
     branches:
       - master
   # pull_request event is required only for autolabeler
-  pull_request:
-    # Only following types are handled by the action, but one can default to all as well
-    types: [ opened, reopened, synchronize ]
 
 jobs:
   update_release_draft:


### PR DESCRIPTION
Add template for release-drafter, and disable release-drafter for PRs. `update_release_draft` Github Action for PRs has been succeeding but failing silently in the logs, and now fails loudly in release-drafter@v7:
```
...
Error: Validation Failed: {"resource":"Release","code":"invalid","field":"target_commitish"}
{
  name: 'HttpError',
  id: '21607234714',
  status: 422,
  response: {
    url: 'https://api.github.com/repos/Netflix/dgs-codegen/releases/267842614',
    status: 422,
    headers: {
...
```
and release drafter isn't applicable for PRs as noted in `releasedraft.yml`:
```
  # pull_request event is required only for autolabeler
```