### PR TITLE
Fix Gradle configuration cache regression from #918

### DIFF
--- a/graphql-dgs-codegen-gradle/src/main/kotlin/com/netflix/graphql/dgs/codegen/gradle/CodegenPlugin.kt
+++ b/graphql-dgs-codegen-gradle/src/main/kotlin/com/netflix/graphql/dgs/codegen/gradle/CodegenPlugin.kt
@@ -69,6 +69,9 @@ class CodegenPlugin : Plugin<Project> {
                     Optional.ofNullable(codegenExtension.clientCoreScope.orNull),
                 )
             }
+            generateJavaTaskProvider.configure { task ->
+                task.jacksonVersions = JacksonVersionDetector.detectVersions(p)
+            }
         }
     }
 

--- a/graphql-dgs-codegen-gradle/src/main/kotlin/com/netflix/graphql/dgs/codegen/gradle/GenerateJavaTask.kt
+++ b/graphql-dgs-codegen-gradle/src/main/kotlin/com/netflix/graphql/dgs/codegen/gradle/GenerateJavaTask.kt
@@ -20,6 +20,7 @@ package com.netflix.graphql.dgs.codegen.gradle
 
 import com.netflix.graphql.dgs.codegen.CodeGen
 import com.netflix.graphql.dgs.codegen.CodeGenConfig
+import com.netflix.graphql.dgs.codegen.JacksonVersion
 import com.netflix.graphql.dgs.codegen.Language
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.ConfigurableFileCollection
@@ -170,6 +171,9 @@ open class GenerateJavaTask
                 project.configurations.findByName("dgsCodegen"),
             )
 
+        @Input
+        var jacksonVersions: Set<JacksonVersion> = emptySet()
+
         @TaskAction
         fun generate() {
             val schemaJarFilesFromDependencies = dgsCodegenClasspath.files.toList()
@@ -181,8 +185,6 @@ open class GenerateJavaTask
             schemaPaths.forEach {
                 logger.info("Processing $it")
             }
-
-            val jacksonVersions = JacksonVersionDetector.detectVersions(project)
 
             val config =
                 CodeGenConfig(


### PR DESCRIPTION
`JacksonVersionDetector.detectVersions(project)` was called in the `@TaskAction generate()` method, accessing `Task.project` at execution time — unsupported with Gradle configuration cache.

Moves Jackson version detection to configuration time by adding a `@Input jacksonVersions` property to `GenerateJavaTask` and resolving it in the plugin's `afterEvaluate` block (after `ClientUtilsConventions` to avoid resolving `compileClasspath` before all dependencies are declared).

Fixes #933