### PR TITLE
Revert "Add __typename to projection interface fields"

### DIFF
--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ClientApiGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ClientApiGenerator.kt
@@ -807,16 +807,6 @@ class ClientApiGenerator(
         val javaType = subProjection.first
         val codeGenResult = subProjection.second
 
-        // Automatically include __typename when the field type is interface to maintain parity with fragment projections
-        if (type is InterfaceTypeDefinition) {
-            javaType.addInitializerBlock(
-                CodeBlock
-                    .builder()
-                    .addStatement("getFields().put(\$S, null)", TypeNameMetaFieldDef.name)
-                    .build(),
-            )
-        }
-
         val javaFile = JavaFile.builder(getPackageName(), javaType.build()).build()
         return CodeGenResult(clientProjections = listOf(javaFile)).merge(codeGenResult)
     }

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/clientapi/ClientApiGenProjectionTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/clientapi/ClientApiGenProjectionTest.kt
@@ -584,46 +584,6 @@ class ClientApiGenProjectionTest {
     }
 
     @Test
-    fun testInterfaceProjectionIncludesTypenameAutomatically() {
-        val schema =
-            """
-            type Query {
-                account: Account
-            }
-
-            type Account {
-                subscriber: Subscriber
-            }
-
-            interface Subscriber {
-                id: ID
-            }
-
-            type PremiumSubscriber implements Subscriber {
-                id: ID
-                tier: String
-            }
-
-            type BasicSubscriber implements Subscriber {
-                id: ID
-            }
-            """.trimIndent()
-
-        val codeGenResult =
-            CodeGen(
-                CodeGenConfig(
-                    schemas = setOf(schema),
-                    packageName = BASE_PACKAGE_NAME,
-                    generateClientApi = true,
-                ),
-            ).generate()
-
-        val subscriberProjection = codeGenResult.clientProjections.first { it.typeSpec().name() == "SubscriberProjection" }
-        assertThat(subscriberProjection.typeSpec().initializerBlock().toString()).contains("__typename")
-        assertCompilesJava(codeGenResult)
-    }
-
-    @Test
     fun testScalarsDontGenerateProjections() {
         val schema =
             """


### PR DESCRIPTION
Reverts Netflix/dgs-codegen#926

Reverting while we look into failing builds from adding a new field