### PR TITLE
Generate list-of-interface getters on Java interfaces

### DIFF
--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/InterfaceGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/InterfaceGenerator.kt
@@ -78,28 +78,7 @@ class InterfaceGenerator(
         val mergedFieldDefinitions = definition.fieldDefinitions + extensions.flatMap { it.fieldDefinitions }
 
         mergedFieldDefinitions.filterSkipped().forEach {
-            // Generate getters/setters for fields that are not interfaces, and only getters for fields that are interfaces
-            // unless generateInterfaceMethodsForInterfaceFields && generateInterfaceSetters.
-            // Skip generating interface methods with list types where the inner type is an interface as Java does not
-            // support overriding them with more specific types (i.e. List<Dog> does not override List<Pet>).
-            //
-            // interface Pet {
-            // 	 parent: Pet
-            // }
-            // type Dog implements Pet {
-            // 	 parent: Dog
-            // }
-            // type Bird implements Pet {
-            // 	 parent: Bird
-            // }
-            // For the schema above, we currently generate Dog::setParent(Dog dog), but the interface
-            // would have Pet::setParent(Pet pet) leading to missing overrides in the generated
-            // implementation classes. This is not an issue if the overridden field has the same base type,
-            // however.
-            // Ref: https://github.com/graphql/graphql-js/issues/776
-            if (!isListOfInterface(it.type) || config.generateInterfaceMethodsForInterfaceFields) {
-                addInterfaceMethod(it, javaType)
-            }
+            addInterfaceMethod(it, javaType)
         }
 
         val implementations =
@@ -128,19 +107,24 @@ class InterfaceGenerator(
             .getDefinitionsOfType(InterfaceTypeDefinition::class.java)
             .any { node -> node.name == typeUtils.findInnerType(fieldDefinition.type).name }
 
-    // Returns true if the field is a list type (possibly nested or non-null) with an innermost type that is an interface
-    private fun isListOfInterface(fieldType: Type<*>): Boolean =
-        when (fieldType) {
-            is ListType -> {
-                val innerType = typeUtils.findInnerType(fieldType)
-                document
-                    .getDefinitionsOfType(InterfaceTypeDefinition::class.java)
-                    .any { node -> node.name == innerType.name }
-            }
-            is NonNullType -> isListOfInterface(fieldType.type)
-            else -> false
-        }
-
+    // Generate getters/setters for fields. Do not generate setters for fields that are also interfaces, unless forced
+    // with generateInterfaceMethodsForInterfaceFields.
+    //
+    // interface Pet {
+    // 	 parent: Pet
+    // }
+    // type Dog implements Pet {
+    // 	 parent: Dog
+    // }
+    // type Bird implements Pet {
+    // 	 parent: Bird
+    // }
+    //
+    // For the schema above, we currently generate Dog::setParent(Dog dog), but the interface
+    // would have Pet::setParent(Pet pet) leading to missing overrides in the generated
+    // implementation classes. This is not an issue if the overridden field has the same base type,
+    // however.
+    // Ref: https://github.com/graphql/graphql-js/issues/776
     private fun addInterfaceMethod(
         fieldDefinition: FieldDefinition,
         javaType: TypeSpec.Builder,

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/TypeUtils.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/TypeUtils.kt
@@ -94,7 +94,9 @@ class TypeUtils(
                     var canUseWildcardType = false
                     if (useWildcardType) {
                         if (typeName is ClassName) {
-                            if (document.definitions
+                            if (isFieldTypeAnInterface(node.type)) {
+                                canUseWildcardType = true
+                            } else if (document.definitions
                                     .filterIsInstance<ObjectTypeDefinition>()
                                     .any { e -> "I${e.name}" == typeName.simpleName() } ||
                                 (
@@ -107,6 +109,8 @@ class TypeUtils(
                             ) {
                                 canUseWildcardType = true
                             }
+                        } else if (typeName is ParameterizedTypeName && typeName.rawType().canonicalName() == "java.util.List") {
+                            canUseWildcardType = true
                         }
                     }
 
@@ -275,7 +279,7 @@ class TypeUtils(
         return NodeTraverser().postOrder(visitor, fieldType) as TypeName
     }
 
-    private fun isFieldTypeAnInterface(fieldDefinitionType: TypeName): Boolean =
+    private fun isFieldTypeAnInterface(fieldDefinitionType: Type<*>): Boolean =
         document
             .getDefinitionsOfType(InterfaceTypeDefinition::class.java)
             .any { node -> node.name == findInnerType(fieldDefinitionType).name }

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
@@ -993,6 +993,12 @@ class CodeGenTest {
                 |  Pet getMother();
                 |
                 |  Pet getFather();
+                |
+                |  List<? extends Pet> getParents();
+                |
+                |  List<? extends List<? extends Pet>> getFriends();
+                |
+                |  List<? extends Pet> getSiblings();
                 |}
             |
             """.trimMargin(),
@@ -3393,6 +3399,7 @@ class CodeGenTest {
             |import com.netflix.graphql.dgs.codegen.tests.generated.Generated;
             |import java.lang.Integer;
             |import java.lang.String;
+            |import java.util.List;
             |
             |@Generated
             |@JsonTypeInfo(
@@ -3414,6 +3421,8 @@ class CodeGenTest {
             |  void setAge(Integer age);
             |
             |  Employee getBoss();
+            |
+            |  List<? extends Employee> getTeam();
             |}
             |
             """.trimMargin(),
@@ -3480,9 +3489,9 @@ class CodeGenTest {
             |
             |  void setAge(Integer age);
             |
-            |  List<Person> getParents();
+            |  List<? extends Person> getParents();
             |
-            |  void setParents(List<Person> parents);
+            |  void setParents(List<? extends Person> parents);
             |
             |  Person getFriend();
             |
@@ -3520,9 +3529,9 @@ class CodeGenTest {
             |
             |  void setAge(Integer age);
             |
-            |  List<Person> getParents();
+            |  List<? extends Person> getParents();
             |
-            |  void setParents(List<Person> parents);
+            |  void setParents(List<? extends Person> parents);
             |
             |  Person getFriend();
             |
@@ -3993,10 +4002,23 @@ class CodeGenTest {
                 |
                 |  void setName(String name);
                 |
-                |  List<Pet> getFriends();
+                |  List<? extends Pet> getFriends();
                 |
-                |  void setFriends(List<Pet> friends);
+                |  void setFriends(List<? extends Pet> friends);
                 |}
+            |
+            """.trimMargin(),
+        )
+
+        assertThat(dataTypes[0].toString()).contains(
+            """
+                |  public List<? extends Pet> getFriends() {
+                |    return friends;
+                |  }
+                |
+                |  public void setFriends(List<? extends Pet> friends) {
+                |    this.friends = friends;
+                |  }
             |
             """.trimMargin(),
         )
@@ -4059,7 +4081,7 @@ class CodeGenTest {
             |
             |  Integer getAge();
             |
-            |  List<Person> getParents();
+            |  List<? extends Person> getParents();
             |
             |  Person getFriend();
             |}
@@ -4091,7 +4113,7 @@ class CodeGenTest {
             |
             |  Integer getAge();
             |
-            |  List<Person> getParents();
+            |  List<? extends Person> getParents();
             |
             |  Person getFriend();
             |}


### PR DESCRIPTION
Generate Java getter methods by default for interface fields that are list of interfaces. This is an enhancement to #882, which added getters by default but excluded lists.

I believe lists were probably left out of #882 due to lack of return type compatibility without using wildcard types. i.e., `List<ConcreteType>` does not override `List<Interface>`, but it _does_ override `List<? extends Interface>`.

This PR basically implements the latter and re-uses the same wildcard logic that was created for the `generateInterfaces` flag. It also introduces wildcards for interface `List` setters on interfaces, which is consistent with how `generateInterfaces` works (and because it shares the logic).