### PR TITLE
Fix tests to support generated annotation by default

### DIFF
--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
@@ -2238,7 +2238,8 @@ class CodeGenTest {
             }
             """.trimIndent()
 
-        val (dataTypes) = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = BASE_PACKAGE_NAME)).generate()
+        val codeGenResult = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = BASE_PACKAGE_NAME)).generate()
+        val (dataTypes) = codeGenResult
         assertThat(dataTypes).hasSize(1)
 
         val data = dataTypes[0]
@@ -2252,7 +2253,7 @@ class CodeGenTest {
         assertThat(maximumField).isNotNull
         assertThat(maximumField!!.initializer().toString()).isEqualTo("null")
 
-        assertCompilesJava(dataTypes)
+        assertCompilesJava(codeGenResult)
     }
 
     @Test

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
@@ -1833,7 +1833,7 @@ class KotlinCodeGenTest {
         assertThat(maximumParam!!.defaultValue).isNotNull
         assertThat(maximumParam.defaultValue.toString()).isEqualTo("null")
 
-        assertCompilesKotlin(dataTypes)
+        assertCompilesKotlin(codeGenResult)
     }
 
     @Test


### PR DESCRIPTION
Since enabling `@Generated` annotations by default, tests that compile generated code need to include interfaces. Fixes two tests added in #920 to compile entire codegen result including interfaces.