### PR TITLE
feat: Reduce redundant imports

### DIFF
--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt
@@ -358,7 +358,7 @@ class CodeGen(
                     .addModifiers(Modifier.PUBLIC)
                     .addAnnotation(retention)
                     .build()
-            val generatedFile = JavaFile.builder(config.packageName, generated).build()
+            val generatedFile = JavaFile.builder(config.packageName, generated).skipJavaLangImports(true).build()
             CodeGenResult(javaInterfaces = listOf(generatedFile))
         } else {
             CodeGenResult.EMPTY

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ClientApiGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ClientApiGenerator.kt
@@ -345,7 +345,7 @@ class ClientApiGenerator(
                 .build(),
         )
         javaType.addType(builderClass.build())
-        return JavaFile.builder(getPackageName(), javaType.build()).build()
+        return JavaFile.builder(getPackageName(), javaType.build()).skipJavaLangImports(true).build()
     }
 
     private fun getVariableDefinitionType(inputValueType: Type<*>): String =
@@ -526,7 +526,7 @@ class ClientApiGenerator(
         val concreteTypesResult = createConcreteTypes(type, javaType.build(), javaType, mutableSetOf(), 0)
         val unionTypesResult = createUnionTypes(type, javaType, javaType.build(), mutableSetOf(), 0)
 
-        val javaFile = JavaFile.builder(getPackageName(), javaType.build()).build()
+        val javaFile = JavaFile.builder(getPackageName(), javaType.build()).skipJavaLangImports(true).build()
         return CodeGenResult(clientProjections = listOf(javaFile)).merge(codeGenResult).merge(concreteTypesResult).merge(unionTypesResult)
     }
 
@@ -670,7 +670,7 @@ class ClientApiGenerator(
                     )
                 }.fold(CodeGenResult.EMPTY) { total, current -> total.merge(current) }
 
-        val javaFile = JavaFile.builder(getPackageName(), javaType.build()).build()
+        val javaFile = JavaFile.builder(getPackageName(), javaType.build()).skipJavaLangImports(true).build()
         return CodeGenResult(clientProjections = listOf(javaFile)).merge(codeGenResult)
     }
 
@@ -790,7 +790,7 @@ class ClientApiGenerator(
                 ).build(),
         )
 
-        val javaFile = JavaFile.builder(getPackageName(), javaType.build()).build()
+        val javaFile = JavaFile.builder(getPackageName(), javaType.build()).skipJavaLangImports(true).build()
         return CodeGenResult(clientProjections = listOf(javaFile)).merge(codeGenResult)
     }
 
@@ -807,7 +807,7 @@ class ClientApiGenerator(
         val javaType = subProjection.first
         val codeGenResult = subProjection.second
 
-        val javaFile = JavaFile.builder(getPackageName(), javaType.build()).build()
+        val javaFile = JavaFile.builder(getPackageName(), javaType.build()).skipJavaLangImports(true).build()
         return CodeGenResult(clientProjections = listOf(javaFile)).merge(codeGenResult)
     }
 

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ConstantsGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/ConstantsGenerator.kt
@@ -212,7 +212,7 @@ class ConstantsGenerator(
             )
         }
 
-        val javaFile = JavaFile.builder(config.packageName, javaType.build()).build()
+        val javaFile = JavaFile.builder(config.packageName, javaType.build()).skipJavaLangImports(true).build()
         return CodeGenResult(javaConstants = listOf(javaFile))
     }
 

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/DataTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/DataTypeGenerator.kt
@@ -488,7 +488,7 @@ abstract class BaseDataTypeGenerator(
         addHashcode(javaType)
         addBuilder(name, fields, javaType)
 
-        val javaFile = JavaFile.builder(packageName, javaType.build()).build()
+        val javaFile = JavaFile.builder(packageName, javaType.build()).skipJavaLangImports(true).build()
 
         return CodeGenResult(javaDataTypes = listOf(javaFile))
     }
@@ -516,7 +516,7 @@ abstract class BaseDataTypeGenerator(
             addAbstractGetter(it.type, it, javaType)
         }
 
-        val javaFile = JavaFile.builder(packageName, javaType.build()).build()
+        val javaFile = JavaFile.builder(packageName, javaType.build()).skipJavaLangImports(true).build()
 
         return CodeGenResult(javaInterfaces = listOf(javaFile))
     }

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/DatafetcherGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/DatafetcherGenerator.kt
@@ -84,7 +84,7 @@ class DatafetcherGenerator(
                 .addAnnotation(DgsComponent::class.java)
                 .addMethod(methodSpec.build())
 
-        val javaFile = JavaFile.builder(getPackageName(), javaType.build()).build()
+        val javaFile = JavaFile.builder(getPackageName(), javaType.build()).skipJavaLangImports(true).build()
 
         return CodeGenResult(javaDataFetchers = listOf(javaFile))
     }

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/EnumTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/EnumTypeGenerator.kt
@@ -81,7 +81,7 @@ class EnumTypeGenerator(
             javaType.addEnumConstant(javaReservedKeywordSanitizer.sanitize(it.name), typeSpec.build())
         }
 
-        val javaFile = JavaFile.builder(getPackageName(), javaType.build()).build()
+        val javaFile = JavaFile.builder(getPackageName(), javaType.build()).skipJavaLangImports(true).build()
 
         return CodeGenResult(javaEnumTypes = listOf(javaFile))
     }

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/InterfaceGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/InterfaceGenerator.kt
@@ -118,7 +118,7 @@ class InterfaceGenerator(
             javaType.addAnnotation(jsonSubTypeAnnotation(implementations))
         }
 
-        val javaFile = JavaFile.builder(packageName, javaType.build()).build()
+        val javaFile = JavaFile.builder(packageName, javaType.build()).skipJavaLangImports(true).build()
 
         return CodeGenResult(javaInterfaces = listOf(javaFile))
     }

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/UnionTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/UnionTypeGenerator.kt
@@ -66,7 +66,7 @@ class UnionTypeGenerator(
             javaType.addAnnotation(jsonSubTypeAnnotation(memberTypes))
         }
 
-        val javaFile = JavaFile.builder(packageName, javaType.build()).build()
+        val javaFile = JavaFile.builder(packageName, javaType.build()).skipJavaLangImports(true).build()
         return CodeGenResult(javaInterfaces = listOf(javaFile))
     }
 }

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
@@ -811,7 +811,6 @@ class CodeGenTest {
                |import com.fasterxml.jackson.annotation.JsonSubTypes;
                |import com.fasterxml.jackson.annotation.JsonTypeInfo;
                |import com.netflix.graphql.dgs.codegen.tests.generated.Generated;
-               |import java.lang.String;
                |
                |@Generated
                |@JsonTypeInfo(
@@ -883,7 +882,6 @@ class CodeGenTest {
                |import com.fasterxml.jackson.annotation.JsonSubTypes;
                |import com.fasterxml.jackson.annotation.JsonTypeInfo;
                |import com.netflix.graphql.dgs.codegen.tests.generated.Generated;
-               |import java.lang.Boolean;
                |
                |@Generated
                |@JsonTypeInfo(
@@ -964,7 +962,6 @@ class CodeGenTest {
                 |import com.fasterxml.jackson.annotation.JsonSubTypes;
                 |import com.fasterxml.jackson.annotation.JsonTypeInfo;
                 |import com.netflix.graphql.dgs.codegen.tests.generated.Generated;
-                |import java.lang.String;
                 |import java.util.List;
                 |
                 |@Generated
@@ -1041,7 +1038,6 @@ class CodeGenTest {
                 |import com.fasterxml.jackson.annotation.JsonSubTypes;
                 |import com.fasterxml.jackson.annotation.JsonTypeInfo;
                 |import com.netflix.graphql.dgs.codegen.tests.generated.Generated;
-                |import java.lang.String;
                 |
                 |@Generated
                 |@JsonTypeInfo(
@@ -1111,7 +1107,6 @@ class CodeGenTest {
                |import com.fasterxml.jackson.annotation.JsonSubTypes;
                |import com.fasterxml.jackson.annotation.JsonTypeInfo;
                |import com.netflix.graphql.dgs.codegen.tests.generated.Generated;
-               |import java.lang.String;
                |
                |@Generated
                |@JsonTypeInfo(
@@ -1412,7 +1407,6 @@ class CodeGenTest {
                 package com.netflix.graphql.dgs.codegen.tests.generated.types;
                 
                 import com.netflix.graphql.dgs.codegen.tests.generated.Generated;
-                import java.lang.Deprecated;
                 
                 @Generated
                 public enum EmployeeTypes {
@@ -1763,7 +1757,6 @@ class CodeGenTest {
                 |import com.fasterxml.jackson.annotation.JsonSubTypes;
                 |import com.fasterxml.jackson.annotation.JsonTypeInfo;
                 |import com.netflix.graphql.dgs.codegen.tests.generated.Generated;
-                |import java.lang.String;
                 |import mypackage.Cat;
                 |
                 |@Generated
@@ -3130,7 +3123,6 @@ class CodeGenTest {
                |package com.netflix.graphql.dgs.codegen.tests.generated.types;
                |
                |import com.netflix.graphql.dgs.codegen.tests.generated.Generated;
-               |import java.lang.String;
                |
                |@Generated
                |public interface Person {
@@ -3154,7 +3146,6 @@ class CodeGenTest {
                |import com.fasterxml.jackson.annotation.JsonSubTypes;
                |import com.fasterxml.jackson.annotation.JsonTypeInfo;
                |import com.netflix.graphql.dgs.codegen.tests.generated.Generated;
-               |import java.lang.String;
                |
                |@Generated
                |@JsonTypeInfo(
@@ -3180,15 +3171,18 @@ class CodeGenTest {
             """.trimMargin(),
         )
 
-        assertThat(JavaFile.builder("$BASE_PACKAGE_NAME.types", talent).build().toString()).isEqualTo(
+        assertThat(
+            JavaFile
+                .builder("$BASE_PACKAGE_NAME.types", talent)
+                .skipJavaLangImports(true)
+                .build()
+                .toString(),
+        ).isEqualTo(
             """
                 |package com.netflix.graphql.dgs.codegen.tests.generated.types;
                 |
                 |import com.fasterxml.jackson.annotation.JsonTypeInfo;
                 |import com.netflix.graphql.dgs.codegen.tests.generated.Generated;
-                |import java.lang.Object;
-                |import java.lang.Override;
-                |import java.lang.String;
                 |import java.util.Objects;
                 |
                 |@Generated
@@ -3366,8 +3360,6 @@ class CodeGenTest {
             |package com.netflix.graphql.dgs.codegen.tests.generated.types;
             |
             |import com.netflix.graphql.dgs.codegen.tests.generated.Generated;
-            |import java.lang.Integer;
-            |import java.lang.String;
             |
             |@Generated
             |public interface Person {
@@ -3391,8 +3383,6 @@ class CodeGenTest {
             |import com.fasterxml.jackson.annotation.JsonSubTypes;
             |import com.fasterxml.jackson.annotation.JsonTypeInfo;
             |import com.netflix.graphql.dgs.codegen.tests.generated.Generated;
-            |import java.lang.Integer;
-            |import java.lang.String;
             |
             |@Generated
             |@JsonTypeInfo(
@@ -3466,8 +3456,6 @@ class CodeGenTest {
             |package com.netflix.graphql.dgs.codegen.tests.generated.types;
             |
             |import com.netflix.graphql.dgs.codegen.tests.generated.Generated;
-            |import java.lang.Integer;
-            |import java.lang.String;
             |import java.util.List;
             |
             |@Generated
@@ -3500,8 +3488,6 @@ class CodeGenTest {
             |import com.fasterxml.jackson.annotation.JsonSubTypes;
             |import com.fasterxml.jackson.annotation.JsonTypeInfo;
             |import com.netflix.graphql.dgs.codegen.tests.generated.Generated;
-            |import java.lang.Integer;
-            |import java.lang.String;
             |import java.util.List;
             |
             |@Generated
@@ -3568,7 +3554,6 @@ class CodeGenTest {
                |package com.netflix.graphql.dgs.codegen.tests.generated.types;
                |
                |import com.netflix.graphql.dgs.codegen.tests.generated.Generated;
-               |import java.lang.String;
                |
                |@Generated
                |public interface Person {
@@ -3798,7 +3783,6 @@ class CodeGenTest {
                 |import com.fasterxml.jackson.annotation.JsonSubTypes;
                 |import com.fasterxml.jackson.annotation.JsonTypeInfo;
                 |import com.netflix.graphql.dgs.codegen.tests.generated.Generated;
-                |import java.lang.String;
                 |
                 |@Generated
                 |@JsonTypeInfo(
@@ -3975,7 +3959,6 @@ class CodeGenTest {
                 |import com.fasterxml.jackson.annotation.JsonSubTypes;
                 |import com.fasterxml.jackson.annotation.JsonTypeInfo;
                 |import com.netflix.graphql.dgs.codegen.tests.generated.Generated;
-                |import java.lang.String;
                 |import java.util.List;
                 |
                 |@Generated
@@ -4049,8 +4032,6 @@ class CodeGenTest {
             |package com.netflix.graphql.dgs.codegen.tests.generated.types;
             |
             |import com.netflix.graphql.dgs.codegen.tests.generated.Generated;
-            |import java.lang.Integer;
-            |import java.lang.String;
             |import java.util.List;
             |
             |@Generated
@@ -4075,8 +4056,6 @@ class CodeGenTest {
             |import com.fasterxml.jackson.annotation.JsonSubTypes;
             |import com.fasterxml.jackson.annotation.JsonTypeInfo;
             |import com.netflix.graphql.dgs.codegen.tests.generated.Generated;
-            |import java.lang.Integer;
-            |import java.lang.String;
             |import java.util.List;
             |
             |@Generated

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/clientapi/ClientApiGenFragmentTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/clientapi/ClientApiGenFragmentTest.kt
@@ -302,7 +302,13 @@ class ClientApiGenFragmentTest {
 
         val searchResult = codeGenResult.javaInterfaces[0].typeSpec()
 
-        assertThat(JavaFile.builder("$BASE_PACKAGE_NAME.types", searchResult).build().toString()).isEqualTo(
+        assertThat(
+            JavaFile
+                .builder("$BASE_PACKAGE_NAME.types", searchResult)
+                .skipJavaLangImports(true)
+                .build()
+                .toString(),
+        ).isEqualTo(
             """
                 |package com.netflix.graphql.dgs.codegen.tests.generated.types;
                 |


### PR DESCRIPTION
The generated code used to include a lot of `java.lang.` imports.
Unless there's a conflicting wildcard import that causes confusion, they are redundant.

This change makes JavaPoet skip those imports in generated code.
