### PR TITLE
Add client directive support in GraphQLQueryRequestOptions

### DIFF
--- a/graphql-dgs-codegen-shared-core/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/GraphQLQueryRequest.kt
+++ b/graphql-dgs-codegen-shared-core/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/GraphQLQueryRequest.kt
@@ -19,6 +19,7 @@ package com.netflix.graphql.dgs.client.codegen
 import graphql.GraphQLContext
 import graphql.language.Argument
 import graphql.language.AstPrinter
+import graphql.language.Directive
 import graphql.language.Field
 import graphql.language.OperationDefinition
 import graphql.language.SelectionSet
@@ -30,7 +31,7 @@ class GraphQLQueryRequest
     constructor(
         val query: GraphQLQuery,
         val projection: BaseProjectionNode? = null,
-        options: GraphQLQueryRequestOptions? = null,
+        private val options: GraphQLQueryRequestOptions? = null,
     ) {
         private var selectionSet: SelectionSet? = null
         constructor(
@@ -57,6 +58,11 @@ class GraphQLQueryRequest
         class GraphQLQueryRequestOptions(
             val scalars: Map<Class<*>, Coercing<*, *>> = emptyMap(),
             val graphQLContext: GraphQLContext = GraphQLContext.getDefault(),
+            /**
+             * Directives to attach to the top-level selection field (the root query, mutation,
+             * or subscription field). Only valid for directives declared `on FIELD` in the schema.
+             */
+            val operationFieldDirectives: List<Directive> = emptyList(),
         ) {
             // When enabled, input values that are derived from properties
             // whose values are null will be serialized in the query request
@@ -94,6 +100,11 @@ class GraphQLQueryRequest
                     },
                 )
             }
+
+            options
+                ?.operationFieldDirectives
+                ?.takeIf { it.isNotEmpty() }
+                ?.let { selection.directives(it) }
 
             if (projection != null) {
                 val selectionSetFromProjection =

--- a/graphql-dgs-codegen-shared-core/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/GraphQLQueryRequest.kt
+++ b/graphql-dgs-codegen-shared-core/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/GraphQLQueryRequest.kt
@@ -55,25 +55,30 @@ class GraphQLQueryRequest
             this.selectionSet = selectionSet
         }
 
-        class GraphQLQueryRequestOptions(
-            val scalars: Map<Class<*>, Coercing<*, *>> = emptyMap(),
-            val graphQLContext: GraphQLContext = GraphQLContext.getDefault(),
-            /**
-             * Directives to attach to the top-level selection field (the root query, mutation,
-             * or subscription field). Only valid for directives declared `on FIELD` in the schema.
-             */
-            val operationFieldDirectives: List<Directive> = emptyList(),
-        ) {
-            // When enabled, input values that are derived from properties
-            // whose values are null will be serialized in the query request
-            var allowNullablePropertyInputValues = false
-        }
+        class GraphQLQueryRequestOptions
+            @JvmOverloads
+            constructor(
+                val scalars: Map<Class<*>, Coercing<*, *>> = emptyMap(),
+                val graphQLContext: GraphQLContext = GraphQLContext.getDefault(),
+                /**
+                 * Directives to attach to the top-level selection field (the field invoked on the root query,
+                 * mutation, or subscription field). Only valid for directives declared `on FIELD` in the schema.
+                 */
+                val operationFieldDirectives: List<Directive> = emptyList(),
+            ) {
+                // When enabled, input values that are derived from properties
+                // whose values are null will be serialized in the query request
+                var allowNullablePropertyInputValues = false
+            }
 
         val inputValueSerializer =
             if (options?.allowNullablePropertyInputValues == true) {
                 NullableInputValueSerializer(options.scalars)
             } else {
-                InputValueSerializer(options?.scalars ?: emptyMap(), options?.graphQLContext ?: GraphQLContext.getDefault())
+                InputValueSerializer(
+                    options?.scalars ?: emptyMap(),
+                    options?.graphQLContext ?: GraphQLContext.getDefault(),
+                )
             }
 
         val projectionSerializer = ProjectionSerializer(inputValueSerializer, query)
@@ -86,7 +91,9 @@ class GraphQLQueryRequest
             val operationDef = OperationDefinition.newOperationDefinition()
 
             query.name?.let { operationDef.name(it) }
-            query.getOperationType()?.let { operationDef.operation(OperationDefinition.Operation.valueOf(it.uppercase())) }
+            query
+                .getOperationType()
+                ?.let { operationDef.operation(OperationDefinition.Operation.valueOf(it.uppercase())) }
 
             val selection = Field.newField(query.getOperationName())
             if (query.input.isNotEmpty()) {

--- a/graphql-dgs-codegen-shared-core/src/test/kotlin/com/netflix/graphql/dgs/client/codegen/GraphQLQueryRequestTest.kt
+++ b/graphql-dgs-codegen-shared-core/src/test/kotlin/com/netflix/graphql/dgs/client/codegen/GraphQLQueryRequestTest.kt
@@ -22,6 +22,10 @@ import com.netflix.graphql.dgs.client.codegen.GraphQLQueryRequest.GraphQLQueryRe
 import com.netflix.graphql.dgs.client.codegen.exampleprojection.EntitiesProjectionRoot
 import graphql.GraphQLContext
 import graphql.execution.CoercedVariables
+import graphql.language.Argument
+import graphql.language.BooleanValue
+import graphql.language.Directive
+import graphql.language.IntValue
 import graphql.language.OperationDefinition
 import graphql.language.StringValue
 import graphql.language.Value
@@ -531,6 +535,108 @@ class GraphQLQueryRequestTest {
             |    name
             |    movieId
             |  }
+            |}
+            """.trimMargin(),
+        )
+    }
+
+    @Test
+    fun testSerializeOperationFieldDirectiveWithStringArgument() {
+        val query =
+            TestGraphQLMutation().apply {
+                input["movie"] = Movie(1234, "testMovie")
+            }
+        val idempotent =
+            Directive
+                .newDirective()
+                .name("idempotent")
+                .arguments(listOf(Argument("key", StringValue.of("abc-123"))))
+                .build()
+        val request =
+            GraphQLQueryRequest(
+                query,
+                MovieProjection().name().movieId(),
+                GraphQLQueryRequestOptions(operationFieldDirectives = listOf(idempotent)),
+            )
+        val result = request.serialize()
+        assertValidQuery(result)
+        assertThat(result).isEqualTo(
+            """mutation {
+            |  testMutation(movie: {movieId : 1234, name : "testMovie"}) @idempotent(key: "abc-123") {
+            |    name
+            |    movieId
+            |  }
+            |}
+            """.trimMargin(),
+        )
+    }
+
+    @Test
+    fun testSerializeMultipleOperationFieldDirectives() {
+        val query = TestGraphQLMutation()
+        val directives =
+            listOf(
+                Directive
+                    .newDirective()
+                    .name("idempotent")
+                    .arguments(listOf(Argument("key", StringValue.of("abc-123"))))
+                    .build(),
+                Directive.newDirective().name("traced").build(),
+            )
+        val request =
+            GraphQLQueryRequest(
+                query,
+                null,
+                GraphQLQueryRequestOptions(operationFieldDirectives = directives),
+            )
+        val result = request.serialize()
+        assertValidQuery(result)
+        assertThat(result).isEqualTo(
+            """mutation {
+            |  testMutation @idempotent(key: "abc-123") @traced
+            |}
+            """.trimMargin(),
+        )
+    }
+
+    @Test
+    fun testSerializeOperationFieldDirectiveWithNonStringArguments() {
+        val query = TestGraphQLMutation()
+        val directive =
+            Directive
+                .newDirective()
+                .name("retry")
+                .arguments(
+                    listOf(
+                        Argument("attempts", IntValue.of(3)),
+                        Argument("backoff", BooleanValue.newBooleanValue(true).build()),
+                    ),
+                ).build()
+        val request =
+            GraphQLQueryRequest(
+                query,
+                null,
+                GraphQLQueryRequestOptions(operationFieldDirectives = listOf(directive)),
+            )
+        val result = request.serialize()
+        assertValidQuery(result)
+        assertThat(result).isEqualTo(
+            """mutation {
+            |  testMutation @retry(attempts: 3, backoff: true)
+            |}
+            """.trimMargin(),
+        )
+    }
+
+    @Test
+    fun testSerializeNoOperationFieldDirectivesByDefault() {
+        val query = TestGraphQLMutation()
+        val request = GraphQLQueryRequest(query)
+        val result = request.serialize()
+        assertValidQuery(result)
+        assertThat(result).isEqualTo(
+            """mutation {
+            |  testMutation
             |}
             """.trimMargin(),
         )


### PR DESCRIPTION
Adds `operationFieldDirectives` parameter to `GraphQLQueryRequestOptions` to allow passing `graphql.language.Directive` directives to be applied to the top-level operation field in the serialized query.

Refactors this PR https://github.com/Netflix/dgs-codegen/pull/935 and requires a bit more verbose setup to build a Directive on the user side but leverages the existing Directive type instead of creating a new one, and adds it to the options field to avoid adding a parameter to `GraphQLQueryRequest` and for extensibility.

Open to feedback on if we want to keep the simplified Directive class from the original PR and let the user pass in that type so they don't have to construct a `graphql.language.Directive` like
```
val idempotent =
            Directive
                .newDirective()
                .name("idempotent")
                .arguments(listOf(Argument("key", StringValue.of("abc-123"))))
                .build()
```